### PR TITLE
kotlin: update release 1.4.10

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -423,7 +423,7 @@ credits = [
     'https://raw.githubusercontent.com/koajs/koa/master/LICENSE'
   ], [
     'Kotlin',
-    '2010-2019 JetBrains s.r.o.',
+    '2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors',
     'Apache',
     'https://raw.githubusercontent.com/JetBrains/kotlin/master/license/LICENSE.txt'
   ], [

--- a/lib/docs/filters/kotlin/clean_html.rb
+++ b/lib/docs/filters/kotlin/clean_html.rb
@@ -15,10 +15,14 @@ module Docs
         end
 
         css('pre').each do |node|
-          node['data-language'] = 'kotlin' if node.at_css('code[data-lang="text/x-kotlin"]')
-          node['data-language'] = 'xml' if node.at_css('code[data-lang="application/xml"]')
-          node['data-language'] = 'javascript' if node.at_css('code[data-lang="text/javascript"]')
+          node['data-language'] = 'kotlin' if node.at_css('code.language-kotlin')
+          node['data-language'] = 'groovy' if node.at_css('code.language-groovy')
+          node['data-language'] = 'javascript' if node.at_css('code.language-javascript')
+          node['data-language'] = 'xml' if node.at_css('code.language-xml')
           node.content = node.content
+          node.parent.remove_attribute('data-highlight-only')
+          node.parent.remove_attribute('data-lang')
+          node.parent.remove_attribute('theme')
         end
       end
 

--- a/lib/docs/scrapers/kotlin.rb
+++ b/lib/docs/scrapers/kotlin.rb
@@ -1,7 +1,7 @@
 module Docs
   class Kotlin < UrlScraper
     self.type = 'kotlin'
-    self.release = '1.3.41'
+    self.release = '1.4.10'
     self.base_url = 'https://kotlinlang.org/'
     self.root_path = 'api/latest/jvm/stdlib/index.html'
     self.links = {
@@ -33,7 +33,7 @@ module Docs
     }
 
     options[:attribution] = <<-HTML
-      &copy; 2010&ndash;2019 JetBrains s.r.o.<br>
+      &copy; 2010&ndash;2020 JetBrains s.r.o. and Kotlin Programming Language contributors<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Fixes #1246.