### PR TITLE
Fix CSS variable support check

### DIFF
--- a/assets/javascripts/app/app.coffee
+++ b/assets/javascripts/app/app.coffee
@@ -245,7 +245,7 @@
         matchMedia:         !!window.matchMedia
         insertAdjacentHTML: !!document.body.insertAdjacentHTML
         defaultPrevented:     document.createEvent('CustomEvent').defaultPrevented is false
-        cssVariables:         CSS.supports and CSS.supports('--t:0')
+        cssVariables:         CSS.supports and CSS.supports('--t', '0')
 
       for key, value of features when not value
         Raven.captureMessage "unsupported/#{key}", level: 'info'


### PR DESCRIPTION
The check to see if the browser supports CSS variables broke DevDocs Desktop, as reported in egoist/devdocs-desktop#85. I'm not sure exactly why it doesn't work correctly, but by using `CSS.supports('--t', '0')` instead of `CSS.supports('--t', '0')` the issue is fixed. This newer way was tested to return `true` on Chrome 59 and 69 (which both support CSS variables), and on Chrome 47 (which doesn't support CSS variables) it returns `false`.

Chrome 47:
![](https://i.imgur.com/5rjlpSb.png)

Chrome 59:
![](https://i.imgur.com/o8KfvvT.png)

Chrome 69:
![](https://i.imgur.com/o87c2l6.png)