### PR TITLE
Fix Rust entries

### DIFF
--- a/lib/docs/filters/rust/entries.rb
+++ b/lib/docs/filters/rust/entries.rb
@@ -42,11 +42,14 @@ module Docs
             entries << [node.content, node['id']] unless node.content.include?('Note:')
           end
         else
-          css('#methods + * + div > .method', '#required-methods + div > .method', '#provided-methods + div > .method').map do |node|
-            name = node.at_css('.fnname').content
-            name.prepend "#{self.name}::"
-            [name, node['id']]
-          end
+          css('.method')
+            .select {|node| !node.at_css('.fnname').nil?}
+            .map {|node|
+              name = node.at_css('.fnname').content
+              name.prepend "#{self.name}::"
+              [name, node['id']]
+            }
+            .uniq {|item| item[0]}
         end
       end
     end


### PR DESCRIPTION
Fixes the additional entries in Rust's entries filter, which fixes #866. Side-by-side (left is development, right is current):

![](https://i.imgur.com/mZa1g3d.png)

The issue shows up when there are more than one of these implementation groups (DevDocs only indexes the methods in the first group):

![](https://i.imgur.com/JC3AmW8.png)