### PR TITLE
Added Julia base language docs for v0.7 and later

### DIFF
--- a/lib/docs/scrapers/julia.rb
+++ b/lib/docs/scrapers/julia.rb
@@ -5,7 +5,6 @@ module Docs
       code: 'https://github.com/JuliaLang/julia'
     }
 
-    options[:only_patterns] = [/\Amanual\//, /\Astdlib\//]
 
     options[:attribution] = <<-HTML
       &copy; 2009&ndash;2019 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors<br>
@@ -20,6 +19,7 @@ module Docs
       html_filters.push 'julia/entries', 'julia/clean_html'
 
       options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
     end
 
     version '1.1' do
@@ -30,6 +30,7 @@ module Docs
       html_filters.push 'julia/entries', 'julia/clean_html'
 
       options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
     end
 
     version '1.0' do
@@ -40,6 +41,7 @@ module Docs
       html_filters.push 'julia/entries', 'julia/clean_html'
 
       options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
     end
 
     version '0.7' do
@@ -50,6 +52,7 @@ module Docs
       html_filters.push 'julia/entries', 'julia/clean_html'
 
       options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
     end
 
     version '0.6' do
@@ -60,6 +63,7 @@ module Docs
       html_filters.push 'julia/entries', 'julia/clean_html'
 
       options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Astdlib\//]
     end
 
     version '0.5' do
@@ -68,6 +72,8 @@ module Docs
       self.type = 'sphinx_simple'
 
       html_filters.push 'julia/entries_sphinx', 'julia/clean_html_sphinx', 'sphinx/clean_html'
+
+      options[:only_patterns] = [/\Amanual\//, /\Astdlib\//]
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
These docs were moved to their own section (`base`) in v0.7.

If you’re **modifying an existing** scraper, please ensure that you have:

- [x] Tested the scraper on a local copy of DevDocs
- [x] Ensured that the docs are styled similarly to other docs on DevDocs
