### PR TITLE
immutable: update URL, license, version

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -353,9 +353,9 @@ credits = [
     'https://raw.githubusercontent.com/Homebrew/brew/master/LICENSE.txt'
   ], [
     'Immutable.js',
-    '2014-2016 Facebook, Inc.',
-    'BSD',
-    'https://raw.githubusercontent.com/facebook/immutable-js/master/LICENSE'
+    '2014-present Facebook, Inc.',
+    'MIT',
+    'https://raw.githubusercontent.com/immutable-js/immutable-js/master/LICENSE'
   ], [
     'InfluxData',
     '2015 InfluxData, Inc.',

--- a/lib/docs/scrapers/immutable.rb
+++ b/lib/docs/scrapers/immutable.rb
@@ -3,11 +3,11 @@ module Docs
     self.name = 'Immutable.js'
     self.slug = 'immutable'
     self.type = 'simple'
-    self.release = '3.8.1'
-    self.base_url = 'https://facebook.github.io/immutable-js/docs/'
+    self.release = '3.8.2'
+    self.base_url = 'https://immutable-js.github.io/immutable-js/docs/'
     self.links = {
-      home: 'https://facebook.github.io/immutable-js/',
-      code: 'https://github.com/facebook/immutable-js'
+      home: 'https://immutable-js.github.io/immutable-js/',
+      code: 'https://github.com/immutable-js/immutable-js'
     }
 
     html_filters.push 'immutable/clean_html', 'immutable/entries', 'title'
@@ -17,13 +17,13 @@ module Docs
     options[:root_title] = 'Immutable.js'
 
     options[:attribution] = <<-HTML
-      &copy; 2014&ndash;2015 Facebook, Inc.<br>
-      Licensed under the 3-clause BSD License.
+      &copy; 2014&ndash;present Facebook, Inc.<br>
+      Licensed under the MIT License.
     HTML
 
     stub '' do
       capybara = load_capybara_selenium
-      capybara.app_host = 'https://facebook.github.io'
+      capybara.app_host = 'https://immutable-js.github.io'
       capybara.visit(URL.parse(self.base_url).path)
       capybara.execute_script <<-JS
         var content, event, links, link;


### PR DESCRIPTION
immutable-js has been relicensed as MIT, https://github.com/immutable-js/immutable-js/commit/d3bce8d9baacac1bf9c233cec1c84e25e8db4083

immutable-js is now hosted on https://immutable-js.github.io/

----

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good