### PR TITLE
Fix 'notable traits' sections

### DIFF
--- a/lib/docs/filters/rust/clean_html.rb
+++ b/lib/docs/filters/rust/clean_html.rb
@@ -27,6 +27,18 @@ module Docs
           end
         end
 
+        # Fix notable trait sections
+        css('.method, .rust.trait').each do |node|
+          traitSection = node.at_css('.notable-traits')
+
+          if traitSection
+            traitSectionContent = traitSection.css('.notable-traits-tooltiptext')
+            traitSection.css('.notable-traits-tooltip').remove
+            traitSection.add_child(traitSectionContent)
+            node.after(traitSection)
+          end
+        end
+
         css('.rusttest', '.test-arrow', 'hr').remove
 
         css('.docblock.attributes').each do |node|
@@ -87,20 +99,6 @@ module Docs
         css('.sidebar').remove
 
         css('.collapse-toggle').remove
-
-        # Fix how notable-traits sections are shown
-
-        css('.method').each do |node|
-          traitSection = node.at_css('.notable-traits')
-
-          if traitSection
-            traitSectionContent = traitSection.css('.notable-traits-tooltiptext')
-            traitSection.css('.notable-traits-tooltip').remove
-            traitSection.add_child(traitSectionContent)
-            node.after(traitSection)
-          end
-
-        end
 
         doc
       end


### PR DESCRIPTION
Fix #1360. Improve style in 'notable traits' sections