### PR TITLE
jquery_core: update release 3.5.1

### DIFF
--- a/lib/docs/scrapers/jquery/jquery_core.rb
+++ b/lib/docs/scrapers/jquery/jquery_core.rb
@@ -1,7 +1,7 @@
 module Docs
   class JqueryCore < Jquery
     self.name = 'jQuery'
-    self.release = '3.3.1'
+    self.release = '3.5.1'
     self.base_url = 'https://api.jquery.com/'
     self.initial_paths = %w(/index/index)
     self.links = {


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
