### PR TITLE
Updated Django Documentation (3.1.4)

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -25,8 +25,11 @@ and put it in `/path/to/devdocs/docs/`
 Go to https://docs.djangoproject.com/, select the version from the
 bubble in the bottom-right corner, then download the HTML version from the sidebar.
 
-URL: `https://media.djangoproject.com/docs/django-docs-$VERSION-en.zip`
-
+```sh
+mkdir --parent docs/django\~$VERSION/; \
+curl https://media.djangoproject.com/docs/django-docs-$VERSION-en.zip | \
+bsdtar --extract --file - --directory=docs/django\~$VERSION/
+```
 
 ## Erlang
 

--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,13 +34,18 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '3.1' do
+      self.release = '3.1.4'
+      self.base_url = 'https://docs.djangoproject.com/en/3.1/'
+    end
+
     version '3.0' do
-      self.release = '3.0.3'
+      self.release = '3.0.11'
       self.base_url = 'https://docs.djangoproject.com/en/3.0/'
     end
 
     version '2.2' do
-      self.release = '2.2.10'
+      self.release = '2.2.17'
       self.base_url = 'https://docs.djangoproject.com/en/2.2/'
     end
 
@@ -55,7 +60,7 @@ module Docs
     end
 
     version '1.11' do
-      self.release = '1.11.28'
+      self.release = '1.11.29'
       self.base_url = 'https://docs.djangoproject.com/en/1.11/'
     end
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
