### PR TITLE
Add Ansible v2.5 and latest docs

### DIFF
--- a/lib/docs/scrapers/ansible.rb
+++ b/lib/docs/scrapers/ansible.rb
@@ -24,8 +24,16 @@ module Docs
     HTML
 
     version '2.4' do
-      self.release = '2.4.3'
+      self.release = '2.4'
       self.base_url = 'https://docs.ansible.com/ansible/2.4/'
+    end
+    version '2.5' do
+      self.release = '2.5'
+      self.base_url = 'https://docs.ansible.com/ansible/2.5/'
+    end
+    version 'latest' do
+      self.release = 'latest'
+      self.base_url = 'https://docs.ansible.com/ansible/latest/'
     end
   end
 end


### PR DESCRIPTION
Ansible was hardcoded to 2.4 but v2.5 has been out for some time now.
Also added latest for good measure.