### PR TITLE
Update Nim to 1.4.2

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -533,7 +533,7 @@ credits = [
     'https://github.com/openresty/lua-nginx-module#copyright-and-license'
   ], [
     'Nim',
-    '2006-2017 Andreas Rumpf',
+    '2006-2020 Andreas Rumpf',
     'MIT',
     'https://github.com/nim-lang/Nim#license'
   ], [

--- a/lib/docs/filters/nim/clean_html.rb
+++ b/lib/docs/filters/nim/clean_html.rb
@@ -4,6 +4,15 @@ module Docs
       def call
         @doc = at_css('#documentId .container')
 
+        # add id to each proc, template and macro
+        css('dl > dt > pre').each do |node|
+          next if !(node.at_css('a'))
+          node.remove_attribute('id')
+          nodeId = node.at_css('a')['href']
+          nodeId.gsub!(/.*\#/, '')
+          node['id'] = nodeId
+        end
+
         css('.docinfo', '.footer', 'blockquote > p:empty', '.link-seesrc').remove
 
         css('h1:not(.title), h2, h3, h4').each do |node|
@@ -15,18 +24,9 @@ module Docs
           @doc = content
         end
 
-        if root_page?
-          at_css('h1').content = 'Nim Documentation'
-        end
-
         css('h1 > a', 'h2 > a', 'h3 > a', 'h4 > a').each do |node|
           node.parent['id'] = node['id'] if node['id']
           node.before(node.children).remove
-        end
-
-        css('a[name]').each do |node|
-          node.next_element['id'] = node['name']
-          node.remove
         end
 
         css('pre').each do |node|

--- a/lib/docs/filters/nim/entries.rb
+++ b/lib/docs/filters/nim/entries.rb
@@ -1,6 +1,15 @@
 module Docs
   class Nim
     class EntriesFilter < Docs::EntriesFilter
+
+      REFERENCE = [
+        'API naming design', 'Internals of the Nim Compiler', 'Nim Backend Integration',
+        'Nim Compiler', 'Nim Destructors and Move Semantics', 'Nim Enhancement Proposal #1',
+        'Nim Experimental Features', 'Nim IDE Integration Guide',
+        'Nim maintenance script', 'Nim Standard Library', "Nim's Memory Management",
+        'NimScript', 'Packaging Nim', 'segfaults', 'Source Code Filters'
+      ]
+
       def get_name
         name = at_css('h1').content
         name.remove! 'Module '
@@ -12,35 +21,20 @@ module Docs
       end
 
       def get_type
-        if name.include?('Tutorial')
-          'Tutorial'
-        elsif slug == 'manual'
+        if slug == 'manual'
           'Manual'
-        elsif at_css('h1').content.include?('Module ')
-          name
-        else
+        elsif REFERENCE.include?(name)
           'Reference'
+        else
+          name
         end
       end
 
       def additional_entries
         entries = []
 
-        if at_css('h1').content.include?('Module ')
-          css('#toc-list > li > .simple-toc-section').each do |node|
-            type = node.previous_element.content.strip
+        if slug == 'manual'
 
-            node.css('a.reference:not(.reference-toplevel)').each do |n|
-              n.css('span').remove
-              name = n.content.strip
-              name << '()' if (type == 'Procs' || type == 'Templates') && !name.include?('`')
-              name.remove! '`'
-              name.prepend "#{self.name}."
-              id = n['href'].remove('#')
-              entries << [name, id] unless entries.any? { |e| e[0] == name }
-            end
-          end
-        elsif slug == 'manual'
           css('#toc-list > li > a').each do |node|
             name = node.content.strip
             next if name.start_with?('About')
@@ -54,11 +48,23 @@ module Docs
             node.css('> li > a').each do |n|
               entries << [n.content.strip, n['href'].remove('#'), "Manual: #{type}"]
             end
+
           end
+
+        else
+
+          css('.simple-toc-section a').each do |node|
+            entry_name = node.content
+            entry_name.gsub!(/,.*/, '')
+            entry_id = slug + node['href']
+            entries << [entry_name, entry_id, name]
+          end
+
         end
 
         entries
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/nim.rb
+++ b/lib/docs/scrapers/nim.rb
@@ -1,7 +1,7 @@
 module Docs
   class Nim < UrlScraper
     self.type = 'simple'
-    self.release = '0.19.0'
+    self.release = '1.4.2'
     self.base_url = 'https://nim-lang.org/docs/'
     self.root_path = 'overview.html'
     self.links = {
@@ -11,10 +11,10 @@ module Docs
 
     html_filters.push 'nim/entries', 'nim/clean_html'
 
-    options[:skip] = %w(theindex.html docgen.txt)
+    options[:skip] = %w(theindex.html docgen.html tut1.html tut2.html tut3.html tools.html)
 
     options[:attribution] = <<-HTML
-      &copy; 2006&ndash;2018 Andreas Rumpf<br>
+      &copy; 2006&ndash;2020 Andreas Rumpf<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

## Caveats
There are some entries with duplicate name. This happen because some procedures, macros and templates share the same name, look at the following image:

![image](https://user-images.githubusercontent.com/52229226/101300534-8a354d00-37fb-11eb-885d-cffdbd7a14c0.png)

The module 'astalgo' has five 'debug' entries, where three are procedures with different arguments and two are templates. Any idea or suggestion to improve this would be helpful.
