### PR TITLE
Update Nim documentation (1.0.0)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -508,7 +508,7 @@ credits = [
     'https://github.com/openresty/lua-nginx-module#copyright-and-license'
   ], [
     'Nim',
-    '2006-2017 Andreas Rumpf',
+    '2006-2019 Andreas Rumpf',
     'MIT',
     'https://github.com/nim-lang/Nim#license'
   ], [

--- a/lib/docs/scrapers/nim.rb
+++ b/lib/docs/scrapers/nim.rb
@@ -1,7 +1,7 @@
 module Docs
   class Nim < UrlScraper
     self.type = 'simple'
-    self.release = '0.19.0'
+    self.release = '1.0.0'
     self.base_url = 'https://nim-lang.org/docs/'
     self.root_path = 'overview.html'
     self.links = {
@@ -14,7 +14,7 @@ module Docs
     options[:skip] = %w(theindex.html docgen.txt)
 
     options[:attribution] = <<-HTML
-      &copy; 2006&ndash;2018 Andreas Rumpf<br>
+      &copy; 2006&ndash;2019 Andreas Rumpf<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

---

Currently emits an error on a single page:

```
ERROR:
  https://nim-lang.org/docs/strutils.html
  ArgumentError: invalid byte sequence in UTF-8
```

Everything else is good.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/freecodecamp/devdocs/1089)
<!-- Reviewable:end -->
