### PR TITLE
bump vue to 2.6.10

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -720,7 +720,7 @@ credits = [
     'https://raw.githubusercontent.com/mitchellh/vagrant/master/website/LICENSE.md'
   ], [
     'Vue.js',
-    '2013-2018 Evan You, Vue.js contributors',
+    '2013-2019 Evan You, Vue.js contributors',
     'MIT',
     'https://raw.githubusercontent.com/vuejs/vue/master/LICENSE'
   ], [

--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -720,9 +720,9 @@ credits = [
     'https://raw.githubusercontent.com/mitchellh/vagrant/master/website/LICENSE.md'
   ], [
     'Vue.js',
-    '2013-2019 Evan You, Vue.js contributors',
+    '2013-present Yuxi Evan You',
     'MIT',
-    'https://raw.githubusercontent.com/vuejs/vue/master/LICENSE'
+    'https://raw.githubusercontent.com/vuejs/vuejs.org/master/LICENSE'
   ], [
     'Vulkan',
     '2014-2017 Khronos Group Inc.<br>Vulkan and the Vulkan logo are registered trademarks of the Khronos Group Inc.',

--- a/lib/docs/filters/vue/clean_html.rb
+++ b/lib/docs/filters/vue/clean_html.rb
@@ -16,8 +16,17 @@ module Docs
           node['data-language'] = node['class'][/highlight (\w+)/, 1]
         end
 
+        css('pre').each do |node|
+          node.content = node.content.strip
+          node['data-language'] = 'javascript'
+        end
+
         css('iframe').each do |node|
           node['sandbox'] = 'allow-forms allow-scripts allow-same-origin'
+        end
+
+        css('details').each do |node|
+          node.name = 'div'
         end
 
         doc

--- a/lib/docs/filters/vue/entries.rb
+++ b/lib/docs/filters/vue/entries.rb
@@ -4,6 +4,8 @@ module Docs
       def get_name
         if slug == 'api/'
           'API'
+        elsif slug == 'style-guide/'
+          'Style Guide'
         else
           name = at_css('.content h1').content
           node = at_css(".sidebar .menu-root a[href='#{File.basename(slug)}']")
@@ -16,6 +18,8 @@ module Docs
       def get_type
         if slug.start_with?('guide')
           'Guide'
+        elsif slug == 'style-guide/'
+          'Style Guide'
         else
           'API'
         end
@@ -31,7 +35,15 @@ module Docs
           else
             name = node.content.strip
             name.sub! %r{\(.*\)}, '()'
-            entries << [name, node['id'], "API: #{type}"]
+            name.sub! /(essential|strongly recommended|recommended|use with caution)\Z/, ''
+
+            current_type = "API: #{type}"
+            if slug == 'style-guide/'
+              current_type = "Style Guide: "
+              current_type += type.sub(/( Rules: )/, ': ').split('(')[0]
+            end
+
+            entries << [name, node['id'], current_type]
           end
         end
       end

--- a/lib/docs/filters/vue/entries.rb
+++ b/lib/docs/filters/vue/entries.rb
@@ -2,13 +2,16 @@ module Docs
   class Vue
     class EntriesFilter < Docs::EntriesFilter
       def get_name
-        if slug == 'api/'
+        if slug == 'api/' || slug == 'api/index'
           'API'
         elsif slug == 'style-guide/'
           'Style Guide'
         else
           name = at_css('.content h1').content
           node = at_css(".sidebar .menu-root a[href='#{File.basename(slug)}']")
+
+          return name if node.nil?
+
           index = node.parent.parent.css('> li > a').to_a.index(node)
           name.prepend "#{index + 1}. " if index
           name

--- a/lib/docs/scrapers/vue.rb
+++ b/lib/docs/scrapers/vue.rb
@@ -15,12 +15,12 @@ module Docs
     options[:replace_paths] = { 'guide/' => 'guide/index.html' }
 
     options[:attribution] = <<-HTML
-      &copy; 2013&ndash;2018 Evan You, Vue.js contributors<br>
+      &copy; 2013&ndash;2019 Evan You, Vue.js contributors<br>
       Licensed under the MIT License.
     HTML
 
     version '2' do
-      self.release = '2.5.16'
+      self.release = '2.6.10'
       self.base_url = 'https://vuejs.org/v2/'
       self.root_path = 'guide/index.html'
       self.initial_paths = %w(api/)

--- a/lib/docs/scrapers/vue.rb
+++ b/lib/docs/scrapers/vue.rb
@@ -15,7 +15,7 @@ module Docs
     options[:replace_paths] = { 'guide/' => 'guide/index.html' }
 
     options[:attribution] = <<-HTML
-      &copy; 2013&ndash;2019 Evan You, Vue.js contributors<br>
+      &copy; 2013&ndash;present Yuxi Evan You<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
https://github.com/vuejs/vue/releases

If you’re adding a new scraper, please ensure that you have:

- [ ] Tested the scraper on a local copy of DevDocs
- [ ] Ensured that the docs are styled similarly to other docs on DevDocs
<!-- If the docs don’t have an icon, delete the next four items: -->
- [ ] Added these files to the <code>public/icons/*your_scraper_name*/</code> directory:
  - [ ] `16.png`: a 16×16 pixel icon for the doc
  - [ ] `16@2x.png`: a 32×32 pixel icon for the doc
  - [ ] `SOURCE`: A text file containing the URL to the page the image can be found on or the URL of the original image itself

<!-- Replace the `[ ]` with a `[x]` once you’ve completed each step. -->
