### PR TITLE
Update Relay to 10.1.0

### DIFF
--- a/lib/docs/filters/relay/clean_html.rb
+++ b/lib/docs/filters/relay/clean_html.rb
@@ -2,58 +2,42 @@ module Docs
   class Relay
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.inner-content, article.withtoc')
 
-        if root_page?
-          at_css('h1').content = 'Relay Documentation'
+        if slug == 'index'
+          css('img').remove
+
+          css('.projectTitle').each do |node|
+            node.name = 'h1'
+            node.content = 'Relay'
+          end
+
+          css('pre').remove
+
         end
 
-        css('.docs-prevnext', '.hash-link', '.edit-page-link', '.edit-github', 'a.hash', '.edit-page-block', 'a.show', 'a.hide', 'hr').remove
+        css('.docLastUpdate').remove
 
-        css('table h1', 'table h2', 'table h3').each do |node|
-          table = node
-          table = table.parent until table.name == 'table'
-          table.replace(node)
+        css('.docs-prevnext').remove
+
+        css('.edit-page-link').remove
+
+        css('h2, h3').each do |node|
+          node.css('a').remove
+          node['id'] = node.content.gsub(/\s/, '-').downcase
         end
 
-        css('a.anchor', 'a.hashref').each do |node|
-          node.parent['id'] ||= node['name'] || node['id']
-        end
+        css('.onPageNav').remove
 
-        css('.highlight').each do |node|
-          node.name = 'pre'
-          node.css('.gutter').remove
-          node['data-language'] = node.at_css('[data-lang]').try(:[], 'data-lang') || 'js'
-          node.content = node.content.strip
-        end
+        css('#docsNav').remove
 
-        css('table.highlighttable').each do |node|
-          node.replace(node.at_css('pre.highlight'))
-        end
+        css('.fixedHeaderContainer').remove
 
-        css('.prism').each do |node|
-          node.name = 'pre'
-          node['data-language'] = node['class'][/(?<=language\-)(\w+)/]
-          node.content = node.content
-        end
+        css('footer').remove
 
-        css('blockquote > p:first-child').each do |node|
-          node.remove if node.content.strip == 'Note:'
-        end
-
-        css('h3#props', 'h3#methods').each { |node| node.name = 'h2' }
-        css('h4.propTitle').each { |node| node.name = 'h3' }
-
-        css('> div > div', '> div', 'div > span', '.props', '.prop').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('a pre', 'h3 .propType').each do |node|
-          node.name = 'code'
-        end
-
-        css('a[target]').each do |node|
-          node.remove_attribute('target')
+        # syntax highlight
+        css('pre').each do |node|
+          node['data-language'] = 'javascript'
+          node.add_class('highlight')
         end
 
         doc

--- a/lib/docs/filters/relay/entries.rb
+++ b/lib/docs/filters/relay/entries.rb
@@ -1,43 +1,53 @@
 module Docs
   class Relay
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
-        at_css('h1').children.select(&:text?).map(&:content).join.strip
+        if slug == 'index'
+          return 'Relay'
+        end
+
+        at_css('h1').content
       end
 
       def get_type
-        link = at_css('.nav-docs-section .active, .toc .active')
-        section = link.ancestors('.nav-docs-section, section').first
-        type = section.at_css('h3').content.strip
-        type
+        if slug == 'index'
+          return 'Relay'
+        end
+
+        at_css('h1').content
       end
 
       def additional_entries
         entries = []
 
-        css('.inner-content h3 code, .inner-content h4 code').each do |node|
-          name = node.content
-          name.remove! %r{[#\(\)]}
-          name.remove! %r{\w+\:}
-          name.strip!
-          id = name.parameterize
-          node.parent['id'] = id
-          entries << [name, id, 'Reference']
+        if slug == 'index'
+          return entries
         end
 
-        css('.apiIndex a pre').each do |node|
-          next unless node.parent['href'].start_with?('#')
-          id = node.parent['href'].remove('#')
-          name = node.content.strip
-          sep = name.start_with?('static') ? '.' : '#'
-          name.remove! %r{(abstract|static) }
-          name.sub! %r{\(.*\)}, '()'
-          name.prepend(self.name + sep)
-          entries << [name, id]
+        ## avoid adding non-desired entries removing tags
+        # remove header which contains a <h2> tag
+        css('.fixedHeaderContainer').remove
+
+        # remove table of content whose title is an <h2> tag
+        css('.toc').remove
+        ##
+
+        css('h2, h3').each do |node|
+          next if node.content.include?('Argument')
+          entry_name = node.content
+
+          if entry_name.include?('(')
+            entry_name = entry_name.match(/.*\(/)[0] + ')'
+          end
+
+          entry_id = node.content.gsub(/\s/, '-').downcase
+          entries << [entry_name, entry_id]
         end
 
         entries
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/relay.rb
+++ b/lib/docs/scrapers/relay.rb
@@ -1,27 +1,38 @@
 module Docs
   class Relay < UrlScraper
     self.type = 'simple'
-    self.release = '1.4.1'
-    self.base_url = 'https://facebook.github.io/relay/docs/'
-    self.root_path = 'getting-started.html'
+    self.release = '10.1.0'
+    self.base_url = 'https://relay.dev'
+    self.root_path = 'index.html'
     self.links = {
-      home: 'https://facebook.github.io/relay/',
+      home: 'https://relay.dev/',
       code: 'https://github.com/facebook/relay'
     }
 
     html_filters.push 'relay/entries', 'relay/clean_html'
 
-    options[:container] = '.documentationContent'
-    options[:skip] = %w(videos.html graphql-further-reading.html)
+    options[:only] = [
+      '/docs/en/graphql-in-relay',
+      '/docs/en//relay-environment',
+      '/docs/en/network-layer',
+      '/docs/en/query-renderer',
+      '/docs/en/fragment-container',
+      '/docs/en/refetch-container',
+      '/docs/en/pagination-container',
+      '/docs/en/mutations',
+      '/docs/en/subscriptions',
+      '/docs/en/relay-store',
+      '/docs/en/fetch-query'
+    ]
 
     options[:attribution] = <<-HTML
-      &copy; 2013&ndash;present Facebook Inc.<br>
+      &copy; 2020&ndash;present Facebook Inc.<br>
       Licensed under the BSD License.
     HTML
 
     def get_latest_version(opts)
-      doc = fetch_doc('http://facebook.github.io/relay/en/', opts)
-      doc.at_css('header > a > h3').content[1..-1]
+      get_latest_github_release('facebook', 'relay', opts)
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

I used the main page of Relay as the base url because index.html refuses being generated using 'https://relay.dev/docs/en/introduction-to-relay/' as base url.

Also note that I only use the API section of Relay for this scraper, if is necessary I can add the other sections.

