### PR TITLE
Fix issue #1101: reloading breaks auto-hide layout

### DIFF
--- a/assets/javascripts/app/router.coffee
+++ b/assets/javascripts/app/router.coffee
@@ -124,6 +124,9 @@ class app.Router
   isIndex: ->
     @context?.path is '/' or (app.isSingleDoc() and @context?.entry?.isIndex())
 
+  isSettings: ->
+    @context?.path is '/settings'
+
   setInitialPath: ->
     # Remove superfluous forward slashes at the beginning of the path
     if (path = location.pathname.replace /^\/{2,}/g, '/') isnt location.pathname

--- a/assets/javascripts/app/settings.coffee
+++ b/assets/javascripts/app/settings.coffee
@@ -129,7 +129,7 @@ class app.Settings
 
   toggleLayout: (layout, enable) ->
     classList = document.body.classList
-    classList.toggle(layout, enable) unless layout is '_sidebar-hidden'
+    classList.toggle(layout, enable) unless app.router?.isSettings
     classList.toggle('_overlay-scrollbars', $.overlayScrollbarsEnabled())
     return
 


### PR DESCRIPTION
This change fixes https://github.com/freeCodeCamp/devdocs/issues/1101 by setting the `_auto-hide` layout based on current location instead of simply by name. My comment to the tickets gives a little more background.