### PR TITLE
Update Padrino to 0.15

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -588,7 +588,7 @@ credits = [
     'https://raw.githubusercontent.com/OpenTSDB/opentsdb.net/gh-pages/COPYING.LESSER'
   ], [
     'Padrino',
-    '2010-2019 Padrino',
+    '2010-2020 Padrino',
     'MIT',
     'https://raw.githubusercontent.com/padrino/padrino-framework/master/padrino/LICENSE.txt'
   ], [

--- a/lib/docs/scrapers/padrino.rb
+++ b/lib/docs/scrapers/padrino.rb
@@ -2,7 +2,7 @@ module Docs
   class Padrino < UrlScraper
     self.slug = 'padrino'
     self.type = 'rubydoc'
-    self.release = '0.14.4'
+    self.release = '0.15'
     self.base_url = 'https://www.rubydoc.info/github/padrino/padrino-framework/'
     self.root_path = 'file/README.rdoc'
     self.initial_paths = %w(index2)
@@ -16,7 +16,7 @@ module Docs
     options[:container] = ->(filter) { filter.root_page? ? '#filecontents' : '#content' }
 
     options[:attribution] = <<-HTML
-      &copy; 2010&ndash;2019 Padrino<br>
+      &copy; 2010&ndash;2020 Padrino<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
