### PR TITLE
Upgrade Ansible doc to version 2.5

### DIFF
--- a/lib/docs/filters/ansible/entries.rb
+++ b/lib/docs/filters/ansible/entries.rb
@@ -11,14 +11,28 @@ module Docs
       end
 
       def get_type
-        if slug.include?('module')
-          if name =~ /\A[a-z]/ && node = css('.toctree-l2.current').last
-            "Modules: #{node.content.remove(' Modules')}"
+        if slug =~ /\Acli\//
+          'CLI Reference'
+        elsif slug =~ /\Anetwork\//
+          'Network'
+        elsif slug =~ /\Aplugins\//
+          if name =~ /\A[a-z]/ && node = css('.toctree-l3.current').last
+            "Plugins: #{node.content.sub(/ Plugins.*/, '')}"
           else
+            'Plugins'
+          end
+        elsif slug =~ /\Amodules\//
+          if slug =~ /\Amodules\/list_/ || slug=~ /_maintained\z/
             'Modules'
+          else
+            'Modules: Index'
           end
         elsif slug.include?('playbook')
           'Playbooks'
+        elsif slug =~ /\Auser_guide\//
+          'Guides: User'
+        elsif slug =~ /\Ascenario_guides\//
+          'Guides: Scenarios'
         elsif slug.include?('guide')
           'Guides'
         else

--- a/lib/docs/scrapers/ansible.rb
+++ b/lib/docs/scrapers/ansible.rb
@@ -7,15 +7,22 @@ module Docs
       code: 'https://github.com/ansible/ansible'
     }
 
-    html_filters.push 'ansible/entries', 'sphinx/clean_html'
+    html_filters.push 'ansible/entries', 'sphinx/clean_html', 'ansible/clean_html'
 
     options[:skip] = %w(
-      glossary.html
-      faq.html
-      community.html
-      tower.html
-      quickstart.html
-      list_of_all_modules.html)
+      installation_guide/index.html
+      reference_appendices/glossary.html
+      reference_appendices/faq.html
+      reference_appendices/tower.html
+      user_guide/quickstart.html
+      modules/modules_by_category.html
+      modules/list_of_all_modules.html)
+
+    options[:skip_patterns] = [
+      /\Acommunity.*/i,
+      /\Adev_guide.*/i,
+      /\Aroadmap.*/i,
+    ]
 
     options[:attribution] = <<-HTML
       &copy; 2012&ndash;2018 Michael DeHaan<br>
@@ -23,9 +30,9 @@ module Docs
       Licensed under the GNU General Public License version 3.
     HTML
 
-    version '2.4' do
-      self.release = '2.4.3'
-      self.base_url = 'https://docs.ansible.com/ansible/2.4/'
+    version '2.5' do
+      self.release = '2.5.3'
+      self.base_url = 'https://docs.ansible.com/ansible/2.5/'
     end
   end
 end


### PR DESCRIPTION
Upgrade to support Ansible 2.5 new documentation structure.

Notes: The new doc structure does not highlight the current module type on the toc, so that 'module category' present on previous versions is not available (or at least I do not know how to obtain it). All the modules goes all under the same `Modules: Index`.