### PR TITLE
Update puppeteer documentation (1.20.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Unless you wish to contribute to the project, we recommend using the hosted vers
 
 DevDocs is made of two pieces: a Ruby scraper that generates the documentation and metadata, and a JavaScript app powered by a small Sinatra app.
 
-DevDocs requires Ruby 2.6.0, libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
+DevDocs requires Ruby 2.6.3, libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
 
 ```
 git clone https://github.com/freeCodeCamp/devdocs.git && cd devdocs

--- a/lib/docs/scrapers/puppeteer.rb
+++ b/lib/docs/scrapers/puppeteer.rb
@@ -1,7 +1,7 @@
 module Docs
   class Puppeteer < Github
-    self.release = '1.19.0'
-    self.base_url = 'https://github.com/GoogleChrome/puppeteer/blob/v1.19.0/docs/api.md'
+    self.release = '1.20.0'
+    self.base_url = 'https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/docs/api.md'
     self.links = {
       code: 'https://github.com/GoogleChrome/puppeteer'
     }


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Also, noticed the `Quick Start` docs seemed outdated, so updated the required ruby version (which closes #1103)
