### PR TITLE
Don’t throw when the `CSS` global is not defined

### DIFF
--- a/assets/javascripts/app/app.coffee
+++ b/assets/javascripts/app/app.coffee
@@ -252,7 +252,7 @@
         matchMedia:         !!window.matchMedia
         insertAdjacentHTML: !!document.body.insertAdjacentHTML
         defaultPrevented:     document.createEvent('CustomEvent').defaultPrevented is false
-        cssVariables:         CSS.supports and CSS.supports('(--t: 0)')
+        cssVariables:       !!CSS?.supports?('(--t: 0)')
 
       for key, value of features when not value
         Raven.captureMessage "unsupported/#{key}", level: 'info'


### PR DESCRIPTION
This should fix [this issue](https://sentry.io/organizations/devdocs/issues/17634871/) from Sentry.

---

Do you want to [add the GitHub integration](https://sentry.io/settings/devdocs/integrations/) to Sentry so issues/PRs can be linked to Sentry?