### PR TITLE
Update Pony documentation (0.38.1)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -613,7 +613,7 @@ credits = [
     'https://creativecommons.org/licenses/by/3.0/'
   ], [
     'Pony',
-    '2016-2018, The Pony Developers & 2014-2015, Causality Ltd.',
+    '2016-2020, The Pony Developers & 2014-2015, Causality Ltd.',
     'BSD',
     'https://raw.githubusercontent.com/ponylang/ponyc/master/LICENSE'
   ], [

--- a/lib/docs/filters/pony/clean_html.rb
+++ b/lib/docs/filters/pony/clean_html.rb
@@ -7,6 +7,7 @@ module Docs
 
         css('pre').each do |node|
           node.content = node.content
+          node['data-language'] = 'pony'
         end
 
         doc

--- a/lib/docs/scrapers/pony.rb
+++ b/lib/docs/scrapers/pony.rb
@@ -1,7 +1,7 @@
 module Docs
   class Pony < UrlScraper
     self.type = 'simple'
-    self.release = '0.30.0'
+    self.release = '0.38.1'
     self.base_url = 'https://stdlib.ponylang.io/'
     self.links = {
       home: 'https://www.ponylang.io/',
@@ -11,7 +11,7 @@ module Docs
     html_filters.push 'pony/clean_html', 'pony/entries'
 
     options[:attribution] = <<-HTML
-      &copy; 2016-2018, The Pony Developers<br>
+      &copy; 2016-2020, The Pony Developers<br>
       &copy; 2014-2015, Causality Ltd.<br>
       Licensed under the BSD 2-Clause License.
     HTML


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Prism (the syntax highlighting library) doesn't currently support Pony, but tagging it now doesn't hurt and saves the effort to rebuild the docs if ever does in the future.
