### PR TITLE
Update Redux to 4.0.5

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -668,7 +668,7 @@ credits = [
     'https://creativecommons.org/licenses/by-sa/4.0/'
   ], [
     'Redux',
-    '2015-2017 Dan Abramov',
+    '2015-2020 Dan Abramov',
     'MIT',
     'https://raw.githubusercontent.com/reactjs/redux/master/LICENSE.md'
   ], [

--- a/lib/docs/filters/redux/clean_html.rb
+++ b/lib/docs/filters/redux/clean_html.rb
@@ -2,36 +2,30 @@ module Docs
   class Redux
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.page-inner section')
 
-        css('#edit-link', 'hr').remove
+        css('h1, h2, h3, h4').each do |node|
+          node.css('a').remove
+        end
 
-        at_css('h2').name = 'h1' unless at_css('h1')
+        css('h3').each do |node|
+          node['id'] = node.content.gsub(/\(|\)/, '').downcase
+        end
 
-        if root_page?
-          at_css('h1').content = 'Redux'
+        css('.codeBlockLines_b7E3').each do |node|
+          node.remove_attribute('style')
+          node.name = 'pre'
+          node['data-language'] = 'javascript'
 
-          at_css('a[href="https://www.npmjs.com/package/redux"]').parent.remove
-
-          css('a[target]').each do |node|
-            node.remove_attribute('target') unless node['href'].start_with?('http')
+          node.css('div, span').each do |subnode|
+            subnode.remove_attribute('style')
           end
+
         end
 
-        css('a[id]:empty').each do |node|
-          (node.next_element || node.parent.next_element)['id'] = node['id']
-        end
-
-        css('h1 > code').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('pre > code').each do |node|
-          node.parent['data-language'] = node['class'][/lang-(\w+)/, 1] if node['class']
-          node.parent.content = node.parent.content
-        end
+        css('.copyButton_10dd').remove
 
         doc
+
       end
     end
   end

--- a/lib/docs/filters/redux/entries.rb
+++ b/lib/docs/filters/redux/entries.rb
@@ -1,29 +1,30 @@
 module Docs
   class Redux
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
-        name = at_css('.page-inner h1, .page-inner h2').content
-        name.sub! %r{\(.*\)}, '()'
-        name
+        name = at_css('h1').content
+        name.gsub(/\(.*\)/, '()')
       end
 
       def get_type
-        path = slug.split('/')
-
-        if path.length > 1
-          path[0].titleize.sub('Api', 'API').sub('Faq', 'FAQ')
-        else
-          'Miscellaneous'
-        end
+        slug.match?(/\Astore\Z/) ? 'Store API' : 'Top-Level Exports'
       end
 
       def additional_entries
-        css('#store-methods + ul > li > a').map do |node|
-          id = node['href'].remove('#')
-          name = "#{self.name}##{id}()"
-          [name, id]
+        entries = []
+
+        if slug.match?(/\Astore\Z/)
+          css('h3').each do |node|
+            entry_path = node.content.gsub(/\(|\)/, '')
+            entry_name = node.content.gsub(/\(.*\)/, '()')
+            entries << [entry_name, entry_path.downcase, 'Store API']
+          end
         end
+
+        entries
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/redux.rb
+++ b/lib/docs/scrapers/redux.rb
@@ -1,28 +1,27 @@
 module Docs
   class Redux < UrlScraper
+
     self.type = 'simple'
-    self.release = '3.7.2'
-    self.base_url = 'http://redux.js.org/docs/'
+    self.release = '4.0.5'
+    self.base_url = 'https://redux.js.org/api'
+    self.root_path = 'index.html'
     self.links = {
       home: 'http://redux.js.org/',
-      code: 'https://github.com/reactjs/redux/'
+      code: 'https://github.com/reduxjs/redux/'
     }
 
-    html_filters.push 'redux/entries', 'redux/clean_html'
+    html_filters.push 'redux/clean_html', 'redux/entries'
 
-    options[:skip] = %w(Feedback.html)
+    options[:container] = '.markdown'
 
     options[:attribution] = <<-HTML
-      &copy; 2015&ndash;2017 Dan Abramov<br>
+      &copy; 2015&ndash;2020 Dan Abramov<br>
       Licensed under the MIT License.
     HTML
-
-    stub '' do
-      request_one('http://redux.js.org/index.html').body
-    end
 
     def get_latest_version(opts)
       get_npm_version('redux', opts)
     end
+
   end
 end

--- a/lib/docs/scrapers/redux.rb
+++ b/lib/docs/scrapers/redux.rb
@@ -2,7 +2,6 @@ module Docs
   class Redux < UrlScraper
 
     self.type = 'simple'
-    self.release = '4.0.5'
     self.base_url = 'https://redux.js.org/api'
     self.root_path = 'index.html'
     self.links = {
@@ -18,6 +17,14 @@ module Docs
       &copy; 2015&ndash;2020 Dan Abramov<br>
       Licensed under the MIT License.
     HTML
+
+    version do
+      self.release = '4.0.5'
+    end
+
+    version '3' do
+      self.release = '3.7.2'
+    end
 
     def get_latest_version(opts)
       get_npm_version('redux', opts)


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Note that I modified this scraper to only scrap the[ 'API' section ](https://redux.js.org/api/api-reference)of the page, let me know If i should scrap the other sections since the 'API' section contains just a few pages.