### PR TITLE
Fix get_latest_version procedure that were showing bad information

### DIFF
--- a/lib/docs/scrapers/apache.rb
+++ b/lib/docs/scrapers/apache.rb
@@ -35,8 +35,8 @@ module Docs
     HTML
 
     def get_latest_version(opts)
-      doc = fetch_doc('http://httpd.apache.org/docs/', opts)
-      doc.at_css('#apcontents > ul a')['href'][0...-1]
+      doc = fetch_doc('http://httpd.apache.org/download', opts)
+      doc.at_css('#apcontents li > a').content
     end
   end
 end

--- a/lib/docs/scrapers/cakephp.rb
+++ b/lib/docs/scrapers/cakephp.rb
@@ -82,8 +82,8 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://api.cakephp.org/3.7/', opts)
-      doc.at_css('.version-picker .dropdown-toggle').content.strip
+      doc = fetch_doc('https://cakephp.org', opts)
+      doc.at_css('.title-home h1').content.scan(/\d\.\d*\.*\d*\.*\d*\.*/)[0]
     end
 
     private

--- a/lib/docs/scrapers/markdown.rb
+++ b/lib/docs/scrapers/markdown.rb
@@ -2,7 +2,6 @@ module Docs
   class Markdown < UrlScraper
     self.name = 'Markdown'
     self.type = 'simple'
-    self.release = '1.0.1'
     self.base_url = 'https://daringfireball.net/projects/markdown/syntax'
 
     html_filters.push 'markdown/clean_html', 'markdown/entries'
@@ -16,8 +15,7 @@ module Docs
     HTML
 
     def get_latest_version(opts)
-      doc = fetch_doc('http://daringfireball.net/projects/markdown', opts)
-      doc.at_css('.article p a').content.scan(/\d\.\d*\.*\d*\.*\d*\.*/)[0]
+      '1.0.0'
     end
   end
 end

--- a/lib/docs/scrapers/markdown.rb
+++ b/lib/docs/scrapers/markdown.rb
@@ -2,7 +2,8 @@ module Docs
   class Markdown < UrlScraper
     self.name = 'Markdown'
     self.type = 'simple'
-    self.base_url = 'http://daringfireball.net/projects/markdown/syntax'
+    self.release = '1.0.1'
+    self.base_url = 'https://daringfireball.net/projects/markdown/syntax'
 
     html_filters.push 'markdown/clean_html', 'markdown/entries'
 
@@ -15,7 +16,8 @@ module Docs
     HTML
 
     def get_latest_version(opts)
-      '1.0.0'
+      doc = fetch_doc('http://daringfireball.net/projects/markdown', opts)
+      doc.at_css('.article p a').content.scan(/\d\.\d*\.*\d*\.*\d*\.*/)[0]
     end
   end
 end

--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -108,7 +108,8 @@ module Docs
     end
 
     def get_latest_version(opts)
-      get_latest_github_release('rails', 'rails', opts)
+      doc = fetch_doc('https://rubyonrails.org/', opts)
+      doc.at_css('.version p a').content.scan(/\d\.\d*\.*\d*\.*\d*/)[0]
     end
   end
 end


### PR DESCRIPTION
- markdown: update scraper and fix get_latest_version

- rails: fix get_latest_version, it was showing an outdated
  version as the latest version

- apache: fix get_latest_version, it was showing and
  outdated version as the latest version

- cakephp: fix get_latest_version, it was showing and
  outdated version as the latest version