### PR TITLE
Fix Elixir documentation layout

### DIFF
--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -25,41 +25,38 @@ module Docs
       end
 
       def api
-        css('footer', '.view-source', 'h1 .visible-xs').remove
+        css('.hover-link', '.view-source', 'footer').remove
 
-        css('section section.docstring h2').each do |node|
-          node.name = 'h4'
+        css('.summary').each do |node|
+          node.name = 'dl'
         end
 
-        css('h1 .hover-link', '.detail-link').each do |node|
-          node.parent['id'] = node['href'].remove('#')
-          node.remove
+        css('.summary h2').each do |node|
+          node.content = node.inner_text
+          node.parent.before(node)
         end
 
-        css('.details-list').each do |list|
-          type = list['id'].remove(/s\z/) if list['id']
-          list.css('.detail-header').each do |node|
+        css('.summary-signature').each do |node|
+          node.name = 'dt'
+        end
+
+        css('.summary-synopsis').each do |node|
+          node.name = 'dd'
+        end
+
+        css('section.detail').each do |detail|
+          id = detail['id']
+          detail.remove_attribute('id')
+
+          detail.css('.detail-header').each do |node|
             node.name = 'h3'
-            node['class'] += " #{type}" if type
+            node['id'] = id
+            node.content = node.at_css('.signature').inner_text
           end
-        end
 
-        css('.summary h2').each { |node| node.parent.before(node) }
-        css('.summary').each { |node| node.name = 'dl' }
-        css('.summary-signature').each { |node| node.name = 'dt' }
-        css('.summary-synopsis').each { |node| node.name = 'dd' }
-
-        css('section', 'div:not(.type-detail)', 'h2 a').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('.detail-header > pre').each do |node|
-          node.parent.after(node)
-        end
-
-        css('.signature').each do |node|
-          non_text_children = node.xpath('node()[not(self::text())]')
-          non_text_children.to_a.reverse.each { |child| node.parent.add_next_sibling(child) }
+          detail.css('.docstring h2').each do |node|
+            node.name = 'h4'
+          end
         end
 
         css('pre').each do |node|

--- a/lib/docs/filters/elixir/entries.rb
+++ b/lib/docs/filters/elixir/entries.rb
@@ -41,21 +41,25 @@ module Docs
       end
 
       def additional_entries
-        return [] if type == 'Exceptions' || type == 'Guide'
+        return [] if type == 'Exceptions' || type == 'Guide' || root_page?
 
-        css('.detail-header .signature').map do |node|
-          id = node.parent['id']
+        css('.detail-header').map do |node|
+          id = node['id']
           name = node.content.strip
+
           name.remove! %r{\(.*\)}
           name.remove! 'left '
           name.remove! ' right'
           name.sub! 'sigil_', '~'
 
-          unless node.parent['class'].end_with?('macro') || self.name.start_with?('Kernel')
+          if self.name && !self.name.start_with?('Kernel')
             name.prepend "#{self.name}."
           end
 
-          name << " (#{id.split('/').last})" if id =~ /\/\d+\z/
+          if id =~ %r{/\d+\z}
+            arity = id.split('/').last
+            name << " (#{arity})"
+          end
 
           [name, id]
         end

--- a/lib/docs/scrapers/elixir.rb
+++ b/lib/docs/scrapers/elixir.rb
@@ -34,7 +34,7 @@ module Docs
     end
 
     version '1.9' do
-      self.release = '1.9.1'
+      self.release = '1.9.4'
       self.base_urls = [
         "https://hexdocs.pm/elixir/#{release}/",
         "https://hexdocs.pm/eex/#{release}/",


### PR DESCRIPTION
Fixes freeCodeCamp/devdocs#1237.

Updated Elixir's filters to fix a documentation layout issue (#1237). I also removed a few `css` selectors that are no longer relevant.

- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
- [x] `thor docs:generate elixir --force`
- [x] Started the local server: `bundle exec rackup`
- [x] Checked that Elixir docs are rendered correctly (see screenshot)

### Before

<img width="2032" alt="Screen Shot 2020-05-24 at 3 06 41 PM" src="https://user-images.githubusercontent.com/1164687/82766150-68312b80-9dd1-11ea-800e-af01aef575ef.png">

### After

<img width="2032" alt="Screen Shot 2020-05-24 at 3 06 43 PM" src="https://user-images.githubusercontent.com/1164687/82766140-59e30f80-9dd1-11ea-8873-c5ede34d4dd0.png">

