### PR TITLE
Fix Codeigniter scraper

### DIFF
--- a/assets/stylesheets/pages/_sphinx.scss
+++ b/assets/stylesheets/pages/_sphinx.scss
@@ -4,6 +4,7 @@
   h4 { font-size: 1em; }
   > dl:not(.docutils) > dt { @extend %block-label, %label-blue; }
   dd > dl:not(.docutils) > dt { @extend %block-label; }
+  .class > dt { @extend %block-label, %label-blue; }
   dt + dt { margin-top: -.5em; }
 
   .note, .admonition, div.versionadded, div.versionchanged, .deprecated-removed, .deprecated, .topic { @extend %note; }

--- a/lib/docs/filters/codeigniter/entries.rb
+++ b/lib/docs/filters/codeigniter/entries.rb
@@ -23,7 +23,7 @@ module Docs
         entries = []
 
         css('.class').each do |node|
-          class_name = node.at_css('dt > .descname').content
+          class_name = node.at_css('dt > .descname').content.split('\\').last
           class_id = node.at_css('dt[id]')['id']
           entries << [class_name, class_id]
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

There are other problems with the documentation, but that's because the source documentation is malformed.