### PR TITLE
numpy: add versions 1.18 and 1.19

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -573,7 +573,7 @@ credits = [
     'https://raw.githubusercontent.com/npm/npm/master/LICENSE'
   ], [
     'NumPy',
-    '2005-2019 NumPy Developers',
+    '2005-2020 NumPy Developers',
     'BSD',
     'https://raw.githubusercontent.com/numpy/numpy/master/LICENSE.txt'
   ], [

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -108,6 +108,12 @@ $GS = '/usr/local/opt/ghostscript/bin/gs';	# GhostScript
 
 ## NumPy
 
+```sh
+mkdir --parent docs/numpy~$VERSION/; \
+curl https://numpy.org/doc/$VERSION/numpy-html.zip | \
+bsdtar --extract --file=- --directory=docs/numpy~$VERSION/
+```
+
 ## OCaml
 
 Download from https://www.ocaml.org/docs/ the HTML reference:

--- a/lib/docs/filters/numpy/entries.rb
+++ b/lib/docs/filters/numpy/entries.rb
@@ -14,10 +14,10 @@ module Docs
       def get_type
         nav_items = css('.nav.nav-pills.pull-left > li')
 
-        if nav_items[3]
-          type = nav_items[3].content
-        elsif nav_items[2] && nav_items[2].content !~ /Manual|Reference/
-          type = nav_items[2].content
+        if nav_items[5]
+          type = nav_items[5].content
+        elsif nav_items[4] && nav_items[4].content !~ /Manual|Reference/
+          type = nav_items[4].content
         else
           type = at_css('h1').content.strip
           type.remove! "\u{00B6}"
@@ -29,7 +29,7 @@ module Docs
             type = 'Universal functions'
           elsif type.start_with?('numpy.nditer.') || type.start_with?('numpy.lib.Arrayterator.') || type.start_with?('numpy.flatiter.')
             type = 'Indexing routines'
-          elsif type.start_with?('numpy.record.') || type.start_with?('numpy.recarray.') || type.start_with?('numpy.broadcast.') || type.start_with?('numpy.matrix.')
+          elsif type.start_with?('numpy.record.') || type.start_with?('numpy.recarray.') || type.start_with?('numpy.broadcast.') || type.start_with?('numpy.matrix.') || type.start_with?('numpy.ma.')
             type = 'Standard array subclasses'
           elsif type.start_with?('numpy.busdaycalendar.')
             type = 'Datetime support functions'
@@ -41,9 +41,9 @@ module Docs
             type = 'Data type objects'
           elsif type.start_with?('numpy.generic.')
             type = 'Scalars'
-          elsif type.start_with?('numpy.char.chararray.') || type.start_with?('numpy.core.defchararray.chararray.')
+          elsif type.start_with?('numpy.chararray.') || type.start_with?('numpy.char.chararray.') || type.start_with?('numpy.core.defchararray.chararray.')
             type = 'String operations'
-          elsif type == 'numpy.memmap.shape'
+          elsif type.start_with?('numpy.memmap.')
             type = 'Input and output'
           elsif type == 'numpy.poly1d.variable'
             type = 'Polynomials'

--- a/lib/docs/scrapers/numpy.rb
+++ b/lib/docs/scrapers/numpy.rb
@@ -17,13 +17,24 @@ module Docs
 
     options[:skip_patterns] = [
       /.*(?<!\.html)\z/,
+      /\Arelease\/.*-notes.html\Z/,
       /\Agenerated\/numpy\.chararray\.[\w\-]+.html\z/ # duplicate
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2005&ndash;2019 NumPy Developers<br>
+      &copy; 2005&ndash;2020 NumPy Developers<br>
       Licensed under the 3-clause BSD License.
     HTML
+
+    version '1.19' do
+      self.release = '1.19.0'
+      self.base_url = "https://numpy.org/doc/#{self.version}/"
+    end
+
+    version '1.18' do
+      self.release = '1.18.5'
+      self.base_url = "https://numpy.org/doc/#{self.version}/"
+    end
 
     version '1.17' do
       self.release = '1.17.0'

--- a/public/icons/docs/numpy/SOURCE
+++ b/public/icons/docs/numpy/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/numpy/numpy/blob/master/branding/icons/numpylogoicon.svg
+https://github.com/numpy/numpy/blob/master/doc/source/_static/numpylogo.svg


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

The entries need some additional cleanup…

![Screenshot_2020-11-19 NumPy 1 18 documentation — DevDocs](https://user-images.githubusercontent.com/782446/99721800-03206f00-2ab0-11eb-91de-e41a74f4d510.png)

Fixes #1352.