### PR TITLE
Update babel to 7.12.6

### DIFF
--- a/lib/docs/filters/babel/clean_html.rb
+++ b/lib/docs/filters/babel/clean_html.rb
@@ -2,36 +2,21 @@ module Docs
   class Babel
     class CleanHtmlFilter < Filter
       def call
-        if root_page?
-          doc.inner_html = '<h1>Babel</h1>'
-          return doc
-        end
 
-        header = at_css('.docs-header .col-md-12')
-        @doc = at_css('.docs-content')
-        doc.prepend_child(header)
+        css('.fixedHeaderContainer').remove
 
-        css('.btn-clipboard', '.package-links').remove
+        css('.toc').remove
 
-        css('.col-md-12', 'h1 a', 'h2 a', 'h3 a', 'h4 a', 'h5 a', 'h5 a').each do |node|
-          node.before(node.children).remove
-        end
+        css('.toc-headings').remove
 
-        css('div.highlighter-rouge').each do |node|
-          pre = node.at_css('pre')
+        css('.postHeader > a').remove
 
-          lang = node['class'][/language-(\w+)/, 1]
-          lang = 'bash' if lang == 'sh'
-          pre['data-language'] = lang
+        css('.nav-footer').remove
 
-          pre.remove_attribute('class')
-          pre.content = pre.content
-          node.replace(pre)
-        end
-
-        css('code').remove_attr('class')
+        css('.docs-prevnext').remove
 
         doc
+
       end
     end
   end

--- a/lib/docs/filters/babel/entries.rb
+++ b/lib/docs/filters/babel/entries.rb
@@ -1,40 +1,28 @@
 module Docs
   class Babel
     class EntriesFilter < Docs::EntriesFilter
+
+      ENTRIES = {
+        'Usage' => ['Options', 'Config Files', '@babel/cli', '@babel/polyfill',
+                    '@babel/plugin-transform-runtime', '@babel/register'],
+
+        'Presets' => ['@babel/preset-env', '@babel/preset-flow', '@babel/preset-react', '@babel/preset-typescript'],
+
+        'Tooling' => ['@babel/parser', '@babel/core', '@babel/generator', '@babel/code-frame',
+                      '@babel/helpers', '@babel/runtime', '@babel/template', '@babel/traverse', '@babel/types']
+      }
+
       def get_name
         at_css('h1').content
       end
 
       def get_type
-        if subpath.start_with?('plugins/preset')
-          'Presets'
-        elsif subpath.start_with?('plugins/transform')
-          'Transform Plugins'
-        elsif subpath.start_with?('plugins/minify')
-          'Minification'
-        elsif subpath.start_with?('plugins/syntax')
-          'Syntax Plugins'
-        elsif subpath.start_with?('plugins')
-          'Plugins'
-        elsif subpath.start_with?('usage/')
-          'Usage'
-        elsif subpath.start_with?('core-packages/')
-          'Core Packages'
-        else
-          'Miscellaneous'
+        ENTRIES.each do |key, value|
+          return key if value.include?(name)
+          return 'Other Plugins' if subpath.include?('babel-plugin')
         end
       end
 
-      def additional_entries
-        return [] unless slug.include?('api')
-
-        css('h2').each_with_object [] do |node, entries|
-          name = node.content.strip
-          next unless name.start_with?('babel.')
-          name.sub! %r{\(.*}, '()'
-          entries << [name, node['id']]
-        end
-      end
     end
   end
 end

--- a/lib/docs/scrapers/babel.rb
+++ b/lib/docs/scrapers/babel.rb
@@ -1,9 +1,8 @@
 module Docs
   class Babel < UrlScraper
     self.type = 'simple'
-    self.base_url = 'http://babeljs.io/docs/'
-    self.release = '6.26.1'
-    self.initial_paths = %w(core-packages/)
+    self.base_url = 'https://babeljs.io/docs/en/'
+    self.release = '7.12.6'
     self.links = {
       home: 'https://babeljs.io/',
       code: 'https://github.com/babel/babel'
@@ -12,19 +11,28 @@ module Docs
     html_filters.push 'babel/clean_html', 'babel/entries'
 
     options[:trailing_slash] = true
-    options[:skip] = %w{setup/ editors/ community/videos/}
+
+    options[:skip_patterns] = [
+      /usage/,
+      /configuration/,
+      /learn/,
+      /v7-migration/,
+      /v7-migration-api/,
+      /editors/,
+      /presets/,
+      /caveats/,
+      /faq/,
+      /roadmap/
+    ]
 
     options[:attribution] = <<-HTML
-      &copy; 2018 Sebastian McKenzie<br>
+      &copy; 2020 Sebastian McKenzie<br>
       Licensed under the MIT License.
     HTML
-
-    stub '' do
-      '<div></div>'
-    end
 
     def get_latest_version(opts)
       get_latest_github_release('babel', 'babel', opts)
     end
+
   end
 end

--- a/lib/docs/scrapers/babel.rb
+++ b/lib/docs/scrapers/babel.rb
@@ -2,7 +2,6 @@ module Docs
   class Babel < UrlScraper
     self.type = 'simple'
     self.base_url = 'https://babeljs.io/docs/en/'
-    self.release = '7.12.6'
     self.links = {
       home: 'https://babeljs.io/',
       code: 'https://github.com/babel/babel'
@@ -29,6 +28,14 @@ module Docs
       &copy; 2020 Sebastian McKenzie<br>
       Licensed under the MIT License.
     HTML
+
+    version '7' do
+      self.release = '7.12.6'
+    end
+
+    version '6' do
+      self.release = '6.26.1'
+    end
 
     def get_latest_version(opts)
       get_latest_github_release('babel', 'babel', opts)


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
