### PR TITLE
use three dots instead of unicode character

### DIFF
--- a/assets/javascripts/views/sidebar/doc_picker.coffee
+++ b/assets/javascripts/views/sidebar/doc_picker.coffee
@@ -44,7 +44,7 @@ class app.views.DocPicker extends app.View
     unless @saving
       @saving = true
       app.settings.setDocs @getSelectedDocs()
-      @saveLink.textContent = if app.appCache then 'Downloading…' else 'Saving…'
+      @saveLink.textContent = if app.appCache then 'Downloading...' else 'Saving...'
       app.reload()
     return
 
@@ -65,5 +65,5 @@ class app.views.DocPicker extends app.View
   onAppCacheProgress: (event) =>
     if event.lengthComputable
       percentage = Math.round event.loaded * 100 / event.total
-      @saveLink.textContent = "Downloading… (#{percentage}%)"
+      @saveLink.textContent = "Downloading... (#{percentage}%)"
     return


### PR DESCRIPTION
No idea what the root cause is, but if I run devdocs via the following commands:

```
rvm wrapper 2.0.0 ddocs rackup
```

and then

```
cd /path/to/devdocs && ~/.rvm/bin/ddocs_rackup
```

I get the following traceback:

```
127.0.0.1 - - [24/Dec/2013 21:49:42] "GET / HTTP/1.1" 500 - 11.0571
Encoding::InvalidByteSequenceError - "\xE2" on US-ASCII
  (in /Users/kevin/code/local-servers/usr/devdocs/devdocs-master/assets/javascripts/views/sidebar/doc_picker.coffee):
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:173:in `read'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:173:in `block in sh'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:173:in `popen'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:173:in `sh'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:138:in `exec_runtime'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:28:in `block in exec'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:41:in `compile_to_tempfile'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:27:in `exec'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:19:in `eval'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/execjs-2.0.2/lib/execjs/external_runtime.rb:33:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/coffee-script-2.2.0/lib/coffee_script.rb:57:in `compile'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/tilt-1.4.1/lib/tilt/coffee.rb:46:in `evaluate'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/context.rb:197:in `block in evaluate'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/context.rb:194:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/context.rb:194:in `evaluate'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/processed_asset.rb:12:in `initialize'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:374:in `new'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:374:in `block in build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:395:in `circular_call_protection'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:373:in `build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:94:in `block in build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/caching.rb:58:in `cache_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:93:in `build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:287:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:61:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/processed_asset.rb:111:in `block in resolve_dependencies'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/processed_asset.rb:105:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/processed_asset.rb:105:in `resolve_dependencies'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/processed_asset.rb:97:in `build_required_assets'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/processed_asset.rb:16:in `initialize'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:374:in `new'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:374:in `block in build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:395:in `circular_call_protection'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:373:in `build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:94:in `block in build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/caching.rb:58:in `cache_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:93:in `build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:287:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:61:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/bundled_asset.rb:16:in `initialize'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:377:in `new'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:377:in `build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:94:in `block in build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/caching.rb:58:in `cache_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:93:in `build_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:287:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/index.rb:61:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/environment.rb:75:in `find_asset'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:295:in `[]'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-helpers-1.1.0/lib/sprockets/helpers.rb:338:in `block in find_asset_path'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:146:in `block in resolve'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:144:in `block in match'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:136:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:136:in `match'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:115:in `block in find_in_paths'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:114:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:114:in `find_in_paths'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:63:in `block in find'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:57:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/index.rb:57:in `find'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/hike-1.2.3/lib/hike/trail.rb:139:in `find'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-2.10.1/lib/sprockets/base.rb:130:in `resolve'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-helpers-1.1.0/lib/sprockets/helpers.rb:337:in `find_asset_path'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-helpers-1.1.0/lib/sprockets/helpers.rb:135:in `asset_path'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-helpers-1.1.0/lib/sprockets/helpers.rb:148:in `asset_tag'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sprockets-helpers-1.1.0/lib/sprockets/helpers.rb:161:in `javascript_tag'
    /Users/kevin/code/local-servers/usr/devdocs/devdocs-master/views/index.erb:28:in `block in singleton class'
    /Users/kevin/code/local-servers/usr/devdocs/devdocs-master/views/index.erb:-5:in `instance_eval'
    /Users/kevin/code/local-servers/usr/devdocs/devdocs-master/views/index.erb:-5:in `singleton class'
    /Users/kevin/code/local-servers/usr/devdocs/devdocs-master/views/index.erb:-7:in `__tilt_70287505041100'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `evaluate'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:805:in `render'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-contrib-1.4.2/lib/sinatra/engine_tracking.rb:91:in `block in render'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-contrib-1.4.2/lib/sinatra/engine_tracking.rb:83:in `with_engine'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-contrib-1.4.2/lib/sinatra/engine_tracking.rb:91:in `render'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:664:in `erb'
    /Users/kevin/code/local-servers/usr/devdocs/devdocs-master/lib/app.rb:112:in `block in <class:App>'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1593:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1593:in `block in compile!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:957:in `[]'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:957:in `block (3 levels) in route!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:976:in `route_eval'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:957:in `block (2 levels) in route!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:997:in `block in process_route'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:995:in `catch'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:995:in `process_route'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:955:in `block in route!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:954:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:954:in `route!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1067:in `block in dispatch!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1049:in `block in invoke'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1049:in `catch'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1049:in `invoke'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1064:in `dispatch!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:889:in `block in call!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1049:in `block in invoke'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1049:in `catch'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1049:in `invoke'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:889:in `call!'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:877:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/better_errors-1.0.1/lib/better_errors/middleware.rb:84:in `protected_app_call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/better_errors-1.0.1/lib/better_errors/middleware.rb:79:in `better_errors_call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/better_errors-1.0.1/lib/better_errors/middleware.rb:56:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-protection-1.5.1/lib/rack/protection/path_traversal.rb:16:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-protection-1.5.1/lib/rack/protection/json_csrf.rb:18:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-protection-1.5.1/lib/rack/protection/base.rb:50:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-protection-1.5.1/lib/rack/protection/base.rb:50:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/logger.rb:15:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:210:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/methodoverride.rb:21:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/show_exceptions.rb:21:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:180:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:2004:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1469:in `block in call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1778:in `synchronize'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:1469:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/commonlogger.rb:33:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/sinatra-1.4.4/lib/sinatra/base.rb:217:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/chunked.rb:43:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/content_length.rb:14:in `call'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/connection.rb:82:in `block in pre_process'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/connection.rb:80:in `catch'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/connection.rb:80:in `pre_process'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/connection.rb:55:in `process'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/connection.rb:41:in `receive_data'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/backends/base.rb:73:in `start'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/thin-1.6.1/lib/thin/server.rb:162:in `start'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/handler/thin.rb:16:in `run'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:264:in `start'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/bin/rackup:23:in `load'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/bin/rackup:23:in `<main>'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/bin/ruby_executable_hooks:15:in `eval'
    /Users/kevin/.rvm/gems/ruby-2.0.0-p247/bin/ruby_executable_hooks:15:in `<main>'
```

If I just run it from the command line with `rackup`, no error. However, changing the ellipsis to three dots fixes the issue by making the file ASCII compliant.

Would like it if someone could advise why running via launchctl generates an encoding error, where running from the command line is fine.
