### PR TITLE
Update Ruby documentation (2.7.1)

### DIFF
--- a/lib/docs/scrapers/rdoc/ruby.rb
+++ b/lib/docs/scrapers/rdoc/ruby.rb
@@ -70,7 +70,7 @@ module Docs
     HTML
 
     version '2.7' do
-      self.release = '2.7.1'
+      self.release = '2.7.2'
     end
 
     version '2.6' do

--- a/lib/docs/scrapers/rdoc/ruby.rb
+++ b/lib/docs/scrapers/rdoc/ruby.rb
@@ -69,6 +69,10 @@ module Docs
       Licensed under their own licenses.
     HTML
 
+    version '2.7' do
+      self.release = '2.7.1'
+    end
+
     version '2.6' do
       self.release = '2.6.3'
     end

--- a/public/icons/docs/ruby/SOURCE
+++ b/public/icons/docs/ruby/SOURCE
@@ -1,1 +1,2 @@
-http://commons.wikimedia.org/wiki/File:Ruby_logo.svg
+https://www.ruby-lang.org/en/about/logo/
+https://commons.wikimedia.org/wiki/File:Ruby_logo.svg


### PR DESCRIPTION
Adding documentation for Ruby 2.7.

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Additional steps:
- [x] Downloaded Ruby 2.7.1: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2
- [x] Compiled Ruby: `./configure --with-openssl-dir="/usr/local/opt/openssl" && make html`
- [x] Copied `ruby-2.7.1/.ext/html` to `devdocs/docs/ruby~2.7`
- [x] `thor docs:generate ruby --force`
- [x] Started the local server: `bundle exec rackup`
- [x] Checked that Ruby 2.7 docs are rendered (see screenshot)

<img width="2032" alt="Screen Shot 2020-05-23 at 12 38 28 PM" src="https://user-images.githubusercontent.com/1164687/82739374-f7681180-9cf3-11ea-9672-a25a9d5b5926.png">
