### PR TITLE
Use `document.scrollingElement` for mobile scrolling

### DIFF
--- a/assets/javascripts/views/content/content.coffee
+++ b/assets/javascripts/views/content/content.coffee
@@ -19,7 +19,10 @@ class app.views.Content extends app.View
     after:  'afterRoute'
 
   init: ->
-    @scrollEl = if app.isMobile() then document.body else @el
+    @scrollEl = if app.isMobile()
+      (document.scrollingElement || document.body)
+    else
+      @el
     @scrollMap = {}
     @scrollStack = []
 


### PR DESCRIPTION
This PR resolves #769.

As the commit message explains, the underlying issue is [browser compatibility and shifting web standards](https://miketaylr.com/posts/2014/11/document-body-scrollTop.html). [Document.scrollingElement](https://developer.mozilla.org/en-US/docs/Web/API/document/scrollingElement) fills in the gap for modern browsers, but the support for that is [not there for some of the minimum versions](https://developer.mozilla.org/en-US/docs/Web/API/document/scrollingElement) listed in this project's README so I've kept the pre-existing value as a fallback when `document.scrollingElement` is undefined.