### PR TITLE
modernizr: update release 3.11.3

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -503,7 +503,7 @@ credits = [
     'https://creativecommons.org/licenses/by/4.0/'
   ], [
     'Modernizr',
-    '2009-2017 The Modernizr team',
+    '2009-2020 The Modernizr team',
     'MIT',
     'https://modernizr.com/license/'
   ], [

--- a/lib/docs/scrapers/modernizr.rb
+++ b/lib/docs/scrapers/modernizr.rb
@@ -2,7 +2,7 @@ module Docs
   class Modernizr < UrlScraper
     self.name = 'Modernizr'
     self.type = 'modernizr'
-    self.release = '3.5.0'
+    self.release = '3.11.3'
     self.base_url = 'https://modernizr.com/docs/'
 
     html_filters.push 'modernizr/entries', 'modernizr/clean_html', 'title'
@@ -12,7 +12,7 @@ module Docs
     options[:skip_links] = true
 
     options[:attribution] = <<-HTML
-      &copy; 2009&ndash;2017 The Modernizr team<br>
+      &copy; 2009&ndash;2020 The Modernizr team<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
