### PR TITLE
Update Phalcon version 3 and add Phalcon version 4

### DIFF
--- a/lib/docs/filters/phalcon/clean_html.rb
+++ b/lib/docs/filters/phalcon/clean_html.rb
@@ -2,45 +2,24 @@ module Docs
   class Phalcon
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.body')
 
-        if root_page?
-          at_css('h1').content = 'Phalcon'
-        end
+        # left navigation bar
+        css('.doc-article-nav-wr').remove
 
-        css('#what-is-phalcon', '#other-formats').remove
+        # right navigation bar
+        css('.phalcon-blog__right-item').remove
 
-        css('#methods > p > strong, #constants > p > strong').each do |node|
-          node.parent.name = 'h3'
-          node.parent['id'] = node.content.parameterize
-          node.parent['class'] = 'method-signature'
-          node.parent.inner_html = node.parent.inner_html.sub(/inherited from .*/, '<small>\0</small>')
-        end
+        css('header').remove
 
-        css('.headerlink').each do |node|
-          id = node['href'][1..-1]
-          node.parent['id'] ||= id
-          node.remove
-        end
+        css('footer').remove
 
-        css('div[class^="highlight-"]').each do |node|
-          code = node.at_css('pre').content
-          code.remove! %r{\A\s*<\?php\s*} unless code.include?(' ?>')
-          node.content = code
-          node.name = 'pre'
-          node['data-language'] = node['class'][/highlight-(\w+)/, 1]
-          node['data-language'] = 'php' if node['data-language'] == 'html+php'
-        end
-
-        css('.section').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('table[border]').each do |node|
-          node.remove_attribute('border')
+        # initial table of contents
+        if !(slug=='index')
+          css('.docSearch-content > ul').remove
         end
 
         doc
+
       end
     end
   end

--- a/lib/docs/filters/phalcon/entries.rb
+++ b/lib/docs/filters/phalcon/entries.rb
@@ -1,32 +1,28 @@
 module Docs
   class Phalcon
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
-        (at_css('h1 > strong') || at_css('h1')).content.strip.remove('Phalcon\\')
+        return 'Phalcon' if slug == 'index'
+        at_css('h1').content.gsub(/\bClass\b|\bAbstract\b|\bFinal\b|Phalcon\\|\bInterface\b/i, '').strip
       end
 
       def get_type
-        if slug.start_with?('reference')
-          'Guides'
-        else
-          path = name.split('\\')
-          path[0] == 'Mvc' ? path[0..1].join('\\') : path[0]
-        end
+        name
       end
 
       def additional_entries
         entries = []
 
-        css('.method-signature').each do |node|
-          next if node.content.include?('inherited from') || node.content.include?('protected ') || node.content.include?('private ')
-          name = node.at_css('strong').content.strip
-          next if name == '__construct' || name == '__toString'
-          name.prepend "#{self.name}::"
-          entries << [name, node['id']]
+        css('h1').each do |node|
+          entrie_name = node.content.gsub(/\bClass\b|\bAbstract\b|\bFinal\b|Phalcon\\|\bInterface\b/i, '').strip
+          next if entrie_name == name
+          entries << [entrie_name, node['id'], name]
         end
 
         entries
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/phalcon.rb
+++ b/lib/docs/scrapers/phalcon.rb
@@ -10,29 +10,75 @@ module Docs
     html_filters.push 'phalcon/clean_html', 'phalcon/entries'
 
     options[:root_title] = 'Phalcon'
