### PR TITLE
Update crystal documentation (0.25.1)

### DIFF
--- a/lib/docs/filters/crystal/clean_html.rb
+++ b/lib/docs/filters/crystal/clean_html.rb
@@ -16,7 +16,7 @@ module Docs
       end
 
       def api
-        @doc = at_css('#main-content')
+        @doc = at_css('.main-content')
 
         at_css('h1 + p').remove if root_page?
 

--- a/lib/docs/filters/crystal/entries.rb
+++ b/lib/docs/filters/crystal/entries.rb
@@ -32,7 +32,7 @@ module Docs
           if hierarchy && hierarchy.content.include?('Exception')
             'Exceptions'
           else
-            type = at_css('#types-list > ul > .current > a').content
+            type = at_css('.types-list > ul > .current > a').content
             type = 'Float' if type.start_with?('Float')
             type = 'Int' if type.start_with?('Int')
             type = 'UInt' if type.start_with?('UInt')

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -1,7 +1,7 @@
 module Docs
   class Crystal < UrlScraper
     self.type = 'crystal'
-    self.release = '0.25.0'
+    self.release = '0.25.1'
     self.base_url = 'https://crystal-lang.org/'
     self.root_path = "api/#{release}/index.html"
     self.initial_paths = %w(docs/index.html)

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -1,7 +1,7 @@
 module Docs
   class Crystal < UrlScraper
     self.type = 'crystal'
-    self.release = '0.24.1'
+    self.release = '0.25.0'
     self.base_url = 'https://crystal-lang.org/'
     self.root_path = "api/#{release}/index.html"
     self.initial_paths = %w(docs/index.html)
@@ -29,7 +29,7 @@ module Docs
         HTML
       else
         <<-HTML
-          &copy; 2012&ndash;2017 Manas Technology Solutions.<br>
+          &copy; 2012&ndash;2018 Manas Technology Solutions.<br>
           Licensed under the Apache License, Version 2.0.
         HTML
       end


### PR DESCRIPTION
Update crystal documentation to 0.25.1.

Changelog:

- fix content node
- fix type node
- update year of copyrights

Here is a local screenshot:
<img width="1219" alt="devdocs-crystal-0-25-1" src="https://user-images.githubusercontent.com/17814/41697337-e5899dbc-754a-11e8-9180-55b47ab22cb4.png">
