### PR TITLE
openjdk: merge 8, update release 8u272

### DIFF
--- a/lib/docs/scrapers/openjdk.rb
+++ b/lib/docs/scrapers/openjdk.rb
@@ -26,60 +26,9 @@ module Docs
     HTML
 
     version '8' do
-      self.release = '8'
-
-      options[:only_patterns] = [
-        /\Ajava\/beans\//,
-        /\Ajava\/io\//,
-        /\Ajava\/lang\//,
-        /\Ajava\/math\//,
-        /\Ajava\/net\//,
-        /\Ajava\/nio\//,
-        /\Ajava\/security\//,
-        /\Ajava\/text\//,
-        /\Ajava\/time\//,
-        /\Ajava\/util\//,
-        /\Ajavax\/annotation\//,
-        /\Ajavax\/crypto\//,
-        /\Ajavax\/imageio\//,
-        /\Ajavax\/lang\//,
-        /\Ajavax\/management\//,
-        /\Ajavax\/naming\//,
-        /\Ajavax\/net\//,
-        /\Ajavax\/print\//,
-        /\Ajavax\/script\//,
-        /\Ajavax\/security\//,
-        /\Ajavax\/sound\//,
-        /\Ajavax\/tools\//]
-    end
-
-    version '8 GUI' do
-      self.release = '8'
-
-      options[:only_patterns] = [
-        /\Ajava\/awt\//,
-        /\Ajavax\/swing\//]
-    end
-
-    version '8 Web' do
-      self.release = '8'
-
-      options[:only_patterns] = [
-        /\Ajava\/applet\//,
-        /\Ajava\/rmi\//,
-        /\Ajava\/sql\//,
-        /\Ajavax\/accessibility\//,
-        /\Ajavax\/activation\//,
-        /\Ajavax\/activity\//,
-        /\Ajavax\/jws\//,
-        /\Ajavax\/rmi\//,
-        /\Ajavax\/sql\//,
-        /\Ajavax\/transaction\//,
-        /\Ajavax\/xml\//,
-        /\Aorg\/ietf\//,
-        /\Aorg\/omg\//,
-        /\Aorg\/w3c\//,
-        /\Aorg\/xml\//]
+      self.release = '8u272'
+      self.base_url = 'https://docs.oracle.com/javase/8/docs/api/'
+      options[:only_patterns] = [/\A(java|javax|org)\//]
     end
 
     # Monkey patch to properly read HTML files encoded in ISO-8859-1


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Fixes https://github.com/freeCodeCamp/devdocs/issues/967.