### PR TITLE
ansible: add version 2.9

### DIFF
--- a/lib/docs/filters/ansible/clean_html.rb
+++ b/lib/docs/filters/ansible/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class Ansible
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('#page-content')
+        @doc = at_css('.document')
 
         css('font').each do |node|
           node.before(node.children).remove

--- a/lib/docs/scrapers/ansible.rb
+++ b/lib/docs/scrapers/ansible.rb
@@ -30,18 +30,23 @@ module Docs
       /\Aroadmap.*/i,
     ]
 
+    version '2.9' do
+      self.release = '2.9.1'
+      self.base_url = "https://docs.ansible.com/ansible/#{version}/"
+    end
+
     version '2.8' do
-      self.release = '2.8.3'
+      self.release = '2.8.7'
       self.base_url = "https://docs.ansible.com/ansible/#{version}/"
     end
 
     version '2.7' do
-      self.release = '2.7.12'
+      self.release = '2.7.15'
       self.base_url = "https://docs.ansible.com/ansible/#{version}/"
     end
 
     version '2.6' do
-      self.release = '2.6.18'
+      self.release = '2.6.20'
       self.base_url = "https://docs.ansible.com/ansible/#{version}/"
     end
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good