### PR TITLE
update React Native to 0.55

### DIFF
--- a/lib/docs/filters/react_native/clean_html.rb
+++ b/lib/docs/filters/react_native/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class ReactNative
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.inner-content, article.withtoc')
+        @doc = at_css('.post')
 
         if root_page?
           at_css('h1').content = 'React Native Documentation'

--- a/lib/docs/filters/react_native/entries.rb
+++ b/lib/docs/filters/react_native/entries.rb
@@ -12,9 +12,9 @@ module Docs
       end
 
       def get_type
-        link = at_css('.nav-docs-section .active, .toc .active')
+        link = at_css('.navItemActive')
         return 'Miscellaneous' unless link
-        section = link.ancestors('.nav-docs-section, section').first
+        section = link.ancestors('.navGroup').first
         type = section.at_css('h3').content.strip
         type = REPLACE_TYPES[type] || type
         type += ": #{name}" if type == 'Components'
@@ -22,15 +22,13 @@ module Docs
       end
 
       def additional_entries
-        css('.props > .prop > .propTitle', '.props > .prop > .methodTitle').each_with_object [] do |node, entries|
-          name = node.children.find(&:text?).try(:content)
-          next if name.blank?
-          sep = node.content.include?('static') ? '.' : '#'
-          name.prepend(self.name + sep)
-          name << '()' if node['class'].include?('methodTitle')
-          name.remove! %r{\??\:\s*\z}
-          id = node.at_css('.anchor')['name']
-          entries << [name, id]
+        css('.mainContainer h3').each_with_object [] do |node, entries|
+          subname = node.text
+          next if subname.blank? || node.css('code').empty?
+          sep = subname.include?('()') ? '.' : '#'
+          subname.prepend(name + sep)
+          id = node.at_css('.anchor')['id']
+          entries << [subname, id]
         end
       end
     end

--- a/lib/docs/scrapers/react_native.rb
+++ b/lib/docs/scrapers/react_native.rb
@@ -2,7 +2,7 @@ module Docs
   class ReactNative < UrlScraper
     self.slug = 'react_native'
     self.type = 'react_native'
-    self.release = '0.49'
+    self.release = '0.55'
     self.base_url = 'https://facebook.github.io/react-native/docs/'
     self.root_path = 'getting-started.html'
     self.links = {
@@ -12,7 +12,7 @@ module Docs
 
     html_filters.push 'react_native/entries', 'react_native/clean_html'
 
-    options[:container] = '.documentationContent'
+    options[:container] = '.docMainWrapper'
     options[:skip_patterns] = [/\Asample\-/]
     options[:skip] = %w(
       videos.html
@@ -27,7 +27,7 @@ module Docs
     }
 
     options[:attribution] = <<-HTML
-      &copy; 2015&ndash;2017 Facebook Inc.<br>
+      &copy; 2015&ndash;2018 Facebook Inc.<br>
       Licensed under the Creative Commons Attribution 4.0 International Public License.
     HTML
   end


### PR DESCRIPTION
Upgrade to support the new documentation structure for React Native 0.55. Resolves #761 

Here is a local screenshot:
![image](https://user-images.githubusercontent.com/1513130/41065285-2ec14ade-69ac-11e8-8bc8-9f1bef078882.png)