### PR TITLE
Update Express to 4.17.1

### DIFF
--- a/lib/docs/scrapers/express.rb
+++ b/lib/docs/scrapers/express.rb
@@ -2,7 +2,7 @@ module Docs
   class Express < UrlScraper
     self.name = 'Express'
     self.type = 'express'
-    self.release = '4.16.3'
+    self.release = '4.17.1'
     self.base_url = 'http://expressjs.com/en/'
     self.root_path = '4x/api.html'
     self.initial_paths = %w(


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
