### PR TITLE
Update Phoenix doc (1.5.6) and add LiveView

### DIFF
--- a/lib/docs/scrapers/phoenix.rb
+++ b/lib/docs/scrapers/phoenix.rb
@@ -1,7 +1,7 @@
 module Docs
   class Phoenix < UrlScraper
     self.type = 'elixir'
-    self.release = '1.3.4'
+    self.release = '1.5.4'
     self.base_url = 'https://hexdocs.pm/'
     self.root_path = 'phoenix/Phoenix.html'
     self.initial_paths = %w(
@@ -31,7 +31,8 @@ module Docs
     options[:attribution] = -> (filter) {
       if filter.slug.start_with?('ecto')
         <<-HTML
-          &copy; 2012 Plataformatec<br>
+          &copy; 2013 Plataformatec<br>
+          &copy; 2020 Dashbit<br>
           Licensed under the Apache License, Version 2.0.
         HTML
       elsif filter.slug.start_with?('plug')

--- a/lib/docs/scrapers/phoenix.rb
+++ b/lib/docs/scrapers/phoenix.rb
@@ -1,13 +1,14 @@
 module Docs
   class Phoenix < UrlScraper
     self.type = 'elixir'
-    self.release = '1.5.4'
+    self.release = '1.5.6'
     self.base_url = 'https://hexdocs.pm/'
     self.root_path = 'phoenix/Phoenix.html'
     self.initial_paths = %w(
       phoenix/api-reference.html
       ecto/api-reference.html
       phoenix_html/api-reference.html
+      phoenix_live_view/api-reference.html
       phoenix_pubsub/api-reference.html
       plug/api-reference.html)
     self.links = {
@@ -25,6 +26,7 @@ module Docs
       /\Aecto\//,
       /\Aphoenix_pubsub\//,
       /\Aphoenix_html\//,
+      /\Aphoenix_live_view\//,
       /\Aplug\//
     ]
 
@@ -39,6 +41,11 @@ module Docs
         <<-HTML
           &copy; 2013 Plataformatec<br>
           Licensed under the Apache License, Version 2.0.
+        HTML
+      elsif filter.slug.start_with?('phoenix_live_view')
+        <<-HTML
+          &copy; 2018 Chris McCord<br>
+          Licensed under the MIT License.
         HTML
       else
         <<-HTML


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

![Screenshot from 2020-08-21 08-08-26](https://user-images.githubusercontent.com/11598866/90834604-a1077f00-e385-11ea-9de8-abbcac64af77.png)
