### PR TITLE
Add light background to images and iframes

### DIFF
--- a/assets/stylesheets/global/_base.scss
+++ b/assets/stylesheets/global/_base.scss
@@ -218,6 +218,10 @@ button:focus {
   outline: -webkit-focus-ring-color auto 5px;
 }
 
+img, iframe {
+  background: $externalsBackground;
+}
+
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;

--- a/assets/stylesheets/global/_variables-dark.scss
+++ b/assets/stylesheets/global/_variables-dark.scss
@@ -13,6 +13,8 @@ $sidebarMediumWidth: 16rem;
 $documentBackground: #222;
 $contentBackground: #33373a;
 
+$externalsBackground: #fff;
+
 $textColor: #cbd0d0;
 $textColorLight: #9da5ad;
 $textColorLighter: #77787a;

--- a/assets/stylesheets/global/_variables.scss
+++ b/assets/stylesheets/global/_variables.scss
@@ -13,6 +13,8 @@ $sidebarMediumWidth: 16rem;
 $documentBackground: #f3f3f3;
 $contentBackground: #fff;
 
+$externalsBackground: $contentBackground;
+
 $textColor: #333;
 $textColorLight: #666;
 $textColorLighter: #888;


### PR DESCRIPTION
Adds a light background to external elements (images and iframes), which fixes #743 and fixes #869.