### PR TITLE
Update Less documentation

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -438,7 +438,7 @@ credits = [
     'https://raw.githubusercontent.com/Leaflet/Leaflet/master/LICENSE'
   ], [
     'Less',
-    '2009-2016 The Core Less Team',
+    '2009-2020 The Core Less Team',
     'CC BY',
     'https://creativecommons.org/licenses/by/3.0/'
   ], [

--- a/lib/docs/filters/less/clean_html.rb
+++ b/lib/docs/filters/less/clean_html.rb
@@ -7,7 +7,7 @@ module Docs
           node.remove
         end
 
-        css('.source-link', 'a[id$="md"]', 'br').remove
+        css('.navbar', '.source-link', 'a[id$="md"]', 'br').remove
 
         css('#functions-overview').each do |node|
           node.ancestors('.docs-section').remove

--- a/lib/docs/scrapers/less.rb
+++ b/lib/docs/scrapers/less.rb
@@ -1,7 +1,7 @@
 module Docs
   class Less < UrlScraper
     self.type = 'simple'
-    self.release = '2.7.2'
+    self.release = '3.12.0'
     self.base_url = 'http://lesscss.org'
     self.root_path = '/features'
     self.initial_paths = %w(/functions)
@@ -18,7 +18,7 @@ module Docs
     options[:trailing_slash] = false
 
     options[:attribution] = <<-HTML
-      &copy; 2009&ndash;2016 The Core Less Team<br>
+      &copy; 2009&ndash;2020 The Core Less Team<br>
       Licensed under the Creative Commons Attribution License 3.0.
     HTML
 

--- a/lib/docs/scrapers/less.rb
+++ b/lib/docs/scrapers/less.rb
@@ -1,7 +1,6 @@
 module Docs
   class Less < UrlScraper
     self.type = 'simple'
-    self.release = '3.12.0'
     self.base_url = 'http://lesscss.org'
     self.root_path = '/features'
     self.initial_paths = %w(/functions)
@@ -21,6 +20,14 @@ module Docs
       &copy; 2009&ndash;2020 The Core Less Team<br>
       Licensed under the Creative Commons Attribution License 3.0.
     HTML
+
+    version '3' do
+      self.release = '3.12.0'
+    end
+
+    version '2' do
+      self.release = '2.7.2'
+    end
 
     def get_latest_version(opts)
       doc = fetch_doc('http://lesscss.org/features/', opts)


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
