### PR TITLE
Update Phoenix documentation (1.5.3)

### DIFF
--- a/lib/docs/scrapers/phoenix.rb
+++ b/lib/docs/scrapers/phoenix.rb
@@ -1,7 +1,7 @@
 module Docs
   class Phoenix < UrlScraper
     self.type = 'elixir'
-    self.release = '1.3.4'
+    self.release = '1.5.1'
     self.base_url = 'https://hexdocs.pm/'
     self.root_path = 'phoenix/Phoenix.html'
     self.initial_paths = %w(

--- a/lib/docs/scrapers/phoenix.rb
+++ b/lib/docs/scrapers/phoenix.rb
@@ -1,7 +1,7 @@
 module Docs
   class Phoenix < UrlScraper
     self.type = 'elixir'
-    self.release = '1.5.1'
+    self.release = '1.5.3'
     self.base_url = 'https://hexdocs.pm/'
     self.root_path = 'phoenix/Phoenix.html'
     self.initial_paths = %w(


### PR DESCRIPTION
Bump Phoenix from 1.3.4 to 1.5.3.

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Additional steps:
- [x] `thor docs:generate phoenix --force`
- [x] Started the local server: bundle exec rackup
- [x] Checked that Phoenix 1.5.3 docs are rendered (see screenshot)

<img width="2032" alt="Screen Shot 2020-05-23 at 2 23 59 PM" src="https://user-images.githubusercontent.com/1164687/82740891-b971ea00-9d01-11ea-8068-0cffb7323626.png">