### PR TITLE
Remove scope by clicking on it or by backspacing into it

### DIFF
--- a/assets/javascripts/views/search/search.coffee
+++ b/assets/javascripts/views/search/search.coffee
@@ -30,6 +30,9 @@ class app.views.Search extends app.View
       .on 'results', @onResults
       .on 'end', @onEnd
 
+    @scope
+      .on 'change', @onScopeChange
+
     app.on 'ready', @onReady
     $.on window, 'hashchange', @searchUrl
     $.on window, 'focus', @onWindowFocus
@@ -136,6 +139,10 @@ class app.views.Search extends app.View
 
   onSubmit: (event) ->
     $.stopEvent(event)
+    return
+
+  onScopeChange: =>
+    @value = ''
     return
 
   afterRoute: (name, context) =>

--- a/assets/javascripts/views/search/search.coffee
+++ b/assets/javascripts/views/search/search.coffee
@@ -143,6 +143,7 @@ class app.views.Search extends app.View
 
   onScopeChange: =>
     @value = ''
+    @onInput()
     return
 
   afterRoute: (name, context) =>

--- a/assets/javascripts/views/search/search_scope.coffee
+++ b/assets/javascripts/views/search/search_scope.coffee
@@ -6,6 +6,7 @@ class app.views.SearchScope extends app.View
     tag:   '._search-tag'
 
   @events:
+    click: 'onClick'
     keydown: 'onKeydown'
 
   @routes:
@@ -87,11 +88,19 @@ class app.views.SearchScope extends app.View
     @trigger 'change', null, previousDoc
     return
 
+  onClick: (event) =>
+    if event.target is @tag
+      @reset()
+      $.trigger @input, 'input'
+      $.stopEvent(event)
+    return
+
   onKeydown: (event) =>
     if event.which is 8 # backspace
-      if @doc and not @input.value
-        $.stopEvent(event)
+      if @doc and @input.selectionEnd is 0
         @reset()
+        $.trigger @input, 'input'
+        $.stopEvent(event)
     else if not @doc and @input.value
       return if event.ctrlKey or event.metaKey or event.altKey or event.shiftKey
       if event.which is 9 or # tab

--- a/assets/javascripts/views/search/search_scope.coffee
+++ b/assets/javascripts/views/search/search_scope.coffee
@@ -91,7 +91,6 @@ class app.views.SearchScope extends app.View
   onClick: (event) =>
     if event.target is @tag
       @reset()
-      $.trigger @input, 'input'
       $.stopEvent(event)
     return
 
@@ -99,7 +98,6 @@ class app.views.SearchScope extends app.View
     if event.which is 8 # backspace
       if @doc and @input.selectionEnd is 0
         @reset()
-        $.trigger @input, 'input'
         $.stopEvent(event)
     else if not @doc and @input.value
       return if event.ctrlKey or event.metaKey or event.altKey or event.shiftKey

--- a/assets/stylesheets/components/_header.scss
+++ b/assets/stylesheets/components/_header.scss
@@ -215,5 +215,6 @@
   color: var(--textColorLight);
   background: var(--searchTagBackground);
   border-radius: 2px;
+  cursor: pointer;
   @extend %truncate-text;
 }


### PR DESCRIPTION
Adds two improvements to the search scope as suggested in #938:
- When a scope is selected and the backspace is pressed when the insertion point is all the way to the left, the scope is removed:
![](https://i.imgur.com/0xYAWKD.gif)
- When a scope is selected and you press on the search tag, it is removed:
![](https://i.imgur.com/0KWZqlF.gif)