### PR TITLE
Move “DevDocs” in the tab title to after the dynamic portion of the title

### DIFF
--- a/assets/javascripts/views/layout/document.coffee
+++ b/assets/javascripts/views/layout/document.coffee
@@ -28,7 +28,7 @@ class app.views.Document extends app.View
     return
 
   setTitle: (title) ->
-    @el.title = if title then "DevDocs — #{title}" else 'DevDocs API Documentation'
+    @el.title = if title then "#{title} — DevDocs" else 'DevDocs API Documentation'
 
   afterRoute: (route) =>
     if route is 'settings'


### PR DESCRIPTION
Fixes #802