### PR TITLE
Update scikit-learn documentation (0.23.2)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -743,7 +743,7 @@ credits = [
     'http://scikit-image.org/docs/dev/license.html'
   ], [
     'scikit-learn',
-    '2007-2018 The scikit-learn developers',
+    '2007-2020 The scikit-learn developers',
     'BSD',
     'https://raw.githubusercontent.com/scikit-learn/scikit-learn/master/COPYING'
   ], [

--- a/lib/docs/filters/scikit_learn/clean_html.rb
+++ b/lib/docs/filters/scikit_learn/clean_html.rb
@@ -3,22 +3,23 @@ module Docs
     class CleanHtmlFilter < Filter
       def call
         if root_page?
-          at_css('h1').content = 'scikit-learn'
-
-          css('.row-fluid').each do |node|
+          css('.row').each do |node|
             html = '<dl>'
-            node.css('.span4').each do |n|
-              html += "<dt>#{n.first_element_child.inner_html}</dt>"
-              html += "<dd>#{n.last_element_child.inner_html}</dd>"
+            node.css('.card-body').each do |n|
+              html += '<dt>'
+              html += "<a href='#{n.at_css('a')['href']}'>#{n.at_css('h4').content}</a>"
+              html += '</dt>'
+              html += "<dd>#{n.css('.card-text').to_html}</dd>"
             end
             html += '</dl>'
             node.replace(html)
           end
         end
 
+        css('.sphx-glr-signature').remove
+
         doc
       end
     end
   end
 end
-

--- a/lib/docs/scrapers/scikit_learn.rb
+++ b/lib/docs/scrapers/scikit_learn.rb
@@ -3,25 +3,28 @@ module Docs
     self.name = 'scikit-learn'
     self.slug = 'scikit_learn'
     self.type = 'sphinx'
-    self.release = '0.20.0'
-    self.base_url = 'http://scikit-learn.org/stable/'
-    self.root_path = 'documentation.html'
+    self.release = '0.23.2'
+    self.base_url = 'https://scikit-learn.org/0.23/'
+    self.root_path = 'index.html'
     self.force_gzip = true
     self.links = {
-      home: 'http://scikit-learn.org/',
+      home: 'https://scikit-learn.org/',
       code: 'https://github.com/scikit-learn/scikit-learn'
     }
 
-    html_filters.push 'scikit_learn/entries', 'scikit_learn/clean_html', 'sphinx/clean_html'
+    html_filters.push 'scikit_learn/entries', 'scikit_learn/clean_html', 'sphinx/clean_html', 'title'
 
-    options[:container] = ->(filter) { filter.root_page? ? '.container-index' : '.body' }
-    options[:skip] = %w(tutorial/statistical_inference/finding_help.html)
+    options[:container] = ->(filter) { filter.root_page? ? 'body > .container' : '.section' }
+    options[:skip] = %w(modules/generated/sklearn.experimental.enable_iterative_imputer.html
+                        modules/generated/sklearn.experimental.enable_hist_gradient_boosting.html)
     options[:only_patterns] = [/\Amodules/, /\Adatasets/, /\Atutorial/, /\Aauto_examples/]
     options[:skip_patterns] = [/\Adatasets\/(?!index)/]
+    options[:title] = false
+    options[:root_title] = 'scikit-learn'
     options[:max_image_size] = 256_000
 
     options[:attribution] = <<-HTML
-      &copy; 2007&ndash;2018 The scikit-learn developers<br>
+      &copy; 2007&ndash;2020 The scikit-learn developers<br>
       Licensed under the 3-clause BSD License.
     HTML
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
