### PR TITLE
openjdk: add version 11

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -548,7 +548,7 @@ credits = [
     'https://octave.org/doc/interpreter/'
   ], [
     'OpenJDK',
-    '1993-2017, Oracle and/or its affiliates. All rights reserved.<br>Licensed under the GNU General Public License, version 2, with the Classpath Exception.<br>Various third party code in OpenJDK is licensed under different licenses.<br>Java and OpenJDK are trademarks or registered trademarks of Oracle and/or its affiliates.',
+    '1993, 2020, Oracle and/or its affiliates. All rights reserved.<br>Licensed under the GNU General Public License, version 2, with the Classpath Exception.<br>Various third party code in OpenJDK is licensed under different licenses.<br>Java and OpenJDK are trademarks or registered trademarks of Oracle and/or its affiliates.',
     'GPLv2',
     'http://openjdk.java.net/legal/gplv2+ce.html'
   ], [

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -80,6 +80,24 @@ $GS = '/usr/local/opt/ghostscript/bin/gs';	# GhostScript
 
 ## OpenJDK
 
+https://packages.debian.org/sid/openjdk-11-doc
+
+```sh
+mkdir docs/openjdk~11
+curl --remote-name http://ftp.debian.org/debian/pool/main/o/openjdk-11/openjdk-11-doc_11.0.9.1+1-1_all.deb
+bsdtar --extract --to-stdout --file openjdk-11-doc_11.0.9.1+1-1_all.deb data.tar.xz | \
+bsdtar --extract --xz --file - --strip-components=6 --directory=docs/openjdk\~11/ ./usr/share/doc/openjdk-11-jre-headless/api/
+```
+
+https://packages.debian.org/sid/openjdk-8-doc
+
+```sh
+mkdir docs/openjdk~8
+curl --remote-name http://ftp.debian.org/debian/pool/main/o/openjdk-8/openjdk-8-doc_8u272-b10-1_all.deb
+bsdtar --extract --to-stdout --file openjdk-8-doc_8u272-b10-1_all.deb data.tar.xz | \
+bsdtar --extract --xz --file - --strip-components=6 --directory=docs/openjdk\~8/ ./usr/share/doc/openjdk-8-jre-headless/api/
+```
+
 ## Perl
 
 ## PHP

--- a/lib/docs/filters/openjdk/clean_html.rb
+++ b/lib/docs/filters/openjdk/clean_html.rb
@@ -33,7 +33,7 @@ module Docs
           node.content = node.content.remove(' Summary').remove(' Detail').pluralize
         end
 
-        if root_page?
+        if root_page? && version == '8'
           css('.header')[1].remove
           css('.contentContainer')[0].remove
           css('.contentContainer')[-1].remove
@@ -45,7 +45,10 @@ module Docs
             end
           end
 
-          at_css('h1').content = "OpenJDK #{release} Documentation" + (version != release ? " (#{version.split(' ').last})" : '')
+        end
+
+        if root_page?
+          at_css('h1').content = "OpenJDK #{release} Documentation"
         end
 
         css('table').each do |node|

--- a/lib/docs/scrapers/openjdk.rb
+++ b/lib/docs/scrapers/openjdk.rb
@@ -18,12 +18,19 @@ module Docs
       /doc-files\//]
 
     options[:attribution] = <<-HTML
-      &copy; 1993&ndash;2017, Oracle and/or its affiliates. All rights reserved.<br>
+      &copy; 1993, 2020, Oracle and/or its affiliates. All rights reserved.<br>
       Documentation extracted from Debian's OpenJDK Development Kit package.<br>
       Licensed under the GNU General Public License, version 2, with the Classpath Exception.<br>
       Various third party code in OpenJDK is licensed under different licenses (see Debian package).<br>
       Java and OpenJDK are trademarks or registered trademarks of Oracle and/or its affiliates.
     HTML
+
+    version '11' do
+      self.release = '11.0.9'
+      self.root_path = 'index.html'
+      self.base_url = 'https://docs.oracle.com/en/java/javase/11/docs/api/'
+      options[:only_patterns] = [/\Ajava\./]
+    end
 
     version '8' do
       self.release = '8'


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
