### PR TITLE
Update _app.scss fixed SyntaxError bug when loading page.

### DIFF
--- a/assets/stylesheets/components/_app.scss
+++ b/assets/stylesheets/components/_app.scss
@@ -19,7 +19,7 @@
   &._loading { opacity: 1; }
 
   &:before {
-    content: 'Loading…';
+    content: 'Loading...';
     position: absolute;
     top: 50%;
     left: 0;


### PR DESCRIPTION
Try to loading index page get a error:
Sass::SyntaxError at /
Invalid US-ASCII character "\xE2"
  (in /Users/zhufenggood/codet/devdocs/assets/stylesheets/application.css.scss:22)

ruby 2.0.0p353
