### PR TITLE
Update Rails documentation (6.0.0)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -658,7 +658,7 @@ credits = [
     'https://www.ruby-lang.org/en/about/license.txt'
   ], [
     'Ruby on Rails',
-    '2004-2017 David Heinemeier Hansson<br>Rails, Ruby on Rails, and the Rails logo are trademarks of David Heinemeier Hansson.',
+    '2004-2019 David Heinemeier Hansson<br>Rails, Ruby on Rails, and the Rails logo are trademarks of David Heinemeier Hansson.',
     'MIT',
     'https://raw.githubusercontent.com/rails/rails/master/activerecord/MIT-LICENSE'
   ], [

--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -45,6 +45,15 @@ module Docs
       ActiveSupport/Dependencies/WatchStack.html
       ActiveSupport/Notifications/Fanout.html)
 
+    # False positives found by docs:generate
+    options[:skip].concat %w(
+      ActionDispatch/www.example.com
+      ActionDispatch/Http/www.rubyonrails.org
+      ActionDispatch/Http/www.rubyonrails.co.uk
+      'TZ'
+      active_record_migrations.html
+      association_basics.html)
+
     options[:skip_patterns] += [
       /release_notes/,
       /\AActionController\/Testing/,

--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -63,15 +63,19 @@ module Docs
     options[:attribution] = ->(filter) do
       if filter.slug.start_with?('guides')
         <<-HTML
-          &copy; 2004&ndash;2018 David Heinemeier Hansson<br>
+          &copy; 2004&ndash;2019 David Heinemeier Hansson<br>
           Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
         HTML
       else
         <<-HTML
-          &copy; 2004&ndash;2018 David Heinemeier Hansson<br>
+          &copy; 2004&ndash;2019 David Heinemeier Hansson<br>
           Licensed under the MIT License.
         HTML
       end
+    end
+
+    version '6.0' do
+      self.release = '6.0.0'
     end
 
     version '5.2' do


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

As mentioned in https://github.com/freeCodeCamp/devdocs/issues/1108, I've added some files to the skip options for the scraper that are erroneously added from internal URLs. I've confirmed that both of the actual files referenced in those anchor links (active_record_migrations and association_basics) are properly scraped.