-    options[:only_patterns] = [/reference\//, /api\//]
-    options[:skip] = %w(
-      api/index.html
-      reference/license.html)
 
     options[:attribution] = <<-HTML
       &copy; 2011&ndash;2017 Phalcon Framework Team<br>
       Licensed under the Creative Commons Attribution License 3.0.
     HTML
 
-    version '3' do
-      self.release = '3.1.1'
-      self.base_url = 'https://docs.phalconphp.com/en/latest/'
+    options[:trailing_slash] = true
+
+    version '4' do
+      self.release = '4.0'
+      self.base_url = "https://docs.phalcon.io/#{self.release}/en/api"
     end
 
-    version '2' do
-      self.release = '2.0.13'
-      self.base_url = 'https://docs.phalconphp.com/en/2.0.0/'
+    version '3' do
+      self.release = '3.4'
+      self.base_url = "https://docs.phalcon.io/#{self.release}/en/api"
+
+      options[:fix_urls] = -> (url) do
+        url.sub!('Phalcon_Application_Exception', 'Phalcon_Application')
+        url.sub!('Phalcon_CryptInterface', 'Phalcon_Crypt')
+        url.sub!('Phalcon_Crypt_Mismatch', 'Phalcon_Crypt')
+        url.sub!('Phalcon_Crypt_Exception', 'Phalcon_Crypt')
+        url.sub!('Phalcon_EscaperInterface', 'Phalcon_Escaper')
+        url.sub!('Phalcon_Loader_Exception', 'Phalcon_Loader')
+        url.sub!('Phalcon_Mvc_CollectionInterface', 'Phalcon_Mvc_Collection')
+        url.sub!('Phalcon_Mvc_Collection_ManagerInterface', 'Phalcon_Mvc_Collection')
+        url.sub!('Phalcon_Mvc_Collection_BehaviorInterface', 'Phalcon_Mvc_Collection')
+        url.sub!('Phalcon_Mvc_Collection_Behavior', 'Phalcon_Mvc_Collection')
+        url.sub!('Phalcon_Mvc_ControllerInterface', 'Phalcon_Mvc_Controller')
+        url.sub!('Phalcon_Mvc_DispatcherInterface', 'Phalcon_Mvc_Dispatcher')
+        url.sub!('Phalcon_Mvc_Micro_Collection', 'Phalcon_Mvc_Micro')
+        url.sub!('Phalcon_Mvc_Micro_CollectionInterface', 'Phalcon_Mvc_Micro')
+        url.sub!('Phalcon_Mvc_ModelInterface', 'Phalcon_Mvc_Model')
+        url.sub!('Phalcon_Mvc_BehaviorInterface', 'Phalcon_Mvc_Behavior')
+        url.sub!('Phalcon_Mvc_Model_BinderInterface', 'Phalcon_Mvc_Model_Binder')
+        url.sub!('Phalcon_Mvc_Model_Managerinterface', 'Phalcon_Mvc_Model_Manager')
+        url.sub!('Phalcon_Mvc_Model_MessageInterface', 'Phalcon_Mvc_Model_Message')
+        url.sub!('Phalcon_Mvc_Model_QueryInterface', 'Phalcon_Mvc_Model_Query')
+        url.sub!('Phalcon_Mvc_Model_Query_StatusInterface', 'Phalcon_Mvc_Model_Query')
+        url.sub!('Phalcon_Mvc_Model_Query_Builder', 'Phalcon_Mvc_Model_Query')
+        url.sub!('Phalcon_Mvc_Model_Query_BuilderInterface', 'Phalcon_Mvc_Model_Query')
+        url.sub!('Phalcon_Mvc_Model_RelationInterface', 'Phalcon_Mvc_Model_Relation')
+        url.sub!('Phalcon_Mvc_Model_ResulsetInterface', 'Phalcon_Mvc_Model_Resulset')
+        url.sub!('Phalcon_Mvc_Model_Resulset_Simple', 'Phalcon_Mvc_Model_Resulset')
+        url.sub!('Phalcon_Mvc_Model_TransactionInterface', 'Phalcon_Mvc_Model_Transaction')
+        url.sub!('Phalcon_Mvc_Model_Transaction_ManagerInterface', 'Phalcon_Mvc_Model_Transaction')
+        url.sub!('Phalcon_Mvc_Model_Transaction_Exception', 'Phalcon_Mvc_Model_Transaction')
+        url.sub!('Phalcon_Mvc_Model_ValidatorInterface', 'Phalcon_Mvc_Model_Validator')
+        url.sub!('Phalcon_Mvc_Router_RouteInterface', 'Phalcon_Mvc_Router')
+        url.sub!('Phalcon_Mvc_RouterInterface', 'Phalcon_Mvc_Router')
+        url.sub!('Phalcon_Mvc_Router_Route', 'Phalcon_Mvc_Router')
+        url.sub!('Phalcon_Mvc_Router_GroupInterface', 'Phalcon_Mvc_Router')
+        url.sub!('Phalcon_Mvc_UrlInterface', 'Phalcon_Mvc_Url')
+        url.sub!('Phalcon_Mvc_ViewBaseInterface', 'Phalcon_Mvc_View')
+        url.sub!('Phalcon_Mvc_ViewInterface', 'Phalcon_Mvc_View')
+        url.sub!('Phalcon_Mvc_View_EngineInterface', 'Phalcon_Mvc_View')
+        url.sub!('Phalcon_Mvc_View_Engine', 'Phalcon_Mvc_View')
+        url.sub!('Phalcon_Mvc_View_Exception', 'Phalcon_Mvc_View')
+        url.sub!('Phalcon_Queue_Beanstalk', 'Phalcon_Queue')
+        url
+      end
+
     end
 
     def get_latest_version(opts)
       doc = fetch_doc('https://docs.phalconphp.com/', opts)
-      doc.at_css('.header__lang.expand > div > ul > li > a').content
+      doc.css('.header-dropdown-wrapper').remove
+      doc.at_css('.header__right > .header__lang').content.strip
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Note that version 2 was removed because its documentation pages are no longer available.