### PR TITLE
Use browser dimensions for mobile detection

### DIFF
--- a/assets/javascripts/views/layout/mobile.coffee
+++ b/assets/javascripts/views/layout/mobile.coffee
@@ -16,8 +16,8 @@ class app.views.Mobile extends app.View
   @detect: ->
     try
       (window.matchMedia('(max-width: 480px)').matches) or
-      (window.matchMedia('(max-device-width: 767px)').matches) or
-      (window.matchMedia('(max-device-height: 767px) and (max-device-width: 1024px)').matches) or
+      (window.matchMedia('(max-width: 767px)').matches) or
+      (window.matchMedia('(max-height: 767px) and (max-width: 1024px)').matches) or
       # Need to sniff the user agent because some Android and Windows Phone devices don't take
       # resolution (dpi) into account when reporting device width/height.
       (navigator.userAgent.indexOf('Android') isnt -1 and navigator.userAgent.indexOf('Mobile') isnt -1) or


### PR DESCRIPTION
This PR resolves #634.

It seems that Firefox in some situations incorrectly reports the device dimensions. The users who reported the issue with Chromium on Linux might be having a problem with their window managers incorrectly reporting the display dimensions as one user suggested.

Outside of those weird bug areas, this PR also makes DevDocs a little [more responsive to browser resizing](https://developers.google.com/web/fundamentals/design-and-ux/responsive/#a_note_on_min-device-width), but since the mobile detection is done on load the user would need to refresh the page for the layout to transition after browser resizing.