### PR TITLE
Fix "doc is undefined" error for local install

### DIFF
--- a/assets/javascripts/app/app.coffee
+++ b/assets/javascripts/app/app.coffee
@@ -92,7 +92,8 @@
   bootAll: ->
     docs = @settings.getDocs()
     for doc in @DOCS
-      (if docs.indexOf(doc.slug) >= 0 then @docs else @disabledDocs).add(doc)
+      if doc?
+        (if docs.indexOf(doc.slug) >= 0 then @docs else @disabledDocs).add(doc)
     @migrateDocs()
     @docs.load @start.bind(@), @onBootError.bind(@), readCache: true, writeCache: true
     delete @DOCS


### PR DESCRIPTION
Having installed this locally
(Fedora 31, inside a vm, apache proxypass / -> 9292/)
i encountered an error that the variable "doc" was undefined (null), likely because coffeescript extends this to walking over the array and some element being undefined? Either way, checking if doc is not null (and thus if ref[i] isnt producing a null result) makes the page work again.