### PR TITLE
Minor fix to Knockout documentation

### DIFF
--- a/lib/docs/filters/knockout/entries.rb
+++ b/lib/docs/filters/knockout/entries.rb
@@ -18,6 +18,7 @@ module Docs
         name = at_css('h1').content.strip
         name.remove! 'The '
         name.sub! %r{"(.+?)"}, '\1'
+        name.sub! %r{"(.+?)"}, '\1'
         name.gsub!(/ [A-Z]/) { |str| str.downcase! }
         name
       end
@@ -27,10 +28,12 @@ module Docs
           'Observables'
         elsif slug =~ /component/i
           'Components'
-        elsif slug.include?('binding') && !name.end_with?('binding')
-          'Binding'
         elsif slug.include? 'binding'
-          'Bindings'
+          if at_css('#purpose')
+            'Bindings'
+          else
+            'Binding'
+          end
         elsif slug.include? 'plugin'
           'Plugins'
         else


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
