### PR TITLE
Update Rethinkdb to 2.4.1

### DIFF
--- a/lib/docs/filters/rethinkdb/clean_html.rb
+++ b/lib/docs/filters/rethinkdb/clean_html.rb
@@ -19,10 +19,6 @@ module Docs
           node.content = node.content
         end
 
-        css('.highlight', 'section', 'div.highlighter-rouge', 'a > p', 'li > h1').each do |node|
-          node.before(node.children).remove
-        end
-
         css('h2, h3, h4').each do |node|
           node.name = node.name.sub(/\d/) { |i| i.to_i + 1 }
         end
@@ -45,6 +41,8 @@ module Docs
         end
 
         css('> .infobox:last-child:contains("Contribute:")').remove
+
+        css('.additional-help').remove
 
         doc
       end

--- a/lib/docs/filters/rethinkdb/entries.rb
+++ b/lib/docs/filters/rethinkdb/entries.rb
@@ -1,9 +1,17 @@
 module Docs
   class Rethinkdb
     class EntriesFilter < Docs::EntriesFilter
+
       def get_name
         if subpath.start_with?('api')
-          at_css('.title').content.remove('ReQL command:').split(', ').first
+          name = at_css('.title').content.remove('ReQL command:').split(', ').first
+
+          if name.strip.empty?
+            'lt'
+          else
+            name
+          end
+
         else
           at_css('.docs-nav .active').content
         end
@@ -30,6 +38,7 @@ module Docs
       def include_default_entry?
         at_css('.docs-article p').try(:content) != 'Choose your language:'
       end
+
     end
   end
 end

--- a/lib/docs/scrapers/rethinkdb.rb
+++ b/lib/docs/scrapers/rethinkdb.rb
@@ -3,7 +3,7 @@ module Docs
     self.name = 'RethinkDB'
     self.type = 'rethinkdb'
     self.base_url = 'https://rethinkdb.com/'
-    self.release = '2.3.5'
+    self.release = '2.4.1'
     self.root_path = 'docs/'
     self.links = {
       home: 'https://rethinkdb.com/',

--- a/lib/docs/scrapers/rethinkdb.rb
+++ b/lib/docs/scrapers/rethinkdb.rb
@@ -13,14 +13,18 @@ module Docs
     html_filters.push 'rethinkdb/entries', 'rethinkdb/clean_html'
 
     options[:trailing_slash] = true
+
     options[:container] = '.documentation'
 
     options[:only_patterns] = [/\Adocs/]
+
     options[:skip_patterns] = [/docs\/install(\-drivers)?\/./]
+
     options[:skip] = %w(
       docs/build/
       docs/tutorials/elections/
-      docs/tutorials/superheroes/)
+      docs/tutorials/superheroes/
+      )
 
     MULTILANG_DOCS = %w(
       changefeeds
@@ -33,30 +37,65 @@ module Docs
       rabbitmq
       secondary-indexes
       sql-to-reql
-      storing-binary)
+      storing-binary
+      )
 
     options[:attribution] = <<-HTML
       &copy; RethinkDB contributors<br>
       Licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License.
     HTML
 
-    %w(JavaScript Ruby Python Java).each do |name|
-      path = name.downcase
-      instance_eval <<-CODE
-        version '#{name}' do
-          self.initial_paths = %w(api/#{path}/)
+    version 'javascript' do
+      self.initial_paths = %w(api/javascript/)
 
-          options[:only_patterns] += [/\\Aapi\\/#{path}\\//]
+      options[:only_patterns] += [/\Aapi\/javascript\//]
 
-          options[:fix_urls] = ->(url) do
-            url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})\\z}, 'rethinkdb.com/docs/\\1/#{path}/'
-            url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})/(?!#{path}/).*}, 'rethinkdb.com/docs/\\1/#{path}/'
-            url.sub! %r{rethinkdb.com/api/(?!javascript|ruby|python|java)}, 'rethinkdb.com/api/#{path}/'
-            url
-          end
-        end
-      CODE
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})\\z}, 'rethinkdb.com/docs/\\1/javascript/'
+        url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})/(?!javascript/).*}, 'rethinkdb.com/docs/\\1/javascript/'
+        url.sub! %r{rethinkdb.com/api/(?!javascript|ruby|python|java)}, 'rethinkdb.com/api/javascript/'
+        url
+      end
     end
+
+    version 'ruby' do
+      self.initial_paths = %w(api/ruby/)
+
+      options[:only_patterns] += [/\Aapi\/ruby\//]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})\\z}, 'rethinkdb.com/docs/\\1/ruby/'
+        url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})/(?!ruby/).*}, 'rethinkdb.com/docs/\\1/ruby/'
+        url.sub! %r{rethinkdb.com/api/(?!javascript|ruby|python|java)}, 'rethinkdb.com/api/ruby/'
+        url
+      end
+    end
+
+      version 'python' do
+        self.initial_paths = %w(api/python/)
+
+        options[:only_patterns] += [/\Aapi\/python\//]
+
+        options[:fix_urls] = ->(url) do
+          url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})\\z}, 'rethinkdb.com/docs/\\1/python/'
+          url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})/(?!python/).*}, 'rethinkdb.com/docs/\\1/python/'
+          url.sub! %r{rethinkdb.com/api/(?!javascript|ruby|python|java)}, 'rethinkdb.com/api/python/'
+          url
+        end
+      end
+
+      version 'java' do
+        self.initial_paths = %w(api/java/)
+
+        options[:only_patterns] += [/\Aapi\/java\//]
+
+        options[:fix_urls] = ->(url) do
+          url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})\\z}, 'rethinkdb.com/docs/\\1/java/'
+          url.sub! %r{rethinkdb.com/docs/(#{MULTILANG_DOCS.join('|')})/(?!java/).*}, 'rethinkdb.com/docs/\\1/java/'
+          url.sub! %r{rethinkdb.com/api/(?!javascript|ruby|python|java)}, 'rethinkdb.com/api/java/'
+          url
+        end
+      end
 
     def get_latest_version(opts)
       get_latest_github_release('rethinkdb', 'rethinkdb', opts)
@@ -68,5 +107,6 @@ module Docs
       return false unless super
       response.body !~ /http-equiv="refresh"/i
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
