### PR TITLE
postgresql: add version 13

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -603,7 +603,7 @@ credits = [
     'https://raw.githubusercontent.com/ponylang/ponyc/master/LICENSE'
   ], [
     'PostgreSQL',
-    '1996-2019 The PostgreSQL Global Development Group<br>&copy; 1994 The Regents of the University of California',
+    '1996-2020 The PostgreSQL Global Development Group<br>&copy; 1994 The Regents of the University of California',
     'PostgreSQL',
     'https://www.postgresql.org/about/licence/'
   ], [

--- a/lib/docs/scrapers/postgresql.rb
+++ b/lib/docs/scrapers/postgresql.rb
@@ -51,9 +51,14 @@ module Docs
       /\Aunsupported-features/ ]
 
     options[:attribution] = <<-HTML
-      &copy; 1996&ndash;2019 The PostgreSQL Global Development Group<br>
+      &copy; 1996&ndash;2020 The PostgreSQL Global Development Group<br>
       Licensed under the PostgreSQL License.
     HTML
+
+    version '13' do
+      self.release = '13.1'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
+    end
 
     version '12' do
       self.release = '12.1'

--- a/public/icons/docs/postgresql/SOURCE
+++ b/public/icons/docs/postgresql/SOURCE
@@ -1,1 +1,1 @@
-http://www.postgresql.org/about/press/presskit93/#logos
+https://www.postgresql.org/about/press/presskit93/#logos


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
