### PR TITLE
Update Crystal documentation (0.31.0)

### DIFF
--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -52,8 +52,8 @@ module Docs
     end
 
     def get_latest_version(opts)
-      body = fetch('https://crystal-lang.org/api', opts)
-      body.scan(/Crystal Docs ([0-9.]+)/)[0][0]
+      doc = fetch_doc('https://crystal-lang.org/', opts)
+      doc.at_css('.latest-release').content.scan(/([0-9.]+)/)[0][0]
     end
   end
 end

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -1,7 +1,6 @@
 module Docs
   class Crystal < UrlScraper
     self.type = 'crystal'
-    self.release = '0.30.1'
     self.base_url = 'https://crystal-lang.org/'
     self.root_path = "api/#{release}/index.html"
     self.initial_paths = %w(docs/index.html)
@@ -34,6 +33,14 @@ module Docs
         HTML
       end
     }
+
+    version '0.31' do
+      self.release = '0.31.0'
+    end
+
+    version '0.30' do
+      self.release = '0.30.1'
+    end
 
     def get_latest_version(opts)
       body = fetch('https://crystal-lang.org/api', opts)

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -2,7 +2,6 @@ module Docs
   class Crystal < UrlScraper
     self.type = 'crystal'
     self.base_url = 'https://crystal-lang.org/'
-    self.root_path = "api/#{release}/index.html"
     self.initial_paths = %w(docs/index.html)
     self.links = {
       home: 'https://crystal-lang.org/',
@@ -10,14 +9,6 @@ module Docs
     }
 
     html_filters.push 'crystal/entries', 'crystal/clean_html'
-
-    options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
-    options[:skip_patterns] = [/debug/i]
-
-    options[:replace_paths] = {
-      "api/#{release}/" => "api/#{release}/index.html",
-      'docs/' => 'docs/index.html'
-    }
 
     options[:attribution] = ->(filter) {
       if filter.slug.start_with?('docs')
@@ -35,11 +26,29 @@ module Docs
     }
 
     version '0.31' do
-      self.release = '0.31.0'
+      self.release = '0.31.1'
+      self.root_path = "api/#{release}/index.html"
+
+      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
+      options[:skip_patterns] = [/debug/i]
+
+      options[:replace_paths] = {
+        "api/#{release}/" => "api/#{release}/index.html",
+        'docs/' => 'docs/index.html'
+      }
     end
 
     version '0.30' do
       self.release = '0.30.1'
+      self.root_path = "api/#{release}/index.html"
+
+      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
+      options[:skip_patterns] = [/debug/i]
+
+      options[:replace_paths] = {
+        "api/#{release}/" => "api/#{release}/index.html",
+        'docs/' => 'docs/index.html'
+      }
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

---

I made the decision to create a new version because of [breaking changes in Crystal 0.31](https://github.com/crystal-lang/crystal/releases/tag/0.31.0) (like removing the `Markdown` module, for example).