### PR TITLE
Fixing dark mode external link display

### DIFF
--- a/assets/stylesheets/components/_page.scss
+++ b/assets/stylesheets/components/_page.scss
@@ -11,7 +11,9 @@
   > h1 { @extend ._lined-heading; }
   > h1:first-child { margin-top: 0; }
 
-  a[href^="http:"], a[href^="https:"] { @extend %external-link; }
+  a[href^="http:"], a[href^="https:"] {
+    &:after { @extend %external-link; }
+  }
 
   a:not([href]) {
     color: inherit;

--- a/assets/stylesheets/components/_sidebar.scss
+++ b/assets/stylesheets/components/_sidebar.scss
@@ -362,8 +362,10 @@
   padding: .75rem 0;
   font-size: .8125rem;
   text-align: center;
-  @extend %external-link;
 
-  &:after { visibility: hidden; }
+  &:after {
+    @extend %external-link;
+    visibility: hidden;
+  }
   &:hover:after { visibility: visible; }
 }


### PR DESCRIPTION
- Only apply %external-link in a:after

Fixes issue : https://github.com/freeCodeCamp/devdocs/issues/892
