### PR TITLE
Update Gnu Cobol to 3.1

### DIFF
--- a/lib/docs/filters/gnu_cobol/clean_html.rb
+++ b/lib/docs/filters/gnu_cobol/clean_html.rb
@@ -21,7 +21,7 @@ module Docs
 
         # Remove everything after Appendix B
         # This includes the license text, the document changelog, the compiler changelog and the footnote
-        current_element = at_css('a[name="Appendix-C-_002d-GNU-Free-Documentation-License"]').previous
+        current_element = at_css('a[name="Appendix-C1-_002d-Grouped-Word-Lists-by-feature-and-function"]').previous
         until current_element.nil?
           next_element = current_element.next
           current_element.remove

--- a/lib/docs/scrapers/gnu_cobol.rb
+++ b/lib/docs/scrapers/gnu_cobol.rb
@@ -3,14 +3,16 @@ module Docs
     self.name = 'GnuCOBOL'
     self.slug = 'gnu_cobol'
     self.type = 'simple'
-    self.release = '2.2'
-    self.base_url = 'https://open-cobol.sourceforge.io/HTML/gnucobpg.html'
+    self.release = '3.1'
+    self.base_url = 'https://gnucobol.sourceforge.io/HTML/gnucobpg.html'
     self.links = {
-      home: 'https://sourceforge.net/projects/open-cobol/',
-      code: 'https://sourceforge.net/p/open-cobol/code/HEAD/tree/trunk/'
+      home: 'https://gnucobol.sourceforge.io/',
+      code: 'https://sourceforge.net/p/gnucobol/code/HEAD/tree/trunk/'
     }
 
     html_filters.push 'gnu_cobol/entries', 'gnu_cobol/clean_html'
+
+    options[:skip_links] = true
 
     options[:attribution] = <<-HTML
       Copyright &copy; 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.<br>


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
