### PR TITLE
Fix Bootstrap scraper get_latest_version

### DIFF
--- a/lib/docs/scrapers/bootstrap.rb
+++ b/lib/docs/scrapers/bootstrap.rb
@@ -37,8 +37,8 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://getbootstrap.com/', opts)
-      doc.at_css('#bd-versions').content.strip[1..-1]
+      doc = fetch_doc('https://getbootstrap.com/docs/versions/', opts)
+      doc.at_css('span:contains("Latest")').parent.content.split(' ').first
     end
   end
 end


### PR DESCRIPTION
The bootstrap team updated their website in preparation for the release of version 5. It's still in beta (and as a rule DevDocs doesn't host beta or prerelease content) so I'll submit the update to the scraper itself once the full 5.0 is available.