### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache: bundler
 
 before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
-  - gem update --system
+  - yes | gem update --system
   - gem install bundler
 
 script:


### PR DESCRIPTION
Currently CI is failing (see https://github.com/freeCodeCamp/devdocs/pull/1143#issuecomment-566534055) due to Travis awaiting for confirmation on `gem update --system`. This fixes CI by piping `yes` to the command.