### PR TITLE
Update crystal 0.35

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -203,7 +203,7 @@ credits = [
     'https://creativecommons.org/licenses/by-sa/2.5/'
   ], [
     'Crystal',
-    '2012-2019 Manas Technology Solutions',
+    '2012-2020 Manas Technology Solutions',
     'Apache',
     'https://raw.githubusercontent.com/crystal-lang/crystal/master/LICENSE'
   ], [

--- a/lib/docs/filters/crystal/entries.rb
+++ b/lib/docs/filters/crystal/entries.rb
@@ -14,7 +14,7 @@ module Docs
 
           name
         else
-          name = at_css('h1').children.last.content.strip
+          name = at_css('.type-name').children.last.content.strip
           name.remove! %r{\(.*\)}
           name
         end

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -25,6 +25,32 @@ module Docs
       end
     }
 
+    version '0.33' do
+      self.release = '0.33.0'
+      self.root_path = "api/#{release}/index.html"
+
+      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
+      options[:skip_patterns] = [/debug/i]
+
+      options[:replace_paths] = {
+        "api/#{release}/" => "api/#{release}/index.html",
+        'docs/' => 'docs/index.html'
+      }
+    end
+
+    version '0.32' do
+      self.release = '0.32.1'
+      self.root_path = "api/#{release}/index.html"
+
+      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
+      options[:skip_patterns] = [/debug/i]
+
+      options[:replace_paths] = {
+        "api/#{release}/" => "api/#{release}/index.html",
+        'docs/' => 'docs/index.html'
+      }
+    end
+
     version '0.31' do
       self.release = '0.31.1'
       self.root_path = "api/#{release}/index.html"

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -25,47 +25,21 @@ module Docs
       end
     }
 
+    version '0.34' do
+      self.release = '0.34.0'
+      self.root_path = "api/#{release}/index.html"
+
+      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
+      options[:skip_patterns] = [/debug/i]
+
+      options[:replace_paths] = {
+        "api/#{release}/" => "api/#{release}/index.html",
+        'docs/' => 'docs/index.html'
+      }
+    end
+
     version '0.33' do
       self.release = '0.33.0'
-      self.root_path = "api/#{release}/index.html"
-
-      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
-      options[:skip_patterns] = [/debug/i]
-
-      options[:replace_paths] = {
-        "api/#{release}/" => "api/#{release}/index.html",
-        'docs/' => 'docs/index.html'
-      }
-    end
-
-    version '0.32' do
-      self.release = '0.32.1'
-      self.root_path = "api/#{release}/index.html"
-
-      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
-      options[:skip_patterns] = [/debug/i]
-
-      options[:replace_paths] = {
-        "api/#{release}/" => "api/#{release}/index.html",
-        'docs/' => 'docs/index.html'
-      }
-    end
-
-    version '0.31' do
-      self.release = '0.31.1'
-      self.root_path = "api/#{release}/index.html"
-
-      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
-      options[:skip_patterns] = [/debug/i]
-
-      options[:replace_paths] = {
-        "api/#{release}/" => "api/#{release}/index.html",
-        'docs/' => 'docs/index.html'
-      }
-    end
-
-    version '0.30' do
-      self.release = '0.30.1'
       self.root_path = "api/#{release}/index.html"
 
       options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -19,27 +19,14 @@ module Docs
         HTML
       else
         <<-HTML
-          &copy; 2012&ndash;2019 Manas Technology Solutions.<br>
+          &copy; 2012&ndash;2020 Manas Technology Solutions.<br>
           Licensed under the Apache License, Version 2.0.
         HTML
       end
     }
 
-    version '0.34' do
-      self.release = '0.34.0'
-      self.root_path = "api/#{release}/index.html"
-
-      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
-      options[:skip_patterns] = [/debug/i]
-
-      options[:replace_paths] = {
-        "api/#{release}/" => "api/#{release}/index.html",
-        'docs/' => 'docs/index.html'
-      }
-    end
-
-    version '0.33' do
-      self.release = '0.33.0'
+    version do
+      self.release = '0.35.1'
       self.root_path = "api/#{release}/index.html"
 
       options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good



E: 0.34 manual checks done, 0.35 releases soon