### PR TITLE
jest: bug fix, missing menu items

### DIFF
--- a/lib/docs/filters/jest/entries.rb
+++ b/lib/docs/filters/jest/entries.rb
@@ -22,7 +22,7 @@ module Docs
 
         entries = []
 
-        at_css('.mainContainer ul').css('li > a').each do |node|
+        at_css('.mainContainer h2 + ul, ul.toc-headings').css('li > a').each do |node|
           code = node.at_css('code')
           next if code.nil?
 
@@ -35,7 +35,6 @@ module Docs
 
           entries << [name, id]
         end
-
         entries
       end
     end


### PR DESCRIPTION
Closes #1121

The Jest documentation had missing menu entries for The Jest Object and also had navigation issues for that page. This update fixes the missing entries and the navigation by expanding the CSS selector used to find the entries that should be highlighted in the menu. Below is a screenshot showing a before and after regeneration entry count.

[![](https://i.imgur.com/zbwxJZw.png)](https://imgur.com/a/SfqElH4)