### PR TITLE
postgresql: add version 12

### DIFF
--- a/lib/docs/scrapers/postgresql.rb
+++ b/lib/docs/scrapers/postgresql.rb
@@ -55,33 +55,38 @@ module Docs
       Licensed under the PostgreSQL License.
     HTML
 
+    version '12' do
+      self.release = '12.1'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
+    end
+
     version '11' do
-      self.release = '11.5'
-      self.base_url = 'https://www.postgresql.org/docs/11/'
+      self.release = '11.6'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
     end
 
     version '10' do
-      self.release = '10.3'
-      self.base_url = 'https://www.postgresql.org/docs/10/static/'
+      self.release = '10.11'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
     end
 
     version '9.6' do
-      self.release = '9.6.6'
-      self.base_url = 'https://www.postgresql.org/docs/9.6/static/'
+      self.release = '9.6.16'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
 
       html_filters.insert_before 'postgresql/extract_metadata', 'postgresql/normalize_class_names'
     end
 
     version '9.5' do
-      self.release = '9.5.10'
-      self.base_url = 'https://www.postgresql.org/docs/9.5/static/'
+      self.release = '9.5.20'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
 
       html_filters.insert_before 'postgresql/extract_metadata', 'postgresql/normalize_class_names'
     end
 
     version '9.4' do
-      self.release = '9.4.15'
-      self.base_url = 'https://www.postgresql.org/docs/9.4/static/'
+      self.release = '9.4.25'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
 
       html_filters.insert_before 'postgresql/extract_metadata', 'postgresql/normalize_class_names'
     end


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
----

Randomly, fetching some pages failes with HTTP 503. After running the scraper a second time, this issue seems to disappear. Not sure how to deal with this.
```
ERROR:                                                                                                                                                                                                    
  https://www.postgresql.org/docs/12/sql-selectinto.html
  RuntimeError: Error status code (503): No error
    https://www.postgresql.org/docs/12/sql-selectinto.html
      "date": "Tue, 26 Nov 2019 03:59:40 GMT",
      "server": "Varnish",
      "content-type": "text/html; charset=utf-8",
      "retry-after": "5",
      "x-varnish": "23831575",
      "age": "0",
      "via": "1.1 varnish (Varnish/6.0)",
      "strict-transport-security": "max-age=31536000",
      "content-length": "285"
```