### PR TITLE
Update arrow scroll copy

### DIFF
--- a/assets/javascripts/templates/pages/settings_tmpl.coffee
+++ b/assets/javascripts/templates/pages/settings_tmpl.coffee
@@ -54,7 +54,7 @@ app.templates.settingsPage = (settings) -> """
       </label>
       <label class="_settings-label">
         <input type="checkbox" form="settings" name="arrowScroll" value="1"#{if settings.arrowScroll then ' checked' else ''}>Use arrow keys to scroll the main content area
-        <small>With this checked, use <code class="_label">alt</code> + <code class="_label">&uarr;</code><code class="_label">&darr;</code><code class="_label">&larr;</code><code class="_label">&rarr;</code> to navigate the sidebar.</small>
+        <small>With this checked, use <code class="_label">shift</code> + <code class="_label">&uarr;</code><code class="_label">&darr;</code><code class="_label">&larr;</code><code class="_label">&rarr;</code> to navigate the sidebar.</small>
       </label>
     </div>
   </div>

--- a/assets/javascripts/templates/tip_tmpl.coffee
+++ b/assets/javascripts/templates/tip_tmpl.coffee
@@ -1,10 +1,10 @@
-app.templates.tipKeyNav = """
+app.templates.tipKeyNav = () -> """
   <p class="_notif-text">
     <strong>ProTip</strong>
     <span class="_notif-info">(click to dismiss)</span>
   <p class="_notif-text">
-    Hit <code class="_label">&darr;</code> <code class="_label">&uarr;</code> <code class="_label">&larr;</code> <code class="_label">&rarr;</code> to navigate the sidebar.<br>
-    Hit <code class="_label">space / shift space</code>, <code class="_label">alt &darr;/&uarr;</code> or <code class="_label">shift &darr;/&uarr;</code> to scroll the page.
+    Hit #{if app.settings.cache.arrowScroll then '<code class="_label">shift</code> +' else ''} <code class="_label">&darr;</code> <code class="_label">&uarr;</code> <code class="_label">&larr;</code> <code class="_label">&rarr;</code> to navigate the sidebar.<br>
+    Hit <code class="_label">space / shift space</code>#{if app.settings.cache.arrowScroll then ' or <code class="_label">&darr;/&uarr;</code>' else ', <code class="_label">alt &darr;/&uarr;</code> or <code class="_label">shift &darr;/&uarr;</code>'} to scroll the page.
   <p class="_notif-text">
     <a href="/help#shortcuts" class="_notif-link">See all keyboard shortcuts</a>
 """


### PR DESCRIPTION
# Outcome

This PR makes the arrow scroll copy in the ProTip popup dynamic to reflect proper key combinations depending on if the setting is enabled or not.

#### Settings page

![Screenshot_2020-12-09 DevDocs](https://user-images.githubusercontent.com/1121087/101725514-a6d4bd80-3a65-11eb-879e-00333d48c67a.png)

I updated the copy here to read `shift` instead of `alt` since enabling this setting doesn't actually allow for `alt` with left/right arrow keys. `alt` + left/right results in previous/next pages. `shift` + left/right works properly.

#### ProTip, arrow scroll enabled

![Screenshot_2020-12-09 DevDocs(1)](https://user-images.githubusercontent.com/1121087/101725719-ff0bbf80-3a65-11eb-8b7b-15a4be1b31c1.png)

#### ProTip, arrow scroll disabled

![Screenshot_2020-12-09 DevDocs(2)](https://user-images.githubusercontent.com/1121087/101725757-0f239f00-3a66-11eb-9a1f-78c03effe821.png)


# Issue

#1265.