### PR TITLE
Deduplicate coding conventions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,9 +75,8 @@ Follow the following steps to update documentations to their latest version:
 
 ## Coding conventions
 
-* two spaces; no tabs
-* no trailing whitespace; blank lines should have no spaces; new line at end-of-file
-* use the same coding style as the rest of the codebase
+Please use the same coding style as the rest of the codebase via [our `.editorconfig` file](../.editorconfig).
+Check out [EditorConfig.org](https://editorconfig.org/) to learn how to make your tools adhere to it.
 
 ## Questions?
 


### PR DESCRIPTION
Hello & thanks for this neat tool :-)

I noticed that in your CONTRIBUTING.md, [the "Coding conventions" section](https://github.com/freeCodeCamp/devdocs/blame/40df521a7cef562aa72a01a59aa58d92828c906e/.github/CONTRIBUTING.md#L78-L80) contained some details that were later [automated in the .editorconfig](https://github.com/freeCodeCamp/devdocs/blame/40df521a7cef562aa72a01a59aa58d92828c906e/.editorconfig#L5-L6).

Maybe it's useful to replace the natural-language duplicate of this with links to both the file itself & its format's explanation.

Cheers!