### PR TITLE
Update Julia docs to v1.3.1, v1.4.1

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -398,7 +398,7 @@ credits = [
     'https://raw.githubusercontent.com/jquery/api.jqueryui.com/master/LICENSE.txt'
   ], [
     'Julia',
-    '2009-2019 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors',
+    '2009-2020 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors',
     'MIT',
     'https://raw.githubusercontent.com/JuliaLang/julia/master/LICENSE.md'
   ], [

--- a/lib/docs/scrapers/julia.rb
+++ b/lib/docs/scrapers/julia.rb
@@ -7,9 +7,31 @@ module Docs
 
 
     options[:attribution] = <<-HTML
-      &copy; 2009&ndash;2019 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors<br>
+      &copy; 2009&ndash;2020 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors<br>
       Licensed under the MIT License.
     HTML
+
+    version '1.4' do
+      self.release = '1.4.1'
+      self.base_url = "https://docs.julialang.org/en/v#{release}/"
+      self.type = 'julia'
+
+      html_filters.push 'julia/entries', 'julia/clean_html'
+
+      options[:container] = '#documenter-page'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
+    end
+
+    version '1.3' do
+      self.release = '1.3.1'
+      self.base_url = "https://docs.julialang.org/en/v#{release}/"
+      self.type = 'julia'
+
+      html_filters.push 'julia/entries', 'julia/clean_html'
+
+      options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
+    end
 
     version '1.2' do
       self.release = '1.2.0'


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->
<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good