### PR TITLE
parse_cf_email.rb: fix URI.unescape is obsolete

### DIFF
--- a/lib/docs/filters/core/parse_cf_email.rb
+++ b/lib/docs/filters/core/parse_cf_email.rb
@@ -12,7 +12,7 @@ module Docs
           result += "%" + "0#{("0x#{slice.join}".hex ^ mask).to_s(16)}"[-2..-1]
         end
 
-        node.replace(URI.decode(result))
+        node.replace(URI.decode_www_form_component(result))
       end
 
       doc

--- a/test/lib/docs/filters/core/parse_cf_email_test.rb
+++ b/test/lib/docs/filters/core/parse_cf_email_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+require 'docs'
+
+class ParseCfEmailFilterTest < MiniTest::Spec
+  include FilterTestHelper
+  self.filter_class = Docs::ParseCfEmailFilter
+
+  before do
+    context[:url] = 'http://example.com/dir/file'
+  end
+
+  it 'rewrites parses CloudFlare mail addresses' do
+    href = 'b3dddad0d6d2ddd7c0dadec3dfd6f3d6cbd2dec3dfd69dd0dcde'
+    @body = %(<a class="__cf_email__" data-cfemail="#{href}">Link</a>)
+    assert_equal 'niceandsimple@example.com', filter_output_string
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/freeCodeCamp/devdocs/issues/1299