### PR TITLE
Update react-native docs to 0.62

### DIFF
--- a/assets/stylesheets/pages/_react_native.scss
+++ b/assets/stylesheets/pages/_react_native.scss
@@ -6,4 +6,5 @@
 
   span.platform { float: right; }
   span.propType, span.platform { font-weight: normal; }
+  .content-banner-img { max-height: 200px; }
 }

--- a/lib/docs/scrapers/react_native.rb
+++ b/lib/docs/scrapers/react_native.rb
@@ -2,18 +2,18 @@ module Docs
   class ReactNative < UrlScraper
     self.slug = 'react_native'
     self.type = 'react_native'
-    self.release = '0.56'
-    self.base_url = 'https://facebook.github.io/react-native/docs/'
-    self.root_path = 'getting-started.html'
+    self.release = '0.62'
+    self.base_url = 'https://reactnative.dev/docs/'
+    self.root_path = 'getting-started'
     self.links = {
-      home: 'https://facebook.github.io/react-native/',
+      home: 'https://reactnative.dev/',
       code: 'https://github.com/facebook/react-native'
     }
 
     html_filters.push 'react_native/entries', 'react_native/clean_html'
 
     options[:container] = '.docMainWrapper'
-    options[:skip_patterns] = [/\Asample\-/]
+    options[:skip_patterns] = [/\Asample\-/, /\Anext/]
     options[:skip] = %w(
       videos.html
       transforms.html
@@ -27,12 +27,12 @@ module Docs
     }
 
     options[:attribution] = <<-HTML
-      &copy; 2015&ndash;2018 Facebook Inc.<br>
-      Licensed under the Creative Commons Attribution 4.0 International Public License.
+      &copy; 2015&ndash;2020 Facebook Inc.<br>
+      Licensed under the MIT License.
     HTML
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://facebook.github.io/react-native/docs/getting-started.html', opts)
+      doc = fetch_doc('https://reactnative.dev/docs/getting-started', opts)
       doc.at_css('header > a > h3').content
     end
   end


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

**SECTION B - Updating an existing documentation to it's latest version**

Update react-native docs to latest version (0.62)

- Closes #1214

<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations

If you're updating an existing documentation to it's latest version, please ensure that you have:
 -->
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
