### PR TITLE
Update Ruby documentation (2.6.3)

### DIFF
--- a/lib/docs/scrapers/rdoc/ruby.rb
+++ b/lib/docs/scrapers/rdoc/ruby.rb
@@ -69,6 +69,10 @@ module Docs
       Licensed under their own licenses.
     HTML
 
+    version '2.6' do
+      self.release = '2.6.3'
+    end
+
     version '2.5' do
       self.release = '2.5.3'
     end


### PR DESCRIPTION
Here's what I did:
- [x] Downloaded Ruby 2.6.3: https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz
- [x] Compiled Ruby: `./configure --with-openssl-dir="/usr/local/opt/openssl" && make html`
- [x] Copied `ruby-2.6.3/.ext/html` to `devdocs/docs/ruby~2.6`
- [x] `thor docs:generate ruby --force`
- [x] Started the local server: `bundle exec rackup`
- [x] Checked that Ruby 2.6 docs are rendered (see screenshot)

<img width="2672" alt="Screen Shot 2019-08-14 at 7 43 10 PM" src="https://user-images.githubusercontent.com/1164687/63069469-cc7ea080-becb-11e9-968e-34f0b20e64b9.png">

