### PR TITLE
Update lua.rb

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -448,7 +448,7 @@ credits = [
     'https://raw.githubusercontent.com/lodash/lodash/master/LICENSE'
   ], [
     'Lua',
-    '1994–2017 Lua.org, PUC-Rio',
+    '1994–2020 Lua.org, PUC-Rio',
     'MIT',
     'http://www.lua.org/license.html'
   ], [

--- a/lib/docs/scrapers/lua.rb
+++ b/lib/docs/scrapers/lua.rb
@@ -8,12 +8,17 @@ module Docs
     options[:skip_links] = true
 
     options[:attribution] = <<-HTML
-      &copy; 1994&ndash;2017 Lua.org, PUC-Rio.<br>
+      &copy; 1994&ndash;2020 Lua.org, PUC-Rio.<br>
       Licensed under the MIT License.
     HTML
 
+    version '5.4' do
+      self.release = '5.4.1'
+      self.base_url = 'https://www.lua.org/manual/5.4/'
+    end
+
     version '5.3' do
-      self.release = '5.3.4'
+      self.release = '5.3.6'
       self.base_url = 'https://www.lua.org/manual/5.3/'
     end
 


### PR DESCRIPTION
This adds Lua 5.4, bumps Lua 5.3 to (probably) the last version, and updates the copyright.

<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
