### PR TITLE
angularjs: add version 1.8

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -83,9 +83,9 @@ app.templates.aboutPage = -> """
 
 credits = [
   [ 'Angular<br>Angular.js',
-    '2010-2019 Google, Inc.',
-    'CC BY',
-    'https://creativecommons.org/licenses/by/4.0/'
+    '2010-2020 Google, Inc.',
+    'CC BY 3.0',
+    'https://creativecommons.org/licenses/by/3.0/'
   ], [
     'Ansible',
     '2012-2018 Michael DeHaan<br>&copy; 2018–2019 Red Hat, Inc.',

--- a/lib/docs/scrapers/angularjs.rb
+++ b/lib/docs/scrapers/angularjs.rb
@@ -38,8 +38,8 @@ module Docs
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2010&ndash;2018 Google, Inc.<br>
-      Licensed under the Creative Commons Attribution License 4.0.
+      &copy; 2010&ndash;2020 Google, Inc.<br>
+      Licensed under the Creative Commons Attribution License 3.0.
     HTML
 
     stub '' do
@@ -47,6 +47,11 @@ module Docs
       capybara.app_host = 'https://code.angularjs.org'
       capybara.visit("/#{self.class.release}/docs/api")
       capybara.execute_script("return document.querySelector('.side-navigation').innerHTML")
+    end
+
+    version '1.8' do
+      self.release = '1.8.2'
+      self.base_url = "https://code.angularjs.org/#{release}/docs/partials/"
     end
 
     version '1.7' do


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
