### PR TITLE
Update Gnu Fortran to 10.2.0

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -36,6 +36,18 @@ Go to https://www.erlang.org/downloads and download the HTML documentation file.
 
 ### GCC
 ### GNU Fortran
+Go to https://gcc.gnu.org/onlinedocs/ and download the HTML tarball of Fortran manual or run the following commands to download the tarball:
+
+```sh
+wget https://gcc.gnu.org/onlinedocs/gcc-<version>/gfortran-html.tar.gz
+```
+
+Then extract the content of the tarball and move it to the devdocs directory.
+
+```sh
+tar xf <tarball>
+mv <extracted_directory> path/to/devdocs/docs/gnu_fortran~<version>/
+```
 
 ## Gnuplot
 

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -39,14 +39,9 @@ Go to https://www.erlang.org/downloads and download the HTML documentation file.
 Go to https://gcc.gnu.org/onlinedocs/ and download the HTML tarball of Fortran manual or run the following commands to download the tarball:
 
 ```sh
-wget https://gcc.gnu.org/onlinedocs/gcc-<version>/gfortran-html.tar.gz
-```
-
-Then extract the content of the tarball and move it to the devdocs directory.
-
-```sh
-tar xf <tarball>
-mv <extracted_directory> path/to/devdocs/docs/gnu_fortran~<version>/
+mkdir docs/gnu_fortran~$VERSION; \
+curl https://gcc.gnu.org/onlinedocs/gcc-$RELEASE/gfortran-html.tar.gz | \
+tar --extract --gzip --strip-components=1 --directory=docs/gnu_fortran~$VERSION
 ```
 
 ## Gnuplot

--- a/lib/docs/scrapers/gnu/gnu_fortran.rb
+++ b/lib/docs/scrapers/gnu/gnu_fortran.rb
@@ -6,6 +6,21 @@ module Docs
       home: 'https://gcc.gnu.org/fortran/'
     }
 
+    version '10' do
+      self.release = '10.2.0'
+      self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gfortran/"
+    end
+
+    version '9' do
+      self.release = '9.3.0'
+      self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gfortran/"
+    end
+
+    version '8' do
+      self.release = '8.4.0'
+      self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gfortran/"
+    end
+
     version '7' do
       self.release = '7.3.0'
       self.base_url = "https://gcc.gnu.org/onlinedocs/gcc-#{release}/gfortran/"


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
