### PR TITLE
Fix SVG case issue (#791)

### DIFF
--- a/lib/docs/filters/svg/entries.rb
+++ b/lib/docs/filters/svg/entries.rb
@@ -3,8 +3,8 @@ module Docs
     class EntriesFilter < Docs::EntriesFilter
       def get_name
         name = super
-        name.gsub!('Element.', '').try(:downcase!)
-        name.gsub!('Attribute.', '').try(:downcase!)
+        name.gsub!('Element.', '')
+        name.gsub!('Attribute.', '')
         name.gsub!('Tutorial.', '')
         name.gsub!('_', '')
 


### PR DESCRIPTION
SVG attributes now keep correct case. 

I wonder why the attributes were changed to lowercase to begin with. Maybe there is a good reason I don't know about.