### PR TITLE
Update haskell version  8 to 8.10.2

### DIFF
--- a/lib/docs/scrapers/haskell.rb
+++ b/lib/docs/scrapers/haskell.rb
@@ -13,6 +13,7 @@ module Docs
     options[:container] = ->(filter) {filter.subpath.start_with?('users_guide') ? '.body' : '#content'}
 
     options[:only_patterns] = [/\Alibraries\//, /\Ausers_guide\//]
+
     options[:skip_patterns] = [
       /-notes/,
       /editing-guide/,
@@ -36,6 +37,7 @@ module Docs
       /Data-Map-Internal\.html\z/i,
       /Data-Sequence-Internal\.html\z/i
     ]
+
     options[:skip] = %w(
       users_guide/license.html
       users_guide/genindex.html
@@ -57,7 +59,7 @@ module Docs
     end
 
     version '8' do
-      self.release = '8.8.3'
+      self.release = '8.10.2'
       self.base_url = "https://downloads.haskell.org/~ghc/#{release}/docs/html/"
     end
 
@@ -75,5 +77,6 @@ module Docs
       versions = links.map {|link| link['href'].scan(/ghc-([0-9.]+)/)}
       versions.find {|version| !version.empty?}[0][0]
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
