### PR TITLE
Update mocha to 8.2.1

### DIFF
--- a/lib/docs/filters/mocha/clean_html.rb
+++ b/lib/docs/filters/mocha/clean_html.rb
@@ -9,6 +9,13 @@ module Docs
           node['data-language'] = 'javascript'
         end
 
+        css('#more-information ~ p').remove
+        css('#more-information').remove
+
+        css('h2 > a, h3 > a').each do |node|
+          node.remove
+        end
+
         doc
       end
     end

--- a/lib/docs/filters/mocha/entries.rb
+++ b/lib/docs/filters/mocha/entries.rb
@@ -9,10 +9,11 @@ module Docs
         'bdd' => ['describe()', 'context()', 'it()', 'specify()'],
         'tdd' => ['suite()', 'test()'],
         'exports' => ['exports'],
-        'qunit' => ['QUnit'],
         'require' => ['require'],
-        'browser-specific-methods' => ['mocha.allowUncaught()', 'mocha.setup()', 'mocha.run()', 'mocha.globals()', 'mocha.checkLeaks()'],
-        'timeouts' => ['timeout()']
+        'running-mocha-in-the-browser' => ['mocha.setup()', 'mocha.run()', 'mocha.globals()', 'mocha.checkLeaks()'],
+        'timeouts' => ['timeout()'],
+        'delayed-root-suite' => ['run()'],
+        'command-line-usage' => ['mocha cli options']
       }
 
       def additional_entries
@@ -24,10 +25,10 @@ module Docs
           end
         end
 
-        css('h2').each do |node|
+        css('h2, h3').each do |node|
           name = node.content.strip
+          next if name.match?(/\A-/)
           next if name.in?(%w(Examples Getting\ Started Installation More\ Information Testing\ Mocha))
-          name = 'mocha' if name == 'Usage'
           entries << [name, node['id']]
         end
 

--- a/lib/docs/scrapers/mocha.rb
+++ b/lib/docs/scrapers/mocha.rb
@@ -1,7 +1,7 @@
 module Docs
   class Mocha < UrlScraper
     self.type = 'simple'
-    self.release = '5.2.0'
+    self.release = '8.2.1'
     self.base_url = 'https://mochajs.org/'
     self.links = {
       home: 'https://mochajs.org/',
@@ -15,7 +15,7 @@ module Docs
     options[:skip_links] = true
 
     options[:attribution] = <<-HTML
-      &copy; 2011&ndash;2018 JS Foundation and contributors<br>
+      &copy; 2011&ndash;2020 JS Foundation and contributors<br>
       Licensed under the Creative Commons Attribution 4.0 International License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
