### PR TITLE
Update Rust to 1.48.0, fix 'notable trait' display

### DIFF
--- a/lib/docs/filters/rust/clean_html.rb
+++ b/lib/docs/filters/rust/clean_html.rb
@@ -97,6 +97,22 @@ module Docs
           node.previous_element.before(node)
         end
 
+        css('.collapse-toggle').remove
+
+        # Fix how notable-traits sections are shown
+
+        css('.method').each do |node|
+          traitSection = node.at_css('.notable-traits')
+
+          if traitSection
+            traitSectionContent = traitSection.css('.notable-traits-tooltiptext')
+            traitSection.css('.notable-traits-tooltip').remove
+            traitSection.add_child(traitSectionContent)
+            node.after(traitSection)
+          end
+
+        end
+
         doc
       end
     end

--- a/lib/docs/filters/rust/clean_html.rb
+++ b/lib/docs/filters/rust/clean_html.rb
@@ -71,19 +71,6 @@ module Docs
         doc.first_element_child.name = 'h1' if doc.first_element_child.name = 'h2'
         at_css('h1').content = 'Rust Documentation' if root_page?
 
-        css('.table-display').each do |node|
-          node.css('td').each do |td|
-            node.before(td.children)
-          end
-          node.remove
-        end
-
-        css('.important-traits').to_a.each_with_index do |node, index|
-          content = node.at_css('.content.hidden .content')
-          node.at_css('.content.hidden').replace(content) if content
-          node.parent.after(node) if node.parent.name.in?(%(h2 h3 h4))
-        end
-
         css('code.content').each do |node|
           node.name = 'pre'
           node.css('.fmt-newline').each do |line|
@@ -96,6 +83,8 @@ module Docs
         css('.since + .srclink').each do |node|
           node.previous_element.before(node)
         end
+
+        css('.sidebar').remove
 
         css('.collapse-toggle').remove
 

--- a/lib/docs/filters/rust/entries.rb
+++ b/lib/docs/filters/rust/entries.rb
@@ -1,9 +1,11 @@
 module Docs
   class Rust
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
         if slug.start_with?('book') || slug.start_with?('reference')
-          at_css("#sidebar a[href='#{File.basename(slug)}']").content
+          name = at_css("#sidebar a[href='#{File.basename(slug)}']")
+          name ? name.content : 'Introduction'
         elsif slug == 'error-index'
           'Compiler Errors'
         else
@@ -51,6 +53,7 @@ module Docs
             }.values
         end
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/rust.rb
+++ b/lib/docs/scrapers/rust.rb
@@ -3,12 +3,11 @@
 module Docs
   class Rust < UrlScraper
     self.type = 'rust'
-    self.release = '1.47.0'
+    self.release = '1.48.0'
     self.base_url = 'https://doc.rust-lang.org/'
     self.root_path = 'book/index.html'
     self.initial_paths = %w(
       reference/introduction.html
-      collections/index.html
       std/index.html
       error-index.html)
     self.links = {


### PR DESCRIPTION
Fixes #1360 

- Modified "notable traits" sections to improve how are displayed in the dom.
- Fixes error in reference/introduction.html while scraping.