### PR TITLE
Update Typescript to 4.0.5

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -783,7 +783,7 @@ credits = [
     'https://twig.symfony.com/license'
   ], [
     'TypeScript',
-    '2012-2019 Microsoft',
+    '2012-2020 Microsoft',
     'Apache',
     'https://raw.githubusercontent.com/Microsoft/TypeScript-Handbook/master/LICENSE'
   ], [

--- a/lib/docs/filters/typescript/clean_html.rb
+++ b/lib/docs/filters/typescript/clean_html.rb
@@ -17,6 +17,13 @@ module Docs
           node.name = 'h1'
         end
 
+        css('a:contains("Try")').remove
+        css('pre').each do |node|
+          node.content = node.content
+          node['data-language'] = 'typescript'
+          node.remove_attribute('class')
+        end
+
         # 'Next' title area
         css('.whitespace-tight').remove
 

--- a/lib/docs/filters/typescript/clean_html.rb
+++ b/lib/docs/filters/typescript/clean_html.rb
@@ -2,30 +2,31 @@ module Docs
   class Typescript
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.doc-content-container')
 
-        if root_page?
-          at_css('h1').content = 'TypeScript Documentation'
+        # Top menu bar
+        css('#top-menu').remove
+        css('.skip-to-main').remove
+
+        # Sidebar
+        css('#sidebar').remove
+
+        # Pound symbol before each title
+        css('.anchor').remove
+
+        css('#handbook-content > h2').each do |node|
+          node.name = 'h1'
         end
 
-        css('.xs-toc-container').remove
-        css('.anchor-hash').remove
+        # 'Next' title area
+        css('.whitespace-tight').remove
 
-        css('article h1').each do |node|
-          node.name = 'h2'
-        end
+        # Right side floating box
+        css('.handbook-toc').remove
 
-        css('> header', '> article').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('pre > code').each do |node|
-          node.parent['data-language'] = node['class'].sub('ts', 'typescript').sub('js', 'javascript').remove('language-') if node['class']
-          node.content = node.content.gsub('    ', '  ')
-          node.before(node.children).remove
-        end
+        css('#site-footer').remove
 
         doc
+
       end
     end
   end

--- a/lib/docs/filters/typescript/entries.rb
+++ b/lib/docs/filters/typescript/entries.rb
@@ -1,41 +1,26 @@
 module Docs
   class Typescript
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
-        name = at_css('h1').content.strip
-        name.sub! ' and ', ' & '
-        name
+        return 'Typescript' if current_url == root_url
+        return at_css('h2').content
       end
 
       def get_type
-        return 'Declaration Files' if subpath.include?('declaration-files')
-        return 'Project Configuration' if slug == 'handbook/configuring-watch'
-        type = at_css('#main-nav a.active').ancestors('.panel').first.at_css('> a').content
-        type = name if type == 'Handbook'
-        type
+        name
       end
-
-      SKIP_ENTRIES = ['Introduction', 'A note', 'A Note', ', and', 'Techniques', ' Concepts', 'Hello World', 'Working with', 'Our ', 'Implementing ', 'Difference between', 'Basic', 'sample', 'Questions', 'Example', 'Export as close', 'Red Flags', 'First steps', 'Pitfalls', 'Well-known', 'Starting out', 'Comparing ', 'Do not', 'Trade-off', ' vs', 'Overview', 'Related', 'Table of contents']
 
       def additional_entries
-        return [] unless slug.start_with?('handbook')
-        return [] if slug.include?('release-notes')
-        return [] if slug == 'handbook/writing-definition-files'
+        entries = []
 
-        css('.post-content h1, .post-content h2').each_with_object [] do |node, entries|
-          next if node.next_element.try(:name) == 'h2'
-          node.css('.anchor-hash').remove
-          name = node.content.strip
-          next if name.length > 40
-          next if name == self.name || SKIP_ENTRIES.any? { |str| name.include?(str) }
-          name.remove! %r{\A#{self.name.remove(/s\z/)}s? }
-          name.sub! 'for..of', 'for...of'
-          name.remove! 'Symbol.'
-          name.remove! '/// '
-          name.prepend "#{self.name}: "
-          entries << [name, node['id']]
+        css('h2').each do |node|
+            entries << [node.content, node['id'], name]
         end
+
+        entries
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/typescript.rb
+++ b/lib/docs/scrapers/typescript.rb
@@ -2,9 +2,9 @@ module Docs
   class Typescript < UrlScraper
     self.name = 'TypeScript'
     self.type = 'simple'
-    self.release = '3.7.4'
-    self.base_url = 'https://www.typescriptlang.org/docs/'
-    self.root_path = 'tutorial.html'
+    self.release = '4.0.5'
+    self.base_url = 'https://www.typescriptlang.org/docs/handbook'
+    self.root_path = 'index.html'
     self.links = {
       home: 'https://www.typescriptlang.org',
       code: 'https://github.com/Microsoft/TypeScript'
@@ -12,16 +12,27 @@ module Docs
 
     html_filters.push 'typescript/entries', 'typescript/clean_html'
 
-    options[:container] = '#doc-content'
-    options[:skip] = %w(home.html handbook/release-notes/overview.html)
-    options[:skip_link] = ->(node) { node.parent.parent['class'] == 'dropdown-menu' }
-    options[:fix_urls] = ->(url) {
-      url.sub!(/(\w+)\.md/) { "#{$1.downcase}.html" }
-      url
-    }
+    options[:skip] = [
+      '/react-&-webpack.html',
+      '/asp-net-core.html',
+      '/gulp.html',
+      '/dom-manipulation.html',
+      '/migrating-from-javascript.html',
+      '/babel-with-typescript.html',
+      '/intro.html'
+    ]
+
+    options[:skip_patterns] = [
+      /2/,
+      /typescript-/,
+      /release-notes/,
+      /introduction/,
+      /tutorials/,
+      /intro.html/
+    ]
 
     options[:attribution] = <<-HTML
-      &copy; 2012-2019 Microsoft<br>
+      &copy; 2012-2020 Microsoft<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
