### PR TITLE
Add another variant of the SFMono font name

### DIFF
--- a/assets/stylesheets/global/_variables.scss
+++ b/assets/stylesheets/global/_variables.scss
@@ -4,7 +4,7 @@ $textColor: #333;
 
 html {
   --baseFont: #{$baseFont};
-  --monoFont: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  --monoFont: 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   --boldFontWeight: 500;
   --bolderFontWeight: 600;
 


### PR DESCRIPTION
Fixes #1268

a simple pull request to add another variation of the SFMono font's name
its the name used by [this](https://aur.archlinux.org/packages/otf-sfmono/) arch linux package