### PR TITLE
Update haxe version + add eval package

### DIFF
--- a/lib/docs/filters/haxe/clean_html.rb
+++ b/lib/docs/filters/haxe/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class Haxe
     class CleanHtmlFilter < Filter
       def call
-        css('.viewsource', 'hr', 'h1 > small', '.inherited-fields').remove
+        css('.viewsource', 'hr', 'h1 > small', '.inherited-fields', '.label-meta').remove
 
         css('h4 + h1').each do |node|
           node.after(node.previous_element)
@@ -28,8 +28,10 @@ module Docs
         end
 
         css('.field').each do |node|
+          h3 = node.at_css('h3:not(:empty)')
+          next unless h3.present?
           link = node.at_css('a[name]')
-          node.at_css('h3:not(:empty)')['id'] = link['name']
+          h3['id'] = link['name']
           link.before(link.children).remove
           node.before(node.children).remove
         end

--- a/lib/docs/scrapers/haxe.rb
+++ b/lib/docs/scrapers/haxe.rb
@@ -2,7 +2,7 @@ module Docs
   class Haxe < UrlScraper
     self.name = 'Haxe'
     self.type = 'simple'
-    self.release = '3.4.7'
+    self.release = '4.0.5'
     self.base_url = 'https://api.haxe.org/'
 
     html_filters.push 'haxe/clean_html', 'haxe/entries'
@@ -10,7 +10,7 @@ module Docs
     options[:container] = '.span9'
 
     options[:attribution] = <<-HTML
-      &copy; 2005&ndash;2018 Haxe Foundation<br>
+      &copy; 2005&ndash;2020 Haxe Foundation<br>
       Licensed under a MIT license.
     HTML
 
@@ -20,7 +20,7 @@ module Docs
         code: 'https://github.com/HaxeFoundation/haxe'
       }
 
-      options[:skip_patterns] = [/\A(?:cpp|cs|flash|java|js|neko|php|python|lua|hl|sys)/i]
+      options[:skip_patterns] = [/\A(?:cpp|cs|flash|java|js|neko|php|python|lua|hl|sys|eval)/i]
     end
 
     version 'C++' do
@@ -65,6 +65,10 @@ module Docs
 
     version 'Python' do
       self.base_url = 'https://api.haxe.org/python/'
+    end
+
+    version 'Eval' do
+      self.base_url = 'https://api.haxe.org/eval/'
     end
 
     def get_latest_version(opts)

--- a/lib/docs/scrapers/haxe.rb
+++ b/lib/docs/scrapers/haxe.rb
@@ -2,7 +2,7 @@ module Docs
   class Haxe < UrlScraper
     self.name = 'Haxe'
     self.type = 'simple'
-    self.release = '4.0.5'
+    self.release = '4.1.3'
     self.base_url = 'https://api.haxe.org/'
 
     html_filters.push 'haxe/clean_html', 'haxe/entries'


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
