### PR TITLE
bundle update ffi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.3.6)
-    ffi (1.11.1)
+    ffi (1.12.2)
     fspath (3.1.2)
     highline (2.0.3)
     html-pipeline (2.12.0)


### PR DESCRIPTION
Fixes "warning: rb_safe_level will be removed in Ruby 3.0"

Ref: https://github.com/typhoeus/ethon/issues/163