### PR TITLE
Update Django documentation (3.0.2)

### DIFF
--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,13 +34,18 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '3.0' do
+      self.release = '3.0.2'
+      self.base_url = 'https://docs.djangoproject.com/en/3.0/'
+    end
+
     version '2.2' do
-      self.release = '2.2.4'
+      self.release = '2.2.9'
       self.base_url = 'https://docs.djangoproject.com/en/2.2/'
     end
 
     version '2.1' do
-      self.release = '2.1.11'
+      self.release = '2.1.15'
       self.base_url = 'https://docs.djangoproject.com/en/2.1/'
     end
 
@@ -50,7 +55,7 @@ module Docs
     end
 
     version '1.11' do
-      self.release = '1.11.23'
+      self.release = '1.11.27'
       self.base_url = 'https://docs.djangoproject.com/en/1.11/'
     end
 


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
