### PR TITLE
Fix Haskell entry names

### DIFF
--- a/lib/docs/filters/haskell/entries.rb
+++ b/lib/docs/filters/haskell/entries.rb
@@ -53,19 +53,15 @@ module Docs
         return [] if IGNORE_ENTRIES_PATHS.include?(subpath.split('/').last)
 
         css('#synopsis > details > ul > li').each_with_object [] do |node, entries|
-          link = node.at_css('a')
-          name = node.content.strip
-          name.remove! %r{\A(?:module|data|newtype|class|type family m|type)\s+}
-          name.sub! %r{\A\((.+?)\)}, '\1'
-          name.sub!(/ (?:\:\: (\w+))?.*\z/) { |_| $1 ? " (#{$1})" : '' }
+          link = node.at_css('a:not([title])')
+          name = link.content
 
           if ADD_SUB_ENTRIES_KEYWORDS.include?(node.at_css('.keyword').try(:content))
             node.css('.subs > li').each do |sub_node|
               sub_link = sub_node.at_css('a')
               next unless sub_link['href'].start_with?('#')
-              sub_name = sub_node.content.strip
-              sub_name.remove! %r{\s.*}
-              sub_name.prepend "#{name} "
+              sub_name = sub_link.content
+              sub_name << " (#{name})"
               entries << [sub_name, sub_link['href'].remove('#')]
             end
           end


### PR DESCRIPTION
# Problem

The existing code for Haskell entry filter's `additonal_entries` gets:
- name by removing the declaration keyword (`data`/etc.) and keeping the first following word, and appending (surrounding with parentheses) the first word following `::` if it exists
- link by finding the first `a` link

Unfortunately Haskell's syntax doesn't work this way; for example
```haskell
class Applicative f => Alternative f where
```
is not declaring `Applicative f` but `Alternative f` that has a constraint `Applicative f`.

Since in this case both `Applicative` and `Alternative` are `a` links, the code selects the first one. Thus a couple consequences:
1. Since the link `href` property doesn't start with `'#'`, the entry never gets added
2. The `name` is wrong for all its sub entries

Also it doesn't make sense to include the next word following `::` (type declaration):
```haskell
-- lookup (Eq): name of first constraint
lookup :: Eq a => a -> [(a, b)] -> Maybe b
-- maybe (b): name of first parameter, possibly a type variable
maybe :: b -> (a -> b) -> Maybe a -> b
-- head: no context since the first parameter doesn't start with a word character
head :: [a] -> a
```
The intent was probably to differentiate between entries of the same name, but the first word after type declaration is not really useful.

Another minor problem is e.g. the `pure` function from `Applicative` is formatted as `Applicative pure`, which puts the context (`Applicative`) before the actual name (`pure`).

# PR Changes

1. Find `a` link with css `a:not([title])`, which seems to work since all links except the one containing the declared item contains a `title` attribute.
2. Get name from the content of the link instead of parsing with regular expressions, and not append any extra information for non-sub entries.
3. Format sub entries as `name (context)` instead of `context name`.

I've tested the changes locally and haven't found a problem for Haskell 8. Somehow scraping Haskell 7 fails even before my changes - I briefly looked at Haskell 7's docs and it seems like they don't have a `#synopsis` element, which could be the reason (and since my changes only affect code using the synopsis, they shouldn't cause any further breakage).

Please let me know if any of these changes is undesired / can be improved.