### PR TITLE
Update Octave to 5.2.0 and add version 6

### DIFF
--- a/lib/docs/scrapers/octave.rb
+++ b/lib/docs/scrapers/octave.rb
@@ -2,8 +2,6 @@ module Docs
   class Octave < UrlScraper
     self.name = 'Octave'
     self.type = 'octave'
-    self.release = '5.1.0'
-    self.base_url = 'https://octave.org/doc/interpreter/'
     self.root_path = 'index.html'
     self.links = {
       home: 'http://www.octave.org/',
@@ -21,18 +19,30 @@ module Docs
       Distribution.html)
 
     options[:title] = false
+
     options[:root_title] = 'GNU Octave'
 
     options[:attribution] = <<-HTML
-      &copy; 1996&ndash;2018 John W. Eaton<br>
+      &copy; 1996&ndash;2020 John W. Eaton<br>
       Permission is granted to make and distribute verbatim copies of this manual provided the copyright notice and this permission notice are preserved on all copies.<br/>
-Permission is granted to copy and distribute modified versions of this manual under the conditions for verbatim copying, provided that the entire resulting derived work is distributed under the terms of a permission notice identical to this one.</br>
-Permission is granted to copy and distribute translations of this manual into another language, under the above conditions for modified versions.
+      Permission is granted to copy and distribute modified versions of this manual under the conditions for verbatim copying, provided that the entire resulting derived work is distributed under the terms of a permission notice identical to this one.</br>
+      Permission is granted to copy and distribute translations of this manual into another language, under the above conditions for modified versions.
     HTML
+
+    version '6' do
+      self.release = '6.1.0'
+      self.base_url = "https://octave.org/doc/v#{self.release}/"
+    end
+
+    version '5' do
+      self.release = '5.2.0'
+      self.base_url = "https://octave.org/doc/v#{self.release}/"
+    end
 
     def get_latest_version(opts)
       doc = fetch_doc('https://octave.org/doc/interpreter/', opts)
       doc.at_css('h1').content.scan(/([0-9.]+)/)[0][0]
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
