### PR TITLE
leaflet: add version 1.7.1

### DIFF
--- a/lib/docs/filters/leaflet/clean_html.rb
+++ b/lib/docs/filters/leaflet/clean_html.rb
@@ -8,13 +8,13 @@ module Docs
           node.name = 'h2'
         end
 
-        at_css('> h2:first-child').name = 'h1'
-
-        # remove "This reference reflects Leaflet 1.2.0."
-        css('h1 ~ p').each do |node|
+        # remove "This reference reflects Leaflet"
+        css('p:contains("This reference reflects Leaflet")').each do |node|
           node.remove
           break
         end
+
+        at_css('> h2:first-child').name = 'h1'
 
         css('section', 'code b', '.accordion', '.accordion-overflow', '.accordion-content').each do |node|
           node.before(node.children).remove
@@ -22,11 +22,11 @@ module Docs
 
         css('pre > code').each do |node|
           node['class'] ||= ''
-          lang = if node['class'].include?('lang-html') || node.content =~ /\A</
+          lang = if node['class'].include?('lang-html') || node['class'].include?('language-html') || node.content =~ /\A</
             'html'
-          elsif node['class'].include?('lang-css')
+          elsif node['class'].include?('lang-css') || node['class'].include?('language-css')
             'css'
-          elsif node['class'].include?('lang-js') || node['class'].include?('lang-javascript')
+          elsif node['class'].include?('lang-js') || node['class'].include?('language-js') || node['class'].include?('lang-javascript')
             'javascript'
           end
           node.parent['data-language'] = lang if lang

--- a/lib/docs/scrapers/leaflet.rb
+++ b/lib/docs/scrapers/leaflet.rb
@@ -19,6 +19,11 @@ module Docs
       Maps &copy; OpenStreetMap contributors.
     HTML
 
+    version '1.7' do
+      self.release = '1.7.1'
+      self.base_url = "https://leafletjs.com/reference-#{release}.html"
+    end
+
     version '1.6' do
       self.release = '1.6.0'
       self.base_url = "https://leafletjs.com/reference-#{release}.html"


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
