### PR TITLE
Fix layout preferences on Firefox

### DIFF
--- a/assets/javascripts/app/app.coffee
+++ b/assets/javascripts/app/app.coffee
@@ -26,6 +26,8 @@
     @document = new app.views.Document
     @mobile = new app.views.Mobile if @isMobile()
 
+    @settings.initLayout()
+
     if document.body.hasAttribute('data-doc')
       @DOC = JSON.parse(document.body.getAttribute('data-doc'))
       @bootOne()

--- a/assets/javascripts/app/settings.coffee
+++ b/assets/javascripts/app/settings.coffee
@@ -19,6 +19,9 @@ class app.Settings
     'news'
   ]
 
+  LAYOUTS = ['_max-width', '_sidebar-hidden', '_native-scrollbars']
+  SIDEBAR_HIDDEN_LAYOUT = '_sidebar-hidden'
+
   @defaults:
     count: 0
     hideDisabled: false
@@ -38,6 +41,7 @@ class app.Settings
   set: (key, value) ->
     @store.set(key, value)
     delete @cache[key]
+    @toggleDark(value) if key == 'dark'
     return
 
   del: (key) ->
@@ -63,6 +67,8 @@ class app.Settings
     return
 
   setLayout: (name, enable) ->
+    @toggleLayout(name, enable)
+
     layout = (@store.get('layout') || '').split(' ')
     $.arrayDelete(layout, '')
 
@@ -80,6 +86,9 @@ class app.Settings
   hasLayout: (name) ->
     layout = (@store.get('layout') || '').split(' ')
     layout.indexOf(name) isnt -1
+
+  getAllLayouts: ->
+    return LAYOUTS
 
   setSize: (value) ->
     @set 'size', value
@@ -104,3 +113,16 @@ class app.Settings
     @store.reset()
     @cache = {}
     return
+
+  initLayout: ->
+    @toggleDark(@get('dark'))
+    @toggleLayout(layout, @hasLayout(layout)) for layout in LAYOUTS
+
+  toggleDark: (enable) ->
+    classList = document.documentElement.classList
+    classList[if enable then 'remove' else 'add']('_theme-default')
+    classList[if enable then 'add' else 'remove']('_theme-dark')
+
+  toggleLayout: (layout, enable) ->
+    document.body.classList[if enable then 'add' else 'remove'](layout) unless layout is SIDEBAR_HIDDEN_LAYOUT
+    document.body.classList[if $.overlayScrollbarsEnabled() then 'add' else 'remove']('_overlay-scrollbars')

--- a/assets/javascripts/app/settings.coffee
+++ b/assets/javascripts/app/settings.coffee
@@ -19,7 +19,7 @@ class app.Settings
     'news'
   ]
 
-  LAYOUTS = ['_max-width', '_sidebar-hidden', '_native-scrollbars']
+  LAYOUTS: ['_max-width', '_sidebar-hidden', '_native-scrollbars']
   SIDEBAR_HIDDEN_LAYOUT = '_sidebar-hidden'
 
   @defaults:
@@ -87,9 +87,6 @@ class app.Settings
     layout = (@store.get('layout') || '').split(' ')
     layout.indexOf(name) isnt -1
 
-  getAllLayouts: ->
-    return LAYOUTS
-
   setSize: (value) ->
     @set 'size', value
     return
@@ -116,7 +113,7 @@ class app.Settings
 
   initLayout: ->
     @toggleDark(@get('dark'))
-    @toggleLayout(layout, @hasLayout(layout)) for layout in LAYOUTS
+    @toggleLayout(layout, @hasLayout(layout)) for layout in @LAYOUTS
 
   toggleDark: (enable) ->
     classList = document.documentElement.classList

--- a/assets/javascripts/app/settings.coffee
+++ b/assets/javascripts/app/settings.coffee
@@ -124,5 +124,6 @@ class app.Settings
     classList[if enable then 'add' else 'remove']('_theme-dark')
 
   toggleLayout: (layout, enable) ->
-    document.body.classList[if enable then 'add' else 'remove'](layout) unless layout is SIDEBAR_HIDDEN_LAYOUT
-    document.body.classList[if $.overlayScrollbarsEnabled() then 'add' else 'remove']('_overlay-scrollbars')
+    classList = document.body.classList
+    classList[if enable then 'add' else 'remove'](layout) unless layout is SIDEBAR_HIDDEN_LAYOUT
+    classList[if $.overlayScrollbarsEnabled() then 'add' else 'remove']('_overlay-scrollbars')

--- a/assets/javascripts/views/content/settings_page.coffee
+++ b/assets/javascripts/views/content/settings_page.coffee
@@ -1,7 +1,4 @@
 class app.views.SettingsPage extends app.View
-  LAYOUTS = ['_max-width', '_sidebar-hidden', '_native-scrollbars']
-  SIDEBAR_HIDDEN_LAYOUT = '_sidebar-hidden'
-
   @className: '_static'
 
   @events:
@@ -17,23 +14,18 @@ class app.views.SettingsPage extends app.View
     settings.dark = app.settings.get('dark')
     settings.smoothScroll = !app.settings.get('fastScroll')
     settings.arrowScroll = app.settings.get('arrowScroll')
-    settings[layout] = app.settings.hasLayout(layout) for layout in LAYOUTS
+    settings[layout] = app.settings.hasLayout(layout) for layout in app.settings.getAllLayouts()
     settings
 
   getTitle: ->
     'Preferences'
 
   toggleDark: (enable) ->
-    html = document.documentElement
-    html.classList.toggle('_theme-default')
-    html.classList.toggle('_theme-dark')
     app.settings.set('dark', !!enable)
     app.appCache?.updateInBackground()
     return
 
   toggleLayout: (layout, enable) ->
-    document.body.classList[if enable then 'add' else 'remove'](layout) unless layout is SIDEBAR_HIDDEN_LAYOUT
-    document.body.classList[if $.overlayScrollbarsEnabled() then 'add' else 'remove']('_overlay-scrollbars')
     app.settings.setLayout(layout, enable)
     app.appCache?.updateInBackground()
     return

--- a/assets/javascripts/views/content/settings_page.coffee
+++ b/assets/javascripts/views/content/settings_page.coffee
@@ -14,7 +14,7 @@ class app.views.SettingsPage extends app.View
     settings.dark = app.settings.get('dark')
     settings.smoothScroll = !app.settings.get('fastScroll')
     settings.arrowScroll = app.settings.get('arrowScroll')
-    settings[layout] = app.settings.hasLayout(layout) for layout in app.settings.getAllLayouts()
+    settings[layout] = app.settings.hasLayout(layout) for layout in app.settings.LAYOUTS
     settings
 
   getTitle: ->


### PR DESCRIPTION
Currently layout preferences are loaded based on the cookies sent in the HTTP request to devdocs.io. This does not work on recent versions of Firefox, as has been reported in #992.

After this PR is merged, layout preferences are also loaded locally based on the user's stored cookies. By loading preferences client-side, we no longer need to rely on the optional [`Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie) header. This fixes #992.

Locally loading layout preferences happens before the content is shown, so there is no flickering between light and dark themes on slow connections. Performance does not seem to be affected neither.

The code to load the layout preferences based on the cookies sent with the HTTP request has not been removed as there seem to be some dependencies between that code and the AppCache-related code.