### PR TITLE
Don't require pry by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby '~> 2.6.0'
 
 gem 'rake'
 gem 'thor'
-gem 'pry', '~> 0.12.0'
+gem 'pry', '~> 0.12.0', require: false
 gem 'activesupport', '~> 5.2', require: false
 gem 'yajl-ruby', require: false
 gem 'html-pipeline'


### PR DESCRIPTION
There is an AUR package for Arch Linux for devdocs here: https://aur.archlinux.org/packages/devdocs-git/

Currently it doesn't start because of the error with pry:
```
 bundler: failed to load command: rackup (/opt/devdocs-git/.bundle/ruby/2.7.0/bin/rackup)
 ArgumentError: couldn't find login name -- expanding `~'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry/pry_class.rb:5:in `expand_path'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry/pry_class.rb:5:in `<class:Pry>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry/pry_class.rb:1:in `<top (required)>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry.rb:119:in `require'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/pry-0.12.2/lib/pry.rb:119:in `<top (required)>'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `block (2 levels) in require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `each'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `block in require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `each'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `require'
   /usr/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler.rb:174:in `require'
   /opt/devdocs-git/lib/docs.rb:2:in `<top (required)>'
   /opt/devdocs-git/lib/app.rb:40:in `require'
   /opt/devdocs-git/lib/app.rb:40:in `block in <class:App>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:1426:in `configure'
   /opt/devdocs-git/lib/app.rb:14:in `<class:App>'
   /opt/devdocs-git/lib/app.rb:6:in `<top (required)>'
   /opt/devdocs-git/config.ru:5:in `require'
   /opt/devdocs-git/config.ru:5:in `block in <main>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:55:in `instance_eval'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:55:in `initialize'
   /opt/devdocs-git/config.ru:in `new'
   /opt/devdocs-git/config.ru:in `<main>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:49:in `eval'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:49:in `new_from_string'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/builder.rb:40:in `parse_file'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:319:in `build_app_and_options_from_config'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:219:in `app'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:354:in `wrapped_app'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:283:in `start'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/lib/rack/server.rb:148:in `start'
   /opt/devdocs-git/.bundle/ruby/2.7.0/gems/rack-2.0.7/bin/rackup:4:in `<top (required)>'
   /opt/devdocs-git/.bundle/ruby/2.7.0/bin/rackup:23:in `load'
   /opt/devdocs-git/.bundle/ruby/2.7.0/bin/rackup:23:in `<top (required)>'
```

It happens because `HOME` environment variable is not set when devdocs is run as a systemd service. And `pry` requires `HOME` env variable to be set.

At the same time, the files in the project that use `pry` are requiring it explicitly anyway. So there doesn't seem to be any harm in setting `require` to `false` for `pry` gem, but it also fixes the issue for the aformentioned package which tries to load `pry` with the application and fails to because `pry` requires `HOME` to be set. In fact `pry` is only needed for running `thor` tasks and not for the webapp itself.