### PR TITLE
Removed background from GitHub button

### DIFF
--- a/assets/stylesheets/components/_content.scss
+++ b/assets/stylesheets/components/_content.scss
@@ -460,4 +460,5 @@
   display: inline-block;
   vertical-align: text-top;
   margin-left: .25rem;
+  background: inherit;
 }


### PR DESCRIPTION
Set GitHub button to inherit background instead of default iframe white background, to aid in visibility.