### PR TITLE
webpack: add version 4.44 and 5.6

### DIFF
--- a/lib/docs/filters/webpack/clean_html.rb
+++ b/lib/docs/filters/webpack/clean_html.rb
@@ -2,47 +2,27 @@ module Docs
   class Webpack
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.page__content')
-
         at_css('h1').content = 'webpack' if root_page?
 
-        css('h3').each do |node|
-          node.name = 'h2'
-        end unless at_css('h2')
-
-        css('.anchor[id]').each do |node|
-          node.parent['id'] = node['id']
-          node.remove
-        end
-
         css('hr', '.page__edit', 'hr + h3:contains("Contributors")', 'hr + h2:contains("Contributors")',
-            '.contributors', '.icon-link', '#maintainers.header', '#maintainers.header + table',
-            '#maintainer.header', '#maintainer.header + table', '.page-links__link', '.page-links__gap').remove
+            'td > .title', '.adjacent-links', '.contributors', '.icon-link',
+            '#maintainers', '#maintainers + table',
+            '#maintainer', '#maintainer + table',
+            '.page-links__link', '.page-links__gap').remove
 
         css('> div', '.tip-content', '.header span').each do |node|
           node.before(node.children).remove
         end
 
-        css('> h1:first-child + h1').remove
-
-        css('.code-details-summary-span').each do |node|
-          node.content = node.content.remove(' (click to show)')
-        end
-
-        css('.table-wrap').each do |node|
-          css('.table-td-title').remove
-          css('.table-th').each { |n| n.name = 'th' }
-          css('.table-td').each { |n| n.name = 'td' }
-          css('.table-tr').each { |n| n.name = 'tr' }
-          css('.table-body').each { |n| n.name = 'tbody' }
-          css('.table-header').each { |n| n.name = 'thead' }
-          node.name = 'table'
-        end
-
         css('pre > code').each do |node|
-          node.parent['data-language'] = node['class'][/lang-(\w+)/, 1].sub('jsx', 'js') if node['class']
+          node.parent['data-language'] = 'js'
+          node.parent['data-language'] = node['class'][/language-(\w+)/, 1].sub('jsx', 'js') if node['class'] && node['class'][/language-(\w+)/, 1]
           node.parent.content = node.parent.content
         end
+
+        # for webpack-contrib /loaders and /plugins
+        shields = at_css('img[src*="shields.io"]')
+        shields.ancestors('p')[0].remove if shields
 
         doc
       end

--- a/lib/docs/scrapers/webpack.rb
+++ b/lib/docs/scrapers/webpack.rb
@@ -3,49 +3,46 @@ module Docs
     self.name = 'webpack'
     self.type = 'webpack'
 
-    version do
-      self.release = '4.16.5'
+    self.root_path = 'guides/'
+    self.initial_paths = %w(
+      concepts/
+      guides/
+      api/
+      configuration/
+      loaders/
+      plugins/
+    )
+    self.links = {
+      home: 'https://webpack.js.org/',
+      code: 'https://github.com/webpack/webpack'
+    }
+
+    html_filters.push 'webpack/clean_html', 'webpack/entries'
+
+    options[:container] = '.page'
+    options[:trailing_slash] = false
+    options[:only_patterns] = [
+      /\Aconcepts\//,
+      /\Aguides\//,
+      /\Aapi\//,
+      /\Aconfiguration\//,
+      /\Aloaders\//,
+      /\Aplugins\//
+    ]
+
+    options[:attribution] = <<-HTML
+      &copy; JS Foundation and other contributors<br>
+      Licensed under the Creative Commons Attribution License 4.0.
+    HTML
+
+    version '5' do
+      self.release = '5.6.0'
       self.base_url = 'https://webpack.js.org/'
-      self.root_path = 'guides/'
-      self.initial_paths = %w(
-        concepts/
-        guides/
-        api/
-        configuration/
-        loaders/
-        plugins/
-      )
-      self.links = {
-        home: 'https://webpack.js.org/',
-        code: 'https://github.com/webpack/webpack'
-      }
+    end
 
-      html_filters.push 'webpack/clean_html', 'webpack/entries'
-
-      options[:container] = '.page'
-      options[:trailing_slash] = false
-      options[:only_patterns] = [
-        /\Aconcepts\//,
-        /\Aguides\//,
-        /\Aapi\//,
-        /\Aconfiguration\//,
-        /\Aloaders\//,
-        /\Aplugins\//
-      ]
-
-      options[:attribution] = <<-HTML
-        &copy; JS Foundation and other contributors<br>
-        Licensed under the Creative Commons Attribution License 4.0.
-      HTML
-
-      ([self.root_path] + self.initial_paths).each do |path|
-        stub(path) do
-          capybara = load_capybara_selenium
-          capybara.app_host = self.base_url.origin
-          capybara.visit("#{self.base_url}#{path}")
-          capybara.execute_script('return document.body.innerHTML')
-        end
-      end
+    version '4' do
+      self.release = '4.44.2'
+      self.base_url = 'https://v4.webpack.js.org/'
     end
 
     version '1' do


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
