### PR TITLE
Document thor docs:download --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bundle exec rackup
 
 Finally, point your browser at [localhost:9292](http://localhost:9292) (the first request will take a few seconds to compile the assets). You're all set.
 
-The `thor docs:download` command is used to download pre-generated documentations from DevDocs's servers (e.g. `thor docs:download html css`). You can see the list of available documentations and versions by running `thor docs:list`. To update all downloaded documentations, run `thor docs:download --installed`.
+The `thor docs:download` command is used to download pre-generated documentations from DevDocs's servers (e.g. `thor docs:download html css`). You can see the list of available documentations and versions by running `thor docs:list`. To update all downloaded documentations, run `thor docs:download --installed`. To download and install all documentation this project has available, run `thor docs:download --all`.
 
 **Note:** there is currently no update mechanism other than `git pull origin master` to update the code and `thor docs:download --installed` to download the latest version of the docs. To stay informed about new releases, be sure to [watch](https://github.com/freeCodeCamp/devdocs/subscription) this repository.
 

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -119,7 +119,7 @@ class DocsCLI < Thor
     puts 'Done'
   end
 
-  desc 'download (<doc> <doc@version>... | --default | --installed)', 'Download documentations'
+  desc 'download (<doc> <doc@version>... | --default | --installed | --all)', 'Download documentations'
   option :default, type: :boolean
   option :installed, type: :boolean
   option :all, type: :boolean


### PR DESCRIPTION
About a week or so ago I wanted to download all of the docs locally for everything this project has available. At the time, I didn't know there was an option for doing that. To make things easier for people to know this option exists, I've added the missing documentation for it.