### PR TITLE
jest: update to 26.6

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -378,7 +378,7 @@ credits = [
     'https://raw.githubusercontent.com/jekyll/jekyll/master/LICENSE'
   ], [
     'Jest',
-    'Facebook, Inc. and its affiliates.',
+    '2020 Facebook, Inc.',
     'MIT',
     'https://raw.githubusercontent.com/facebook/jest/master/LICENSE'
   ], [

--- a/lib/docs/filters/jest/entries.rb
+++ b/lib/docs/filters/jest/entries.rb
@@ -19,6 +19,7 @@ module Docs
 
       def additional_entries
         return [] unless !root_page? && self.type == self.name # api page
+        return [] if self.slug == 'environment-variables'
 
         entries = []
 

--- a/lib/docs/scrapers/jest.rb
+++ b/lib/docs/scrapers/jest.rb
@@ -1,7 +1,7 @@
 module Docs
   class Jest < UrlScraper
     self.type = 'simple'
-    self.release = '24.9'
+    self.release = '26.6'
     self.base_url = 'https://jestjs.io/docs/en/'
     self.root_path = 'getting-started'
     self.links = {
@@ -14,7 +14,7 @@ module Docs
     options[:container] = '.docMainWrapper'
 
     options[:attribution] = <<-HTML
-      &copy; 2019 Facebook, Inc. and its affiliates.<br>
+      &copy; 2020 Facebook, Inc.<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
