### PR TITLE
Fix internal links to method reference in the Express documentation

### DIFF
--- a/lib/docs/filters/express/clean_html.rb
+++ b/lib/docs/filters/express/clean_html.rb
@@ -42,6 +42,11 @@ module Docs
           node.parent.content = node.parent.content
         end
 
+        # Fix links to the method reference
+        css('a').each do |node|
+          node['href'] = node['href'].sub('4x/api', 'index')
+        end
+
         doc
       end
     end


### PR DESCRIPTION
Fixes #741 by making sure links to the method reference in the Express documentation are replaced with the correct link. Because the root path of the parser is set to `4x/api.html`, the `4x/api.html` file is renamed to `index.html` which breaks all internal links that point towards `4x/api.html`. This pull request fixes that.