### PR TITLE
Fix linebreaks in Elixir code blocks

### DIFF
--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -59,6 +59,7 @@ module Docs
 
         css('pre').each do |node|
           node['data-language'] = 'elixir'
+          node.content = node.content
         end
       end
     end


### PR DESCRIPTION
Fixed the linebreaks in code blocks in the Elixir documentation, which fixes #864:
![](https://i.imgur.com/8vIVN7s.png)