### PR TITLE
Allow styles in <dt> elements

### DIFF
--- a/lib/docs/filters/sphinx/clean_html.rb
+++ b/lib/docs/filters/sphinx/clean_html.rb
@@ -57,14 +57,6 @@ module Docs
           node.parent.before(node.content).remove
         end
 
-        css('dt').each do |node|
-          next unless node['id'] || node.at_css('code, .classifier')
-          links = []
-          links << node.children.last.remove while node.children.last.try(:name) == 'a'
-          node.inner_html = "<code>#{CGI::escapeHTML(node.content.strip)}</code> "
-          links.reverse_each { |link| node << link }
-        end
-
         css('li > p:first-child:last-child').each do |node|
           node.before(node.children).remove
         end


### PR DESCRIPTION
I have not yet checked to see if this breaks things. Fixes #1154.

Steps
- check if doc includes `<dt>`
- check each `<dt>` to see if it has unwanted content

Potentially affected docs:
- [ ] ansible
- [ ] bottle
- [ ] cmake
- [ ] codeigniter
- [ ] django
- [ ] falcon
- [ ] godot
- [ ] julia
- [ ] matplotlib
- [ ] numpy
- [ ] pandas
- [ ] python
- [ ] scikit_image
- [ ] scikit_learn
- [ ] statsmodels