### PR TITLE
Fix Issue #943: Update All button not working

### DIFF
--- a/assets/javascripts/views/content/offline_page.coffee
+++ b/assets/javascripts/views/content/offline_page.coffee
@@ -56,7 +56,7 @@ class app.views.OfflinePage extends app.View
       action = 'install' if action is 'update'
       doc[action](@onInstallSuccess.bind(@, doc), @onInstallError.bind(@, doc), @onInstallProgress.bind(@, doc))
       el.parentNode.innerHTML = "#{el.textContent.replace(/e$/, '')}ing…"
-    else if action = el.getAttribute('data-action-all')
+    else if action = el.getAttribute('data-action-all') || el.parentElement.getAttribute('data-action-all')
       return unless action isnt 'uninstall' or window.confirm('Uninstall all docs?')
       app.db.migrate()
       $.click(el) for el in @findAll("[data-action='#{action}']")


### PR DESCRIPTION
This change fixes https://github.com/freeCodeCamp/devdocs/issues/943

The "Update All" button uses a `<strong>` tag within the `<button>` tag, breaking the current `data-action` extraction method of looking at the target element. This PR adds an alternative way of trying to extract the action from the parent in case it can't be extracted from the target of the click.
