### PR TITLE
Update QT documentation (6.0)

### DIFF
--- a/lib/docs/scrapers/qt.rb
+++ b/lib/docs/scrapers/qt.rb
@@ -103,6 +103,11 @@ module Docs
       Licensed under the GNU Free Documentation License, Version 1.3.
     HTML
 
+    version '6.0' do
+      self.release = '6.0'
+      self.base_url = "https://doc.qt.io/qt-#{self.release}/"
+    end
+
     version '5.15' do
       self.release = '5.15'
       self.base_url = "https://doc.qt.io/qt-#{self.release}/"
@@ -120,7 +125,7 @@ module Docs
 
     version '5.12' do
       self.release = '5.12'
-      self.base_url = "https://doc.qt.io/archivex/qt-#{self.release}/"
+      self.base_url = "https://doc.qt.io/archives/qt-#{self.release}/"
     end
 
     version '5.11' do
@@ -139,7 +144,7 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://doc.qt.io/qt-5/index.html', opts)
+      doc = fetch_doc('https://doc.qt.io/qt-6/index.html', opts)
       doc.at_css('.mainContent h1.title').content.sub(/Qt /, '')
     end
   end


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

This is a new major version release. The first since we added QT to DevDocs. I did some spot-checks of my generated files to the existing 5.15 versions, but I'm neither a C++ nor QT developer so there may be something I missed.