### PR TITLE
Fix OpenJDK scraper

### DIFF
--- a/lib/docs/core/scrapers/file_scraper.rb
+++ b/lib/docs/core/scrapers/file_scraper.rb
@@ -29,7 +29,7 @@ module Docs
 
     def request_one(url)
       assert_source_directory_exists
-      Response.new read_file(url_to_path(url)), URL.parse(url)
+      Response.new read_file(File.join(source_directory, url_to_path(url))), URL.parse(url)
     end
 
     def request_all(urls)
@@ -50,7 +50,7 @@ module Docs
     end
 
     def read_file(path)
-      File.read(File.join(source_directory, path))
+      File.read(path)
     rescue
       instrument 'warn.doc', msg: "Failed to open file: #{path}"
       nil

--- a/test/lib/docs/core/scrapers/file_scraper_test.rb
+++ b/test/lib/docs/core/scrapers/file_scraper_test.rb
@@ -63,7 +63,7 @@ class FileScraperTest < MiniTest::Spec
       end
 
       it "reads a file" do
-        mock(scraper).read_file(path)
+        mock(scraper).read_file(File.join(ROOT_PATH, 'docs/scraper', path))
         result
       end
 
@@ -165,7 +165,7 @@ class FileScraperTest < MiniTest::Spec
 
   describe "#read_file" do
     let :result do
-      scraper.send :read_file, 'file'
+      scraper.send :read_file, File.join(ROOT_PATH, 'docs', 'scraper', 'file')
     end
 
     it "returns the file's content when the file exists in the source directory" do


### PR DESCRIPTION
This PR makes sure `read_file` in file scrapers is always passed an absolute path to the file to be read. In the current version of DevDocs this is done in the `read_file` method in [`file_scraper.rb`](https://github.com/freeCodeCamp/devdocs/blob/master/lib/docs/core/scrapers/file_scraper.rb) itself, but is not done in the `read_file` override in [`openjdk.rb`](https://github.com/freeCodeCamp/devdocs/blob/master/lib/docs/scrapers/openjdk.rb). This causes the OpenJDK scraper to ignore the first page to scrape because it can't open the file based on the relative path given to it's `read_file` method.

This PR ensures that the `read_file` method is always called with an absolute path by creating the absolute path in the `request_one` method, instead of in the `read_file` method itself.