### PR TITLE
Update Scikit-image documentation (0.17.2)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -738,7 +738,7 @@ credits = [
     'https://raw.githubusercontent.com/scala/scala-lang/master/license.md'
   ], [
     'scikit-image',
-    '2011 the scikit-image team',
+    '2019 the scikit-image team',
     'BSD',
     'http://scikit-image.org/docs/dev/license.html'
   ], [

--- a/lib/docs/scrapers/scikit_image.rb
+++ b/lib/docs/scrapers/scikit_image.rb
@@ -3,10 +3,10 @@ module Docs
     self.name = 'scikit-image'
     self.slug = 'scikit_image'
     self.type = 'sphinx'
-    self.release = '0.14.1'
-    self.base_url = 'http://scikit-image.org/docs/0.14.x/'
+    self.release = '0.17.2'
+    self.base_url = 'https://scikit-image.org/docs/0.17.x/'
     self.links = {
-      home: 'http://scikit-image.org/',
+      home: 'https://scikit-image.org/',
       code: 'https://github.com/scikit-image/scikit-image'
     }
 
@@ -17,7 +17,7 @@ module Docs
     options[:only_patterns] = [/\Aapi/, /\Auser_guide/]
 
     options[:attribution] = <<-HTML
-      &copy; 2011 the scikit-image team<br>
+      &copy; 2019 the scikit-image team<br>
       Licensed under the BSD 3-clause License.
     HTML
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
