### PR TITLE
typescript: update to 3.7.2

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -763,7 +763,7 @@ credits = [
     'https://twig.symfony.com/license'
   ], [
     'TypeScript',
-    'Microsoft and other contributors',
+    '2012-2019 Microsoft',
     'Apache',
     'https://raw.githubusercontent.com/Microsoft/TypeScript-Handbook/master/LICENSE'
   ], [

--- a/lib/docs/filters/typescript/clean_html.rb
+++ b/lib/docs/filters/typescript/clean_html.rb
@@ -9,6 +9,7 @@ module Docs
         end
 
         css('.xs-toc-container').remove
+        css('.anchor-hash').remove
 
         css('article h1').each do |node|
           node.name = 'h2'
@@ -19,7 +20,7 @@ module Docs
         end
 
         css('pre > code').each do |node|
-          node.parent['data-language'] = node['class'].sub('ts', 'typescript').sub('js', 'javascript').remove('language-')
+          node.parent['data-language'] = node['class'].sub('ts', 'typescript').sub('js', 'javascript').remove('language-') if node['class']
           node.content = node.content.gsub('    ', '  ')
           node.before(node.children).remove
         end

--- a/lib/docs/filters/typescript/entries.rb
+++ b/lib/docs/filters/typescript/entries.rb
@@ -2,7 +2,7 @@ module Docs
   class Typescript
     class EntriesFilter < Docs::EntriesFilter
       def get_name
-        name = at_css('h1').content
+        name = at_css('h1').content.strip
         name.sub! ' and ', ' & '
         name
       end
@@ -24,6 +24,7 @@ module Docs
 
         css('.post-content h1, .post-content h2').each_with_object [] do |node, entries|
           next if node.next_element.try(:name) == 'h2'
+          node.css('.anchor-hash').remove
           name = node.content.strip
           next if name.length > 40
           next if name == self.name || SKIP_ENTRIES.any? { |str| name.include?(str) }

--- a/lib/docs/scrapers/typescript.rb
+++ b/lib/docs/scrapers/typescript.rb
@@ -2,7 +2,7 @@ module Docs
   class Typescript < UrlScraper
     self.name = 'TypeScript'
     self.type = 'simple'
-    self.release = '3.1.6'
+    self.release = '3.7.2'
     self.base_url = 'https://www.typescriptlang.org/docs/'
     self.root_path = 'tutorial.html'
     self.links = {
@@ -21,7 +21,7 @@ module Docs
     }
 
     options[:attribution] = <<-HTML
-      &copy; Microsoft and other contributors<br>
+      &copy; 2012-2019 Microsoft<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good