### PR TITLE
Update Jekyll documentation

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -378,7 +378,7 @@ credits = [
     'https://raw.githubusercontent.com/jasmine/jasmine/master/MIT.LICENSE'
   ], [
     'Jekyll',
-    '2008-2018 Tom Preston-Werner and Jekyll contributors',
+    '2020 Jekyll Core Team and contributors',
     'MIT',
     'https://raw.githubusercontent.com/jekyll/jekyll/master/LICENSE'
   ], [

--- a/lib/docs/filters/jekyll/entries.rb
+++ b/lib/docs/filters/jekyll/entries.rb
@@ -1,13 +1,35 @@
 module Docs
   class Jekyll
     class EntriesFilter < Docs::EntriesFilter
+      # Information for which high-level category a page belongs to only exists
+      # on the first level hierarchy. Beyond that, we have to use slug.
+      TYPE_BY_DIR = {
+        'installation' => 'Getting Started',
+        'community' => 'Getting Started',
+
+        'usage' => 'Build',
+        'configuration' => 'Build',
+        'rendering-process' => 'Build',
+
+        'liquid' => 'Site Structure',
+
+        'plugins' => 'Guides',
+        'deployment' => 'Guides',
+
+        'continuous-integration' => 'Deployment'
+      }
+
       def get_name
-        at_css('h1').content
+        if slug.split('/').first == 'step-by-step'
+          at_css('h2').content
+        else
+          at_css('h1').content
+        end
       end
 
       def get_type
-        if slug.include?('continuous-integration')
-          'Deployment'
+        if slug.split('/').first == 'step-by-step'
+          'Tutorial'
         else
           nav_link = doc.document # document
             .at_css('aside li.current') # item in navbar
@@ -18,7 +40,11 @@ module Docs
               .previous_element # header before <ul>
               .content # category
           else
-            'Miscellaneous'
+            if TYPE_BY_DIR.key?(slug.split('/').first)
+              TYPE_BY_DIR[slug.split('/').first]
+            else
+              'Miscellaneous'
+            end
           end
         end
       end

--- a/lib/docs/scrapers/jekyll.rb
+++ b/lib/docs/scrapers/jekyll.rb
@@ -1,9 +1,9 @@
 module Docs
   class Jekyll < UrlScraper
     self.type = 'jekyll'
-    self.release = '3.7.2'
+    self.release = '4.1.1'
     self.base_url = 'https://jekyllrb.com/docs/'
-    self.root_path = 'home/'
+    self.root_path = 'index.html'
     self.links = {
       home: 'https://jekyllrb.com/',
       code: 'https://github.com/jekyll/jekyll'
@@ -20,12 +20,11 @@ module Docs
       /contributing/,
     ]
     options[:replace_paths] = {
-      '' => 'home/',
-      '/' => 'home/'
+      'templates/' => 'liquid/'
     }
 
     options[:attribution] = <<-HTML
-      &copy; 2008&ndash;2018 Tom Preston-Werner and Jekyll contributors<br>
+      &copy; 2020 Jekyll Core Team and contributors<br>
       Licensed under the MIT license.
     HTML
 

--- a/lib/docs/scrapers/jekyll.rb
+++ b/lib/docs/scrapers/jekyll.rb
@@ -1,7 +1,6 @@
 module Docs
   class Jekyll < UrlScraper
     self.type = 'jekyll'
-    self.release = '4.1.1'
     self.base_url = 'https://jekyllrb.com/docs/'
     self.root_path = 'index.html'
     self.links = {
@@ -27,6 +26,14 @@ module Docs
       &copy; 2020 Jekyll Core Team and contributors<br>
       Licensed under the MIT license.
     HTML
+
+    version '4' do
+      self.release = '4.1.1'
+    end
+
+    version '3' do
+      self.release = '3.7.2'
+    end
 
     def get_latest_version(opts)
       doc = fetch_doc('https://jekyllrb.com/docs/', opts)


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
