### PR TITLE
Fix typos across devdocs repository

### DIFF
--- a/assets/javascripts/vendor/fastclick.js
+++ b/assets/javascripts/vendor/fastclick.js
@@ -413,7 +413,7 @@
 				// when the user next taps anywhere else on the page, new touchstart and touchend events are dispatched
 				// with the same identifier as the touch event that previously triggered the click that triggered the alert.
 				// Sadly, there is an issue on iOS 4 that causes some normal touch events to have the same identifier as an
-				// immediately preceeding touch event (issue #52), so this fix is unavailable on that platform.
+				// immediately preceding touch event (issue #52), so this fix is unavailable on that platform.
 				// Issue 120: touch.identifier is 0 when Chrome dev tools 'Emulate touch events' is set with an iOS device UA string,
 				// which causes all touch events to be ignored. As this block only applies to iOS, and iOS identifiers are always long,
 				// random integers, it's safe to to continue if the identifier is 0 here.
@@ -805,7 +805,7 @@
 			}
 		}
 
-		// IE11: prefixed -ms-touch-action is no longer supported and it's recomended to use non-prefixed version
+		// IE11: prefixed -ms-touch-action is no longer supported and it's recommended to use non-prefixed version
 		// http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx
 		if (layer.style.touchAction === 'none' || layer.style.touchAction === 'manipulation') {
 			return true;

--- a/assets/javascripts/vendor/raven.js
+++ b/assets/javascripts/vendor/raven.js
@@ -856,7 +856,7 @@ Raven.prototype = {
   },
 
   _triggerEvent: function(eventType, options) {
-    // NOTE: `event` is a native browser thing, so let's avoid conflicting wiht it
+    // NOTE: `event` is a native browser thing, so let's avoid conflicting with it
     var evt, key;
 
     if (!this._hasDocument) return;

--- a/lib/docs/filters/pygame/clean_html.rb
+++ b/lib/docs/filters/pygame/clean_html.rb
@@ -85,7 +85,7 @@ module Docs
               if initial_header.start_with?(@section)
                 sig.content = @section + '.' + sig.text
               end
-              # seperate the signatures on different lines.
+              # separate the signatures on different lines.
               header.add_child "<br>"
             end
           end

--- a/lib/docs/scrapers/pygame.rb
+++ b/lib/docs/scrapers/pygame.rb
@@ -1,7 +1,7 @@
 module Docs
   class Pygame < UrlScraper
     self.type = 'simple'
-    self.release = '1.9.4'
+    self.release = '1.9.6'
     self.base_url = 'https://www.pygame.org/docs/'
     self.root_path = 'py-modindex.html'
     self.links = {

--- a/lib/docs/scrapers/pygame.rb
+++ b/lib/docs/scrapers/pygame.rb
@@ -14,7 +14,7 @@ module Docs
     options[:only_patterns] = [/ref\//]
 
     options[:attribution] = <<-HTML
-      &copy; Pygame Developpers.<br>
+      &copy; Pygame Developers.<br>
       Licensed under the GNU LGPL License version 2.1.
     HTML
 


### PR DESCRIPTION
:blue_heart: Fix typos across **devdocs repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
devdocs/assets/javascripts/vendor/fastclick.js:416:19: "preceeding" is a misspelling of "preceding"
devdocs/assets/javascripts/vendor/fastclick.js:808:69: "recomended" is a misspelling of "recommended"
devdocs/assets/javascripts/vendor/raven.js:859:75: "wiht" is a misspelling of "with"
devdocs/lib/docs/filters/pygame/clean_html.rb:88:16: "seperate" is a misspelling of "separate"
devdocs/lib/docs/scrapers/pygame.rb:17:20: "Developpers" is a misspelling of "Developers"
```

</p>
</details>