### PR TITLE
Update cypress to 5.6.0

### DIFF
--- a/lib/docs/filters/cypress/clean_html.rb
+++ b/lib/docs/filters/cypress/clean_html.rb
@@ -14,6 +14,8 @@ module Docs
         css('.article-footer').remove
         css('.article-footer-updated').remove
 
+        css('.dashboard-ad').remove
+
         css('pre').each do |node|
           node.content = node.content
           node['data-language'] = 'javascript'

--- a/lib/docs/scrapers/cypress.rb
+++ b/lib/docs/scrapers/cypress.rb
@@ -4,7 +4,7 @@ module Docs
   class Cypress < UrlScraper
     self.name = 'Cypress'
     self.type = 'cypress'
-    self.release = '3.4.1'
+    self.release = '5.6.0'
     self.base_url = 'https://docs.cypress.io'
     self.root_path = '/api/api/table-of-contents.html'
     self.links = {
@@ -18,14 +18,18 @@ module Docs
     options[:max_image_size] = 300_000
     options[:include_default_entry] = true
 
-    options[:skip_patterns] = [/examples\//]
+    options[:skip_patterns] = [
+      /examples\//,
+      /guides/
+    ]
+
     options[:skip_link] = ->(link) {
       href = link.attr(:href)
       href.nil? ? true : EntriesFilter::SECTIONS.none? { |section| href.match?("/#{section}/") }
     }
 
     options[:attribution] = <<-HTML
-      &copy; 2017 Cypress.io<br>
+      &copy; 2020 Cypress.io<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
