### PR TITLE
Update Koa documentation

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -423,7 +423,7 @@ credits = [
     'https://raw.githubusercontent.com/knockout/knockout/master/LICENSE'
   ], [
     'Koa',
-    '2018 Koa contributors',
+    '2020 Koa contributors',
     'MIT',
     'https://raw.githubusercontent.com/koajs/koa/master/LICENSE'
   ], [

--- a/lib/docs/scrapers/koa.rb
+++ b/lib/docs/scrapers/koa.rb
@@ -3,7 +3,7 @@
 module Docs
   class Koa < Github
     self.base_url = 'https://github.com/koajs/koa/blob/master/docs/'
-    self.release = '2.6.1'
+    self.release = '2.13.0'
 
     self.root_path = 'api/index.md'
     self.initial_paths = %w[
@@ -30,8 +30,13 @@ module Docs
     options[:trailing_slash] = false
     options[:container] = '.markdown-body'
 
+    options[:fix_urls] = ->(url) do
+      url.sub! 'https://koajs.com/#error-handling', Koa.base_url + '/error-handling.md'
+      url
+    end
+
     options[:attribution] = <<-HTML
-      &copy; 2018 Koa contributors<br>
+      &copy; 2020 Koa contributors<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/master/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
