### PR TITLE
added basic support for firefox OS and firefox desktop apps WIP

### DIFF
--- a/public/manifest.webapp
+++ b/public/manifest.webapp
@@ -1,0 +1,28 @@
+{
+    "version" : "0.0.1",
+    "name" : "devdocs",
+    "launch_path" : "/",
+
+    "installs_allowed_from" : ["*"],
+
+    "developer": {
+        "name": "Thibaut Courouble",
+        "url": "http://devdocs.io"
+    },
+
+    "default_locale": "en",
+
+    "description": "DevDocs combines multiple API documentations in a fast, organized, and searchable interface.",
+
+    "icons": {
+        "16" : "/favicon.ico",
+        "32" : "/favicon.ico",
+        "48" : "/favicon.ico",
+        "60" : "/favicon.ico",
+        "64" : "/favicon.ico",
+        "90" : "/favicon.ico",
+        "120" : "/favicon.ico",
+        "128" : "/favicon.ico",
+        "256" : "/favicon.ico"
+    }
+}


### PR DESCRIPTION
hey :)

If you use Firefox Aurora or Nightly, this allows you to easily install devdocs cross-platform

e.g., on Mac, clicking the install will make a `devdocs.app` that you can easily launch.  Awesome!

Firefox for Android can also install this kind of app (and they will appear on the home screen like a native android app)

Let me know what you think, I have some questions within the code

TODO:
- [ ] add mimetype support for manifest to app.rb
- [ ] submit to firefox marketplace
- [ ] find out where to toggle the display of the `firefox-app-supported` class
