### PR TITLE
Update Bash to 5.1

### DIFF
--- a/lib/docs/filters/bash/entries.rb
+++ b/lib/docs/filters/bash/entries.rb
@@ -1,13 +1,22 @@
 module Docs
   class Bash
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
-        name = at_css('hr + a + *').content.gsub(/(\d+\.?)+/, '')
+        name = at_css('h1','h2', 'h3', 'h4').content.gsub(/(\d+\.?)+/, '')
 
-        # Remove the "D. " from names like "D. Concept Index" and "D. Function Index"
-        name = name[3..-1] if name.start_with?('D. ')
+        # remove 'E.' notation for appendixes
+        if name.match?(/[[:upper:]]\./)
+          # remove 'E.'
+          name = name.sub(/[[:upper:]]\./, '')
+          # remove all dots (.)
+          name = name.gsub(/\./, '')
+          # remove all numbers
+          name = name.gsub(/[[:digit:]]/, '')
+        end
 
-        name
+        name.strip
+
       end
 
       def get_type
@@ -44,13 +53,14 @@ module Docs
           end
 
           # Construct path to the page which the index links to
-          entry_path = '/html_node/' + page + '#' + hash
+          entry_path = page + '#' + hash
 
           entries << [entry_name, entry_path, entry_type]
         end
 
         entries
       end
+
     end
   end
 end

--- a/lib/docs/filters/bash/entries.rb
+++ b/lib/docs/filters/bash/entries.rb
@@ -8,11 +8,11 @@ module Docs
         # remove 'E.' notation for appendixes
         if name.match?(/[[:upper:]]\./)
           # remove 'E.'
-          name = name.sub(/[[:upper:]]\./, '')
+          name.sub!(/[[:upper:]]\./, '')
           # remove all dots (.)
-          name = name.gsub(/\./, '')
+          name.gsub!(/\./, '')
           # remove all numbers
-          name = name.gsub(/[[:digit:]]/, '')
+          name.gsub!(/[[:digit:]]/, '')
         end
 
         name.strip

--- a/lib/docs/scrapers/bash.rb
+++ b/lib/docs/scrapers/bash.rb
@@ -1,17 +1,15 @@
 module Docs
   class Bash < UrlScraper
     self.type = 'bash'
-    self.release = '5.0'
-    self.base_url = 'https://www.gnu.org/software/bash/manual'
-    self.root_path = '/html_node/index.html'
+    self.release = '5.1'
+    self.base_url = 'https://www.gnu.org/software/bash/manual/html_node'
+    self.root_path = 'index.html'
     self.links = {
       home: 'https://www.gnu.org/software/bash/',
       code: 'http://git.savannah.gnu.org/cgit/bash.git'
     }
 
     html_filters.push 'bash/entries', 'bash/clean_html'
-
-    options[:only_patterns] = [/\/html_node\//]
 
     options[:attribution] = <<-HTML
       Copyright &copy; 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.<br>


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
