### PR TITLE
Update Dart version 2 to 2.10.4

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -20,6 +20,12 @@ Click the “API docs” link under the “Stable channel” header on
 https://www.dartlang.org/tools/sdk/archive. Rename the expanded ZIP to `dart~2`
 and put it in `/path/to/devdocs/docs/`
 
+Or run the following commands in your terminal:
+
+```sh
+curl https://storage.googleapis.com/dart-archive/channels/stable/release/$RELEASE/api-docs/dartdocs-gen-api-zip > dartApi.zip; \
+unzip dartApi.zip; mv gen-dartdocs docs/dart~$VERSION
+```
 ## Django
 
 Go to https://docs.djangoproject.com/, select the version from the

--- a/lib/docs/scrapers/dart.rb
+++ b/lib/docs/scrapers/dart.rb
@@ -21,7 +21,7 @@ module Docs
     HTML
 
     version '2' do
-      self.release = '2.5.0'
+      self.release = '2.10.4'
       self.base_url = "https://api.dart.dev/stable/#{release}/"
     end
 
@@ -31,9 +31,10 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://api.dartlang.org/', opts)
+      doc = fetch_doc('https://api.dart.dev/', opts)
       label = doc.at_css('footer > span').content.strip
       label.sub(/Dart\s*/, '')
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
