### PR TITLE
d: update release 2.094.2

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -218,7 +218,7 @@ credits = [
     'https://raw.githubusercontent.com/cypress-io/cypress-documentation/develop/LICENSE.md'
   ], [
     'D',
-    '1999-2019 The D Language Foundation',
+    '1999-2020 The D Language Foundation',
     'Boost',
     'https://raw.githubusercontent.com/dlang/phobos/master/LICENSE_1_0.txt'
   ], [

--- a/lib/docs/scrapers/d.rb
+++ b/lib/docs/scrapers/d.rb
@@ -2,7 +2,7 @@ module Docs
   class D < UrlScraper
     include MultipleBaseUrls
 
-    self.release = '2.088.0'
+    self.release = '2.094.2'
     self.type = 'd'
     self.base_urls = ['https://dlang.org/phobos/', 'https://dlang.org/spec/']
     self.root_path = 'index.html'
@@ -19,7 +19,7 @@ module Docs
     options[:title] = false
 
     options[:attribution] = <<-HTML
-      &copy; 1999&ndash;2019 The D Language Foundation<br>
+      &copy; 1999&ndash;2020 The D Language Foundation<br>
       Licensed under the Boost License 1.0.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
