### PR TITLE
python: add version 3.9

### DIFF
--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -23,22 +23,23 @@ module Docs
       Licensed under the PSF License.
     HTML
 
+    # mkdir -p docs/python~3.8 && cd docs/python~3.8 && curl -L https://docs.python.org/3.8/archives/python-3.8.6-docs-html.tar.bz2 | tar xj --strip-components=1
     version '3.8' do # docs.python.org/3.8/download.html
-      self.release = '3.8.1'
+      self.release = '3.8.6'
       self.base_url = 'https://docs.python.org/3.8/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.7' do # docs.python.org/3.7/download.html
-      self.release = '3.7.6'
+      self.release = '3.7.9'
       self.base_url = 'https://docs.python.org/3.7/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.6' do # docs.python.org/3.6/download.html
-      self.release = '3.6.10'
+      self.release = '3.6.12'
       self.base_url = 'https://docs.python.org/3.6/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'

--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -23,7 +23,14 @@ module Docs
       Licensed under the PSF License.
     HTML
 
-    # mkdir -p docs/python~3.8 && cd docs/python~3.8 && curl -L https://docs.python.org/3.8/archives/python-3.8.6-docs-html.tar.bz2 | tar xj --strip-components=1
+    # mkdir -p docs/python~3.9 && cd docs/python~3.9 && curl -L https://docs.python.org/3.9/archives/python-3.9.0-docs-html.tar.bz2 | tar xj --strip-components=1
+    version '3.9' do # docs.python.org/3.9/download.html
+      self.release = '3.9.0'
+      self.base_url = 'https://docs.python.org/3.9/'
+
+      html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
+    end
+
     version '3.8' do # docs.python.org/3.8/download.html
       self.release = '3.8.6'
       self.base_url = 'https://docs.python.org/3.8/'


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
