### PR TITLE
Update Nim docs to v1.2.0

### DIFF
--- a/lib/docs/scrapers/nim.rb
+++ b/lib/docs/scrapers/nim.rb
@@ -1,7 +1,7 @@
 module Docs
   class Nim < UrlScraper
     self.type = 'simple'
-    self.release = '0.19.0'
+    self.release = '1.2.0'
     self.base_url = 'https://nim-lang.org/docs/'
     self.root_path = 'overview.html'
     self.links = {
@@ -14,7 +14,7 @@ module Docs
     options[:skip] = %w(theindex.html docgen.txt)
 
     options[:attribution] = <<-HTML
-      &copy; 2006&ndash;2018 Andreas Rumpf<br>
+      &copy; 2006&ndash;2020 Andreas Rumpf<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
I am unable to build devdocs locally. I have only updated the version from 0.19.0 to 1.2.0 (it was long overdue).

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon

I do not know how to ensure the below.

- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
