### PR TITLE
bump jest to 24.8.0

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -354,8 +354,8 @@ credits = [
     'https://raw.githubusercontent.com/jekyll/jekyll/master/LICENSE'
   ], [
     'Jest',
-    '2014-present Facebook Inc.',
-    'BSD',
+    'Facebook, Inc. and its affiliates.',
+    'MIT',
     'https://raw.githubusercontent.com/facebook/jest/master/LICENSE'
   ], [
     'jQuery',

--- a/lib/docs/filters/jest/entries.rb
+++ b/lib/docs/filters/jest/entries.rb
@@ -20,15 +20,23 @@ module Docs
       def additional_entries
         return [] unless !root_page? && self.type == self.name # api page
 
-        at_css('.mainContainer ul').css('li > a').map do |node|
-          name = node.at_css('code').content.strip
+        entries = []
+
+        at_css('.mainContainer ul').css('li > a').each do |node|
+          code = node.at_css('code')
+          next if code.nil?
+
+          name = code.content.strip
           name.sub! %r{\(.*\)}, '()'
           name.remove! %r{[\s=<].*}
           name.prepend 'jest ' if name.start_with?('--')
           name.prepend 'Config: ' if slug == 'configuration'
           id = node['href'].remove('#')
-          [name, id]
+
+          entries << [name, id]
         end
+
+        entries
       end
     end
   end

--- a/lib/docs/scrapers/jest.rb
+++ b/lib/docs/scrapers/jest.rb
@@ -1,11 +1,11 @@
 module Docs
   class Jest < UrlScraper
     self.type = 'simple'
-    self.release = '24.8.0'
+    self.release = '24.9'
     self.base_url = 'https://jestjs.io/docs/en/'
     self.root_path = 'getting-started'
     self.links = {
-      home: 'https://facebook.github.io/jest/',
+      home: 'https://jestjs.io/',
       code: 'https://github.com/facebook/jest'
     }
 
@@ -14,8 +14,8 @@ module Docs
     options[:container] = '.docMainWrapper'
 
     options[:attribution] = <<-HTML
-      &copy; 2014&ndash;present Facebook Inc.<br>
-      Licensed under the BSD License.
+      &copy; 2019 Facebook, Inc. and its affiliates.<br>
+      Licensed under the MIT License.
     HTML
 
     def get_latest_version(opts)

--- a/lib/docs/scrapers/jest.rb
+++ b/lib/docs/scrapers/jest.rb
@@ -1,7 +1,7 @@
 module Docs
   class Jest < UrlScraper
     self.type = 'simple'
-    self.release = '23.5.0'
+    self.release = '24.8.0'
     self.base_url = 'https://jestjs.io/docs/en/'
     self.root_path = 'getting-started'
     self.links = {


### PR DESCRIPTION
If you’re adding a new scraper, please ensure that you have:

- [ ] Tested the scraper on a local copy of DevDocs
- [ ] Ensured that the docs are styled similarly to other docs on DevDocs
<!-- If the docs don’t have an icon, delete the next four items: -->
- [ ] Added these files to the <code>public/icons/*your_scraper_name*/</code> directory:
  - [ ] `16.png`: a 16×16 pixel icon for the doc
  - [ ] `16@2x.png`: a 32×32 pixel icon for the doc
  - [ ] `SOURCE`: A text file containing the URL to the page the image can be found on or the URL of the original image itself

<!-- Replace the `[ ]` with a `[x]` once you’ve completed each step. -->
