### PR TITLE
Add Julia version 1.5.3

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -408,7 +408,7 @@ credits = [
     'https://raw.githubusercontent.com/jquery/api.jqueryui.com/master/LICENSE.txt'
   ], [
     'Julia',
-    '2009-2019 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors',
+    '2009-2020 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors',
     'MIT',
     'https://raw.githubusercontent.com/JuliaLang/julia/master/LICENSE.md'
   ], [

--- a/lib/docs/filters/julia/clean_html.rb
+++ b/lib/docs/filters/julia/clean_html.rb
@@ -4,11 +4,19 @@ module Docs
       def call
         css('> header', '> footer').remove
 
+        # Julia 1.4+ uses different HTML
+        at_css('h1').content = at_css('h1').content
+
+        if at_css('#documenter-page')
+          @doc.children = at_css('#documenter-page').children
+        end
+        # End 1.4+ specific cleaning
+
         css('.docstring', 'div:not([class])').each do |node|
           node.before(node.children).remove
         end
 
-        css('.docstring-header').each do |node|
+        css('.docstring-header', 'header').each do |node|
           node.name = 'h3'
           node.children.each { |child| child.remove if child.text? }
           node.remove_attribute('class')

--- a/lib/docs/scrapers/julia.rb
+++ b/lib/docs/scrapers/julia.rb
@@ -22,6 +22,28 @@ module Docs
       options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
     end
 
+    version '1.4' do
+      self.release = '1.4.2'
+      self.base_url = "https://docs.julialang.org/en/v#{release}/"
+      self.type = 'julia'
+
+      html_filters.push 'julia/entries', 'julia/clean_html'
+
+      options[:container] = '.docs-main'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
+    end
+
+    version '1.3' do
+      self.release = '1.3.1'
+      self.base_url = "https://docs.julialang.org/en/v#{release}/"
+      self.type = 'julia'
+
+      html_filters.push 'julia/entries', 'julia/clean_html'
+
+      options[:container] = '#docs'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
+    end
+
     version '1.2' do
       self.release = '1.2.0'
       self.base_url = "https://docs.julialang.org/en/v#{release}/"

--- a/lib/docs/scrapers/julia.rb
+++ b/lib/docs/scrapers/julia.rb
@@ -7,9 +7,20 @@ module Docs
 
 
     options[:attribution] = <<-HTML
-      &copy; 2009&ndash;2019 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors<br>
+      &copy; 2009&ndash;2020 Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors<br>
       Licensed under the MIT License.
     HTML
+
+    version '1.5' do
+      self.release = '1.5.3'
+      self.base_url = "https://docs.julialang.org/en/v#{release}/"
+      self.type = 'julia'
+
+      html_filters.push 'julia/entries', 'julia/clean_html'
+
+      options[:container] = '.docs-main'
+      options[:only_patterns] = [/\Amanual\//, /\Abase\//, /\Astdlib\//]
+    end
 
     version '1.2' do
       self.release = '1.2.0'


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
