### PR TITLE
Add Graphite documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ public/fonts
 public/docs/**/*
 !public/docs/docs.json
 !public/docs/**/index.json
-.idea
 log

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ public/fonts
 public/docs/**/*
 !public/docs/docs.json
 !public/docs/**/index.json
+.idea
+log

--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -291,6 +291,11 @@ credits = [
     'MIT',
     'https://raw.githubusercontent.com/godotengine/godot/master/LICENSE.txt'
   ], [
+    'Graphite',
+    '2008-2012 Chris Davis; 2011-2016 The Graphite Project',
+    'Apache',
+    'https://raw.githubusercontent.com/graphite-project/graphite-web/master/LICENSE'
+  ], [
     'Grunt',
     'GruntJS Team',
     'MIT',

--- a/assets/stylesheets/application-dark.css.scss
+++ b/assets/stylesheets/application-dark.css.scss
@@ -54,6 +54,7 @@
         'pages/git',
         'pages/github',
         'pages/go',
+        'pages/graphite',
         'pages/haskell',
         'pages/jekyll',
         'pages/jquery',

--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -54,6 +54,7 @@
         'pages/git',
         'pages/github',
         'pages/go',
+        'pages/graphite',
         'pages/haskell',
         'pages/jekyll',
         'pages/jquery',

--- a/assets/stylesheets/pages/_graphite.scss
+++ b/assets/stylesheets/pages/_graphite.scss
@@ -1,0 +1,19 @@
+._graphite {
+  @extend %simple;
+
+  dl > dt {
+    @extend %note, %note-blue;
+    padding: 1px 0.5rem 2px 0.5rem;
+    font-weight: bold;
+  }
+
+  dl.function > dt {
+    code {
+      font-weight: bold;
+    }
+
+    em {
+      font-style: normal;
+    }
+  }
+}

--- a/assets/stylesheets/pages/_graphite.scss
+++ b/assets/stylesheets/pages/_graphite.scss
@@ -1,6 +1,14 @@
 ._graphite {
   @extend %simple;
 
+  h1 {
+    @extend %lined-heading;
+  }
+
+  .section:first-child h1 {
+    margin-top: 0;
+  }
+
   dl > dt {
     @extend %note, %note-blue;
     padding: 1px 0.5rem 2px 0.5rem;
@@ -11,7 +19,6 @@
     code {
       font-weight: bold;
     }
-
     em {
       font-style: normal;
     }

--- a/lib/docs/filters/graphite/clean_html.rb
+++ b/lib/docs/filters/graphite/clean_html.rb
@@ -1,0 +1,18 @@
+module Docs
+  class Graphite
+    class CleanHtmlFilter < Filter
+      def call
+        # Remove the paragraph icon after all headers
+        css('.headerlink').remove
+
+        # Extract the text from function titles to get rid of the inconsistent styling
+        css('dl.function > dt').each do |node|
+          node['data-name'] = node.at_css('.descname').inner_html.to_s
+          node.content = node.text
+        end
+
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/graphite/entries.rb
+++ b/lib/docs/filters/graphite/entries.rb
@@ -1,0 +1,45 @@
+module Docs
+  class Graphite
+    class EntriesFilter < Docs::EntriesFilter
+      def get_name
+        at_css('h1').children[0].to_s
+      end
+
+      def get_type
+        get_name
+      end
+
+      def additional_entries
+        entries = []
+
+        # Sections
+        css('.section').each do |node|
+          title = node.at_css('h2, h3')
+
+          next if title.nil?
+
+          # Move the id attribute to the title
+          # If this is excluded, the complete section will be highlighted in yellow when someone navigates to it
+          title['id'] = node['id']
+          node.remove_attribute('id')
+
+          entry = [title.children[0].to_s, title['id']]
+
+          # Separate sub-sections in additional types
+          if title.name == 'h3'
+            entry.push title.xpath('parent::div[@class="section"]/preceding::h2').last.children[0].to_s
+          end
+
+          entries << entry
+        end
+
+        # Functions
+        css('dl.function > dt').each do |node|
+          entries << [node['data-name'], node['id'], 'List of functions']
+        end
+
+        entries
+      end
+    end
+  end
+end

--- a/lib/docs/filters/graphite/entries.rb
+++ b/lib/docs/filters/graphite/entries.rb
@@ -13,7 +13,7 @@ module Docs
         entries = []
 
         # Sections
-        css('.section').each do |node|
+        css('.section > .section').each do |node|
           title = node.at_css('h2, h3')
 
           next if title.nil?
@@ -23,14 +23,13 @@ module Docs
           title['id'] = node['id']
           node.remove_attribute('id')
 
-          entry = [title.children[0].to_s, title['id']]
+          parent_title_selector = "parent::div[@class='section']/preceding::#{title.name == 'h2' ? 'h1' : 'h2'}"
 
-          # Separate sub-sections in additional types
-          if title.name == 'h3'
-            entry.push title.xpath('parent::div[@class="section"]/preceding::h2').last.children[0].to_s
-          end
-
-          entries << entry
+          entries << [
+            title.children[0].to_s,
+            title['id'],
+            title.xpath(parent_title_selector).last.children[0].to_s
+          ]
         end
 
         # Functions

--- a/lib/docs/scrapers/graphite.rb
+++ b/lib/docs/scrapers/graphite.rb
@@ -9,8 +9,8 @@ module Docs
 
     html_filters.push 'graphite/clean_html', 'graphite/entries'
 
-    options[:container] = '.document > div > .section'
-    options[:skip] = %w(releases.html who-is-using.html composer.html)
+    options[:container] = '.document > div'
+    options[:skip] = %w(releases.html who-is-using.html composer.html search.html py-modindex.html genindex.html)
 
     options[:attribution] = <<-HTML
       &copy; 2008-2012 Chris Davis; 2011-2016 The Graphite Project<br>

--- a/lib/docs/scrapers/graphite.rb
+++ b/lib/docs/scrapers/graphite.rb
@@ -1,0 +1,20 @@
+module Docs
+  class Graphite < UrlScraper
+    self.type = 'graphite'
+    self.release = '1.1.3'
+    self.base_url = 'http://graphite.readthedocs.io/en/latest/'
+    self.links = {
+      code: 'https://github.com/graphite-project/graphite-web'
+    }
+
+    html_filters.push 'graphite/clean_html', 'graphite/entries'
+
+    options[:container] = '.document > div > .section'
+    options[:skip] = %w(releases.html who-is-using.html composer.html)
+
+    options[:attribution] = <<-HTML
+      &copy; 2008-2012 Chris Davis; 2011-2016 The Graphite Project<br>
+      Licensed under the Apache License, Version 2.0.
+    HTML
+  end
+end


### PR DESCRIPTION
Added a scraper for the Graphite documentation ([Trello card](https://trello.com/c/RydHbzls)).

The documentation is licensed under the [Apache license, version 2.0](https://raw.githubusercontent.com/graphite-project/graphite-web/master/LICENSE).

While there is [a logo](https://raw.githubusercontent.com/graphite-project/graphite-web/master/webapp/content/img/graphite-logo.png), there is no svg version of it or a version with only it's icon besides the 14x14 favicon which can't be scaled well. I think it's a better idea to use the default icon.

I have tried to reduce the number of types a bit, but because some pages are larger than others I decided to rather have too many types than too few (in order to prevent cluttered entries in the menu of pages with multiple sections and sub-sections).