### PR TITLE
Gemfile: Move pry to development and test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ ruby '~> 2.6.0'
 
 gem 'rake'
 gem 'thor'
-gem 'pry', '~> 0.12.0'
 gem 'activesupport', '~> 5.2', require: false
 gem 'yajl-ruby', require: false
 gem 'html-pipeline'
@@ -49,6 +48,10 @@ group :test do
   gem 'minitest'
   gem 'rr', require: false
   gem 'rack-test', require: false
+end
+
+group :development, :test do
+  gem 'pry', '~> 0.12.0'
 end
 
 if ENV['SELENIUM'] == '1'


### PR DESCRIPTION
`pry` gem is currently requested at the top level of `Gemfile`.

I faced a problem that `pry` requires `HOME` environment variable to be set. If `HOME` env var is unset devdocs fail with the following error:
```
 bundler: failed to load command: rackup (/opt/devdocs-git/.bundle/ruby/2.7.0/bin/rackup)
 ArgumentError: couldn't find login name -- expanding `~'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry/pry_class.rb:5:in `expand_path'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry/pry_class.rb:5:in `<class:Pry>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry/pry_class.rb:1:in `<top (required)>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry.rb:119:in `require'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry.rb:119:in `<top (required)>'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `block (2 levels) in require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `each'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `block in require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `each'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler.rb:174:in `require'
   /opt/devdocs-git/lib/docs.rb:2:in `<top (required)>'
   /opt/devdocs-git/lib/app.rb:40:in `require'
   /opt/devdocs-git/lib/app.rb:40:in `block in <class:App>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:1426:in `configure'
   /opt/devdocs-git/lib/app.rb:14:in `<class:App>'
   /opt/devdocs-git/lib/app.rb:6:in `<top (required)>'
   /opt/devdocs-git/config.ru:5:in `require'
   /opt/devdocs-git/config.ru:5:in `block in <main>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:55:in `instance_eval'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:55:in `initialize'
   /opt/devdocs-git/config.ru:in `new'
   /opt/devdocs-git/config.ru:in `<main>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:49:in `eval'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:49:in `new_from_string'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:40:in `parse_file'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:319:in `build_app_and_options_from_config'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:219:in `app'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:354:in `wrapped_app'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:283:in `start'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:148:in `start'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/bin/rackup:4:in `<top (required)>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/bin/rackup:23:in `load'
   /opt/devdocs-git/.bundle/ruby/2.7.0/bin/rackup:23:in `<top (required)>'
```

While `HOME` is usually defined in UNIX-like OSs, there are cases when it isn't. For example when an application is run as a service by systemd it doesn't define `HOME` environment variable.

But the thing about `pry` gem is that it's a development gem and the reason why it needs `HOME` is that it reads/stores command history. For the production usage it absolutely unnecessary. So basically adding `pry` to the root of the `Gemfile` adds additional requirement for the environment (`HOME` var to be defined). I believe that it's best to avoid additional requirements like this when they don't have strong grounding. Therefore I suggest to move `pry` to `development` and `test` groups of the `Gemfile`. This way it's possible to exclude `pry` from production setup by using `bundle install --without development test` and remove the aforementioned requirement.