### PR TITLE
Update terraform to version 0.12.26

### DIFF
--- a/lib/docs/filters/terraform/entries.rb
+++ b/lib/docs/filters/terraform/entries.rb
@@ -20,6 +20,7 @@ module Docs
         'http'             => 'HTTP',
         'mysql'            => 'MySQL',
         'newrelic'         => 'New Relic',
+        'oci'              => 'Oracle Cloud Infrastructure',
         'oneandone'        => '1&1',
         'opentelekomcloud' => 'OpenTelekomCloud',
         'opsgenie'         => 'OpsGenie',
@@ -50,11 +51,9 @@ module Docs
         "google"  => true,
       }
 
-
       def get_name
-        name ||= at_css('#inner h1').content
+        name ||= at_css('#inner h1')&.content || at_css('#inner h2').content
         name.remove! "» "
-        name.remove! "Data Source: "
         name
       end
 

--- a/lib/docs/scrapers/terraform.rb
+++ b/lib/docs/scrapers/terraform.rb
@@ -2,7 +2,7 @@ module Docs
   class Terraform < UrlScraper
     self.name = 'Terraform'
     self.type = 'terraform'
-    self.release = '0.11.7'
+    self.release = '0.12.26'
     self.base_url = 'https://www.terraform.io/docs/'
     self.root_path = 'index.html'
     self.links = {
@@ -12,7 +12,7 @@ module Docs
 
     html_filters.push 'terraform/entries', 'terraform/clean_html'
 
-    options[:skip_patterns] = [/enterprise/, /enterprise-legacy/]
+    options[:skip_patterns] = [/enterprise/, /enterprise-legacy/, /guides/]
 
     options[:attribution] = <<-HTML
       &copy; 2018 HashiCorp</br>


### PR DESCRIPTION
Updates terraform to version 0.12.26

<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->


- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
