### PR TITLE
homebrew: update release 2.5.11

### DIFF
--- a/lib/docs/filters/homebrew/clean_html.rb
+++ b/lib/docs/filters/homebrew/clean_html.rb
@@ -11,6 +11,7 @@ module Docs
 
         css('div.highlighter-rouge').each do |node|
           lang = node['class'][/language-(\w+)/, 1]
+          lang = 'bash' if lang == 'sh'
           node['data-language'] = lang if lang
           node.content = node.content.strip
           node.name = 'pre'

--- a/lib/docs/scrapers/homebrew.rb
+++ b/lib/docs/scrapers/homebrew.rb
@@ -2,7 +2,7 @@ module Docs
   class Homebrew < UrlScraper
     self.name = 'Homebrew'
     self.type = 'simple'
-    self.release = '2.1.9'
+    self.release = '2.5.11'
     self.base_url = 'https://docs.brew.sh/'
     self.links = {
       home: 'https://brew.sh',

--- a/public/icons/docs/homebrew/SOURCE
+++ b/public/icons/docs/homebrew/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/Homebrew/brew/tree/master/docs/img
+https://docs.brew.sh/assets/img/apple-touch-icon.png


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
