### PR TITLE
Add Django alias 'dj'

### DIFF
--- a/assets/javascripts/models/entry.coffee
+++ b/assets/javascripts/models/entry.coffee
@@ -56,6 +56,7 @@ class app.models.Entry extends app.Model
     'c++': 'cpp'
     'coffeescript': 'cs'
     'crystal': 'cr'
+    'django': 'dj'
     'elixir': 'ex'
     'javascript': 'js'
     'julia': 'jl'


### PR DESCRIPTION
Django is used by about 45% of all Python developers ( https://www.jetbrains.com/research/python-developers-survey-2018/ ) so an alias seems appropriate :)