### PR TITLE
bootstrap: update to 3.4.1 and 4.4.1

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -123,7 +123,7 @@ credits = [
     'https://raw.githubusercontent.com/petkaantonov/bluebird/master/LICENSE'
   ], [
     'Bootstrap',
-    '2011-2019 Twitter, Inc.<br>2011-2019 The Bootstrap Authors',
+    '2011-2020 Twitter, Inc.<br>2011-2020 The Bootstrap Authors',
     'CC BY',
     'https://creativecommons.org/licenses/by/3.0/'
   ], [

--- a/lib/docs/scrapers/bootstrap.rb
+++ b/lib/docs/scrapers/bootstrap.rb
@@ -10,15 +10,15 @@ module Docs
 
     # https://github.com/twbs/bootstrap/blob/master/LICENSE
     options[:attribution] = <<-HTML
-      &copy; 2011&ndash;2019 Twitter, Inc.<br>
-      &copy; 2011&ndash;2019 The Bootstrap Authors<br>
+      &copy; 2011&ndash;2020 Twitter, Inc.<br>
+      &copy; 2011&ndash;2020 The Bootstrap Authors<br>
       Code licensed under the MIT License.<br>
       Documentation licensed under the Creative Commons Attribution License v3.0.
     HTML
 
     version '4' do
-      self.release = '4.3.1'
-      self.base_url = 'https://getbootstrap.com/docs/4.3/'
+      self.release = '4.4.1'
+      self.base_url = 'https://getbootstrap.com/docs/4.4/'
       self.root_path = 'getting-started/introduction/'
 
       html_filters.push 'bootstrap/entries_v4', 'bootstrap/clean_html_v4'
@@ -27,8 +27,8 @@ module Docs
     end
 
     version '3' do
-      self.release = '3.3.7'
-      self.base_url = 'https://getbootstrap.com/docs/3.3/'
+      self.release = '3.4.1'
+      self.base_url = 'https://getbootstrap.com/docs/3.4/'
       self.root_path = 'getting-started/'
 
       html_filters.push 'bootstrap/entries_v3', 'bootstrap/clean_html_v3'


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Fixes #1122.