### PR TITLE
Added new laravel versions and fixed scraper

### DIFF
--- a/lib/docs/filters/laravel/clean_html.rb
+++ b/lib/docs/filters/laravel/clean_html.rb
@@ -56,7 +56,7 @@ module Docs
       end
 
       def other
-        @doc = at_css('article')
+        @doc = at_css('.docs_body')
 
         # Clean up headings
         css('h2 > a').each do |node|
@@ -70,6 +70,12 @@ module Docs
         css('blockquote').each do |node|
           node['class'] = 'tip' if node.inner_html.include?('{tip}')
           node.inner_html = node.inner_html.remove(/\{(tip|note)\}\s?/)
+        end
+
+        css('blockquote').each do |node|
+          if node.inner_html.include?('You\'re browsing the documentation for an old version of Laravel.')
+            node.remove
+          end
         end
       end
     end

--- a/lib/docs/filters/laravel/entries.rb
+++ b/lib/docs/filters/laravel/entries.rb
@@ -13,12 +13,12 @@ module Docs
 
       def get_type
         unless api_page?
-          link = at_css(".sidebar li a[href='#{result[:path].split('/').last}']")
+          link = at_css(".docs_sidebar li a[href='#{result[:path].split('/').last}']")
           heading = link.ancestors('li').last.at_css('> h2')
           return heading ? "Guides: #{heading.content.strip}" : 'Guides'
         end
 
-        type = slug.remove(%r{api/\d.\d/}).remove('Illuminate/').remove(/\/\w+?\z/).gsub('/', '\\')
+        type = slug.remove(%r{api/\d.[0-9x]/}).remove('Illuminate/').remove(/\/\w+?\z/).gsub('/', '\\')
 
         if type.end_with?('Console')
           type.split('\\').first

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -10,24 +10,63 @@ module Docs
     html_filters.push 'laravel/entries', 'laravel/clean_html'
 
     options[:container] = ->(filter) {
-      filter.subpath.start_with?('/api') ? '#content' : '.docs-wrapper'
+      filter.subpath.start_with?('/api') ? '#content' : '.page_contain'
     }
 
     options[:skip_patterns] = [
-      %r{\A/api/\d\.\d/\.html},
-      %r{\A/api/\d\.\d/panel\.html},
-      %r{\A/api/\d\.\d/namespaces\.html},
-      %r{\A/api/\d\.\d/interfaces\.html},
-      %r{\A/api/\d\.\d/traits\.html},
-      %r{\A/api/\d\.\d/doc-index\.html},
-      %r{\A/api/\d\.\d/Illuminate\.html},
-      %r{\A/api/\d\.\d/search\.html} ]
+      %r{\A/api/\d\.[0-9x]/\.html},
+      %r{\A/api/\d\.[0-9x]/panel\.html},
+      %r{\A/api/\d\.[0-9x]/namespaces\.html},
+      %r{\A/api/\d\.[0-9x]/interfaces\.html},
+      %r{\A/api/\d\.[0-9x]/traits\.html},
+      %r{\A/api/\d\.[0-9x]/doc-index\.html},
+      %r{\A/api/\d\.[0-9x]/Illuminate\.html},
+      %r{\A/api/\d\.[0-9x]/search\.html} ]
 
     options[:attribution] = <<-HTML
       &copy; Taylor Otwell<br>
       Licensed under the MIT License.<br>
       Laravel is a trademark of Taylor Otwell.
     HTML
+
+    version '7.0' do
+      self.release = '7.11.0'
+      self.root_path = '/api/7.x/index.html'
+      self.initial_paths = %w(/docs/7.x/installation /api/7.x/classes.html)
+
+      options[:only_patterns] = [%r{\A/api/7\.x/}, %r{\A/docs/7\.x/}]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/7.x/"
+        url
+      end
+    end
+
+    version '6.0' do
+      self.release = '6.18.14'
+      self.root_path = '/api/6.x/index.html'
+      self.initial_paths = %w(/docs/6.x/installation /api/6.x/classes.html)
+
+      options[:only_patterns] = [%r{\A/api/6\.x/}, %r{\A/docs/6\.x/}]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/6.x/"
+        url
+      end
+    end
+
+    version '5.8' do
+      self.release = '5.8.38'
+      self.root_path = '/api/5.8/index.html'
+      self.initial_paths = %w(/docs/5.8/installation /api/5.8/classes.html)
+
+      options[:only_patterns] = [%r{\A/api/5\.8/}, %r{\A/docs/5\.8/}]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/5.8/"
+        url
+      end
+    end
 
     version '5.7' do
       self.release = '5.7.7'

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -29,6 +29,19 @@ module Docs
       Laravel is a trademark of Taylor Otwell.
     HTML
 
+    version '8' do
+      self.release = '8.4.1'
+      self.root_path = '/api/8.x/index.html'
+      self.initial_paths = %w(/docs/8.x/installation /api/8.x/classes.html)
+
+      options[:only_patterns] = [%r{\A/api/8\.x/}, %r{\A/docs/8\.x/}]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/8.x/"
+        url
+      end
+    end
+
     version '7' do
       self.release = '7.30.1'
       self.root_path = '/api/7.x/index.html'

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -29,8 +29,8 @@ module Docs
       Laravel is a trademark of Taylor Otwell.
     HTML
 
-    version '7.0' do
-      self.release = '7.11.0'
+    version '7' do
+      self.release = '7.30.1'
       self.root_path = '/api/7.x/index.html'
       self.initial_paths = %w(/docs/7.x/installation /api/7.x/classes.html)
 
@@ -42,8 +42,8 @@ module Docs
       end
     end
 
-    version '6.0' do
-      self.release = '6.18.14'
+    version '6' do
+      self.release = '6.20.0'
       self.root_path = '/api/6.x/index.html'
       self.initial_paths = %w(/docs/6.x/installation /api/6.x/classes.html)
 


### PR DESCRIPTION
- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

I've updated the Laravel scraper to handle the new website format on their site, and to add the following versions. The scraper is still backwards compatible with older versions, as they all use the same site layout.

* Laravel 5.8
* Laravel 6.0
* Laravel 7.0