### PR TITLE
Rails version bump

### DIFF
--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -19,7 +19,7 @@ module Docs
 
     self.name = 'Ruby on Rails'
     self.slug = 'rails'
-    self.version = '4.1.0'
+    self.version = '4.1.1'
     self.dir = '/Users/Thibaut/DevDocs/Docs/RDoc/Rails'
 
     html_filters.replace 'rdoc/entries', 'rails/entries'


### PR DESCRIPTION
Still need to generate and upload docs with new version label. Just to keep docs version up to date (there's nothing new in Rails 4.1.1).
