### PR TITLE
Fixed two Python 3.7 types

### DIFF
--- a/lib/docs/filters/python/clean_html.rb
+++ b/lib/docs/filters/python/clean_html.rb
@@ -22,8 +22,10 @@ module Docs
           end
         end
 
-        css('h2', 'h3', 'h4').each do |node|
-          node.inner_html = node.inner_html.remove @levelRegexp
+        unless @levelRegexp.nil?
+          css('h2', 'h3', 'h4').each do |node|
+            node.inner_html = node.inner_html.remove @levelRegexp
+          end
         end
       end
     end

--- a/lib/docs/filters/python/entries_v3.rb
+++ b/lib/docs/filters/python/entries_v3.rb
@@ -2,16 +2,18 @@ module Docs
   class Python
     class EntriesV3Filter < Docs::EntriesFilter
       REPLACE_TYPES = {
-        'Cryptographic'                           => 'Cryptography',
-        'Custom Interpreters'                     => 'Interpreters',
-        'Data Compression & Archiving'            => 'Data Compression',
-        'Generic Operating System'                => 'Operating System',
-        'Graphical User Interfaces with Tk'       => 'Tk',
-        'Internet Data Handling'                  => 'Internet Data',
-        'Internet Protocols & Support'            => 'Internet',
-        'Interprocess Communication & Networking' => 'Networking',
-        'Program Frameworks'                      => 'Frameworks',
-        'Structured Markup Processing Tools'      => 'Structured Markup' }
+        'contextvars — Context Variables'          => 'Context Variables',
+        'Cryptographic'                            => 'Cryptography',
+        'Custom Interpreters'                      => 'Interpreters',
+        'Data Compression & Archiving'             => 'Data Compression',
+        'email — An email & MIME handling package' => 'Email',
+        'Generic Operating System'                 => 'Operating System',
+        'Graphical User Interfaces with Tk'        => 'Tk',
+        'Internet Data Handling'                   => 'Internet Data',
+        'Internet Protocols & Support'             => 'Internet',
+        'Interprocess Communication & Networking'  => 'Networking',
+        'Program Frameworks'                       => 'Frameworks',
+        'Structured Markup Processing Tools'       => 'Structured Markup' }
 
       def get_name
         name = at_css('h1').content


### PR DESCRIPTION
This fixes #845. It groups all email documentation under the `Email` type and all context variable documentation under the `Context Variables` type.

Also fixes a minor issue that caused a lot of errors when generating the documentation because `@levelRegExp` in `lib/docs/filters/python/clean_html.rb` can be `nil`.