### PR TITLE
Update Gcc scraper

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -35,6 +35,24 @@ Go to https://www.erlang.org/downloads and download the HTML documentation file.
 ## Gnu
 
 ### GCC
+Go to https://gcc.gnu.org/onlinedocs/ and download the HTML tarball of GCC Manual and GCC CPP manual or run the following commands to download the tarballs:
+
+```sh
+# Gcc manual
+wget https://gcc.gnu.org/onlinedocs/gcc-<version>/gcc-html.tar.gz
+# Gcc cpp manual
+wget https://gcc.gnu.org/onlinedocs/gcc-<version>/cpp-html.tar.gz
+```
+
+Then extract the content of the tarball and move it to the devdocs directory.
+
+```sh
+tar xf <tarball>
+# Gcc
+mv <extracted_directory> path/to/devdocs/docs/gcc~<version>/
+# Gcc Cpp
+mv <extracted_directory> path/to/devdocs/docs/gcc~<version>_cpp/
+```
 ### GNU Fortran
 
 ## Gnuplot

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -38,21 +38,17 @@ Go to https://www.erlang.org/downloads and download the HTML documentation file.
 Go to https://gcc.gnu.org/onlinedocs/ and download the HTML tarball of GCC Manual and GCC CPP manual or run the following commands to download the tarballs:
 
 ```sh
-# Gcc manual
-wget https://gcc.gnu.org/onlinedocs/gcc-<version>/gcc-html.tar.gz
-# Gcc cpp manual
-wget https://gcc.gnu.org/onlinedocs/gcc-<version>/cpp-html.tar.gz
+# GCC manual
+mkdir docs/gcc~${VERSION}; \
+curl https://gcc.gnu.org/onlinedocs/gcc-$RELEASE/gcc-html.tar.gz | \
+tar --extract --gzip --strip-components=1 --directory=docs/gcc~${VERSION}
+
+# GCC CPP manual
+mkdir docs/gcc~${VERSION}_cpp; \
+curl https://gcc.gnu.org/onlinedocs/gcc-$RELEASE/cpp-html.tar.gz | \
+tar --extract --gzip --strip-components=1 --directory=docs/gcc~${VERSION}_cpp
 ```
 
-Then extract the content of the tarball and move it to the devdocs directory.
-
-```sh
-tar xf <tarball>
-# Gcc
-mv <extracted_directory> path/to/devdocs/docs/gcc~<version>/
-# Gcc Cpp
-mv <extracted_directory> path/to/devdocs/docs/gcc~<version>_cpp/
-```
 ### GNU Fortran
 
 ## Gnuplot

--- a/lib/docs/scrapers/gnu/gcc.rb
+++ b/lib/docs/scrapers/gnu/gcc.rb
@@ -69,66 +69,66 @@ module Docs
     end
 
     version '8' do
-      self.release = '8.4.0'
+      self.release = '8.3.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
     end
 
     version '8 CPP' do
-      self.release = '8.4.0'
+      self.release = '8.3.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '7' do
-      self.release = '7.5.0'
+      self.release = '7.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
     end
 
     version '7 CPP' do
-      self.release = '7.5.0'
+      self.release = '7.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '6' do
-      self.release = '6.5.0'
+      self.release = '6.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
 
       options[:root_title] = 'Using the GNU Compiler Collection (GCC)'
     end
 
     version '6 CPP' do
-      self.release = '6.5.0'
+      self.release = '6.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '5' do
-      self.release = '5.5.0'
+      self.release = '5.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
 
       options[:root_title] = 'Using the GNU Compiler Collection (GCC)'
     end
 
     version '5 CPP' do
-      self.release = '5.5.0'
+      self.release = '5.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '4' do
-      self.release = '4.9.4'
+      self.release = '4.9.3'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
 
       options[:root_title] = 'Using the GNU Compiler Collection (GCC)'
     end
 
     version '4 CPP' do
-      self.release = '4.9.4'
+      self.release = '4.9.3'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS

--- a/lib/docs/scrapers/gnu/gcc.rb
+++ b/lib/docs/scrapers/gnu/gcc.rb
@@ -46,79 +46,89 @@ module Docs
       'Wtrigraphs.html' => 'Invocation.html'
     }
 
+    version '10' do
+      self.release = '10.2.0'
+      self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
+    end
+
+    version '10 CPP' do
+      self.release = '10.2.0'
+      self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
+    end
+
     version '9' do
-      self.release = '9.2.0'
+      self.release = '9.3.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
     end
 
     version '9 CPP' do
-      self.release = '9.2.0'
+      self.release = '9.3.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '8' do
-      self.release = '8.3.0'
+      self.release = '8.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
     end
 
     version '8 CPP' do
-      self.release = '8.3.0'
+      self.release = '8.4.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '7' do
-      self.release = '7.4.0'
+      self.release = '7.5.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
     end
 
     version '7 CPP' do
-      self.release = '7.4.0'
+      self.release = '7.5.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '6' do
-      self.release = '6.4.0'
+      self.release = '6.5.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
 
       options[:root_title] = 'Using the GNU Compiler Collection (GCC)'
     end
 
     version '6 CPP' do
-      self.release = '6.4.0'
+      self.release = '6.5.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '5' do
-      self.release = '5.4.0'
+      self.release = '5.5.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
 
       options[:root_title] = 'Using the GNU Compiler Collection (GCC)'
     end
 
     version '5 CPP' do
-      self.release = '5.4.0'
+      self.release = '5.5.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS
     end
 
     version '4' do
-      self.release = '4.9.3'
+      self.release = '4.9.4'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gcc/"
 
       options[:root_title] = 'Using the GNU Compiler Collection (GCC)'
     end
 
     version '4 CPP' do
-      self.release = '4.9.3'
+      self.release = '4.9.4'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/cpp/"
 
       options[:replace_paths] = CPP_PATHS


### PR DESCRIPTION
- Add 10.2.0 version

- Update previous versions

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
