### PR TITLE
Fixed bundle install --system deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
 
 COPY Gemfile Gemfile.lock Rakefile /devdocs/
 
-RUN bundle install --system && \
+RUN bundle config set system 'true' && \
+    bundle install && \
     rm -rf ~/.gem /root/.bundle/cache /usr/local/bundle/cache
 
 COPY . /devdocs

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -9,7 +9,8 @@ COPY . /devdocs
 
 RUN apk --update add nodejs build-base libstdc++ gzip git zlib-dev libcurl && \
     gem install bundler && \
-    bundle install --system --without test && \
+    bundle config set system 'true'  && \
+    bundle install --without test && \
     thor docs:download --all && \
     thor assets:compile && \
     apk del gzip build-base git zlib-dev && \


### PR DESCRIPTION
On `docker build .`, I noticed the message
> [DEPRECATED] The `--system` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set system 'true'`, and stop using this flag

I replaced the deprecated flag in both Dockerfiles. Rebuilting the image worked as expected with the change. 
