### PR TITLE
Tell Travis to cache bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+
+cache: bundler
+
 before_script:
   - gem update --system
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 
-cache:
-  bundler: true
-  directories:
-    - /home/travis/.rvm/
+cache: bundler
 
 before_script:
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - /home/travis/.rvm/
 
 before_script:
   - gem update --system


### PR DESCRIPTION
Currently, Travis builds take about 2m15s. About 1 minute of that is spent installing the dependencies. That number can be brought down by telling Travis to cache the dependencies, which should turn that 1 minute into 5 - 10 seconds.