### PR TITLE
Update QT documentation

### DIFF
--- a/lib/docs/scrapers/qt.rb
+++ b/lib/docs/scrapers/qt.rb
@@ -103,29 +103,39 @@ module Docs
       Licensed under the GNU Free Documentation License, Version 1.3.
     HTML
 
+    version '5.15' do
+      self.release = '5.15'
+      self.base_url = "https://doc.qt.io/qt-#{self.release}/"
+    end
+
+    version '5.14' do
+      self.release = '5.14'
+      self.base_url = "https://doc.qt.io/qt-#{self.release}/"
+    end
+
     version '5.13' do
       self.release = '5.13'
-      self.base_url = 'https://doc.qt.io/qt-5.13/'
+      self.base_url = "https://doc.qt.io/archives/qt-#{self.release}/"
     end
 
     version '5.12' do
       self.release = '5.12'
-      self.base_url = 'https://doc.qt.io/qt-5.12/'
+      self.base_url = "https://doc.qt.io/archivex/qt-#{self.release}/"
     end
 
     version '5.11' do
       self.release = '5.11'
-      self.base_url = 'https://doc.qt.io/archives/qt-5.11/'
+      self.base_url = "https://doc.qt.io/archives/qt-#{self.release}/"
     end
 
     version '5.9' do
       self.release = '5.9'
-      self.base_url = 'https://doc.qt.io/qt-5.9/'
+      self.base_url = "https://doc.qt.io/archives/qt-#{self.release}/"
     end
 
     version '5.6' do
       self.release = '5.6'
-      self.base_url = 'https://doc.qt.io/archives/qt-5.6/'
+      self.base_url = "https://doc.qt.io/archives/qt-#{self.release}/"
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good