### PR TITLE
Revert "Don't require pry by default"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby '~> 2.6.0'
 
 gem 'rake'
 gem 'thor'
-gem 'pry', '~> 0.12.0', require: false
+gem 'pry', '~> 0.12.0'
 gem 'activesupport', '~> 5.2', require: false
 gem 'yajl-ruby', require: false
 gem 'html-pipeline'


### PR DESCRIPTION
Reverts freeCodeCamp/devdocs#1273

Caused the build to fail – `Forwardable` is provided by pry.

cc: @cmrd-senyacmrd-senya

```
$ bundle exec rake assets:precompile
Docs -- BEGIN
rake aborted!
NameError: uninitialized constant Docs::FilterStack::Forwardable
/home/simon/src/devdocs/lib/docs/core/filter_stack.rb:3:in `<class:FilterStack>'
/home/simon/src/devdocs/lib/docs/core/filter_stack.rb:2:in `<module:Docs>'
/home/simon/src/devdocs/lib/docs/core/filter_stack.rb:1:in `<top (required)>'
/home/simon/src/devdocs/lib/docs/core/scraper.rb:41:in `require'
/home/simon/src/devdocs/lib/docs/core/scraper.rb:41:in `<class:Scraper>'
/home/simon/src/devdocs/lib/docs/core/scraper.rb:4:in `<module:Docs>'
/home/simon/src/devdocs/lib/docs/core/scraper.rb:3:in `<top (required)>'
/home/simon/src/devdocs/lib/docs/core/scrapers/url_scraper.rb:2:in `require'
/home/simon/src/devdocs/lib/docs/core/scrapers/url_scraper.rb:2:in `<module:Docs>'
/home/simon/src/devdocs/lib/docs/core/scrapers/url_scraper.rb:1:in `<top (required)>'
/home/simon/src/devdocs/lib/docs/scrapers/github.rb:2:in `require'
/home/simon/src/devdocs/lib/docs/scrapers/github.rb:2:in `<module:Docs>'
/home/simon/src/devdocs/lib/docs/scrapers/github.rb:1:in `<top (required)>'
/home/simon/src/devdocs/lib/docs.rb:37:in `require'
/home/simon/src/devdocs/lib/docs.rb:37:in `const_get'
/home/simon/src/devdocs/lib/docs.rb:37:in `block in all'
/home/simon/src/devdocs/lib/docs.rb:37:in `map'
/home/simon/src/devdocs/lib/docs.rb:37:in `all'
/home/simon/src/devdocs/lib/docs.rb:43:in `all_versions'
/home/simon/src/devdocs/lib/tasks/docs.thor:236:in `prepare_deploy'
/home/simon/src/devdocs/Rakefile:18:in `block (2 levels) in <top (required)>'
/home/simon/src/devdocs/vendor/bundle/ruby/2.7.0/gems/rake-13.0.0/exe/rake:27:in `<top (required)>'
/usr/bin/bundle:23:in `load'
/usr/bin/bundle:23:in `<main>'
```