### PR TITLE
python: add version 3.8

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -613,7 +613,7 @@ credits = [
     'https://raw.githubusercontent.com/pygame/pygame/master/LICENSE'
   ], [
     'Python',
-    '2001-2018 Python Software Foundation<br>Python is a trademark of the Python Software Foundation.',
+    '2001-2019 Python Software Foundation<br>Python is a trademark of the Python Software Foundation.',
     'PSFL',
     'https://docs.python.org/3/license.html'
   ], [

--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -19,12 +19,25 @@ module Docs
       library/sunau.html)
 
     options[:attribution] = <<-HTML
-      &copy; 2001&ndash;2018 Python Software Foundation<br>
+      &copy; 2001&ndash;2019 Python Software Foundation<br>
       Licensed under the PSF License.
     HTML
 
+    # In order to download the documentation, run:
+    # $ mkdir -p docs/python~3.8 && \
+    #   cd docs/python~3.8 && \
+    #   curl -L https://docs.python.org/3.8/archives/python-3.8.0-docs-html.tar.bz2 | \
+    #   tar xj --strip-components=1
+
+    version '3.8' do # docs.python.org/3.8/download.html
+      self.release = '3.8.0'
+      self.base_url = 'https://docs.python.org/3.8/'
+
+      html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
+    end
+
     version '3.7' do # docs.python.org/3.7/download.html
-      self.release = '3.7.4'
+      self.release = '3.7.5'
       self.base_url = 'https://docs.python.org/3.7/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
@@ -38,7 +51,7 @@ module Docs
     end
 
     version '3.5' do # docs.python.org/3.5/download.html
-      self.release = '3.5.7'
+      self.release = '3.5.9'
       self.base_url = 'https://docs.python.org/3.5/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good