### PR TITLE
Added tooltip for the reveal link

### DIFF
--- a/assets/javascripts/templates/sidebar_tmpl.coffee
+++ b/assets/javascripts/templates/sidebar_tmpl.coffee
@@ -15,7 +15,7 @@ templates.sidebarEntry = (entry) ->
   """<a href="#{entry.fullPath()}" class="_list-item _list-hover">#{$.escape entry.name}</a>"""
 
 templates.sidebarResult = (entry) ->
-  """<a href="#{entry.fullPath()}" class="_list-item _list-hover _list-result _icon-#{entry.doc.slug}"><span class="_list-reveal" data-reset-list></span>#{$.escape entry.name}</a>"""
+  """<a href="#{entry.fullPath()}" class="_list-item _list-hover _list-result _icon-#{entry.doc.slug}"><span class="_list-reveal" data-reset-list title="Reveal in list"></span>#{$.escape entry.name}</a>"""
 
 templates.sidebarPageLink = (count) ->
   """<span class="_list-item _list-pagelink">Show more… (#{count})</span>"""


### PR DESCRIPTION
The reveal link is great, but a little opaque. It would be nice to have a tooltip that says what it does. So I added it. Yay open source!
