### PR TITLE
Fix TensorFlow Python frontpage

### DIFF
--- a/lib/docs/scrapers/tensorflow/tensorflow.rb
+++ b/lib/docs/scrapers/tensorflow/tensorflow.rb
@@ -2,7 +2,7 @@ module Docs
   class Tensorflow < UrlScraper
     self.name = 'TensorFlow'
     self.type = 'tensorflow'
-    self.root_path = 'all_symbols'
+    self.root_path = '/'
     self.links = {
       home: 'https://www.tensorflow.org/',
       code: 'https://github.com/tensorflow/tensorflow'

--- a/lib/docs/scrapers/tensorflow/tensorflow_cpp.rb
+++ b/lib/docs/scrapers/tensorflow/tensorflow_cpp.rb
@@ -2,7 +2,6 @@ module Docs
   class TensorflowCpp < Tensorflow
     self.name = 'TensorFlow C++'
     self.slug = 'tensorflow_cpp'
-    self.root_path = '/'
 
     version '2.3' do
       self.release = "#{version}.0"


### PR DESCRIPTION
This PR fixes the TensorFlow Python index page which is currently broken: https://devdocs.io/tensorflow~2.3/

/cc @simon04 