### PR TITLE
Update self.links in several scrapers

### DIFF
--- a/lib/docs/scrapers/angularjs.rb
+++ b/lib/docs/scrapers/angularjs.rb
@@ -5,6 +5,10 @@ module Docs
     self.type = 'angularjs'
     self.root_path = 'api.html'
     self.initial_paths = %w(guide.html guide/controller.html)
+    self.links = {
+      home: 'https://angularjs.org/',
+      code: 'https://github.com/angular/angular.js'
+    }
 
     html_filters.push 'angularjs/clean_html', 'angularjs/entries', 'title'
     text_filters.push 'angularjs/clean_urls'

--- a/lib/docs/scrapers/clojure.rb
+++ b/lib/docs/scrapers/clojure.rb
@@ -2,6 +2,10 @@ module Docs
   class Clojure < UrlScraper
     self.type = 'clojure'
     self.root_path = 'api-index.html'
+    self.links = {
+      home: 'https://clojure.org',
+      code: 'https://github.com/clojure/clojure'
+    }
 
     html_filters.push 'clojure/entries', 'clojure/clean_html'
 

--- a/lib/docs/scrapers/gnuplot.rb
+++ b/lib/docs/scrapers/gnuplot.rb
@@ -3,7 +3,8 @@ module Docs
     self.type = 'gnuplot'
     self.release = '5.2.8'
     self.links = {
-      home: 'http://gnuplot.sourceforge.net/'
+      home: 'http://www.gnuplot.info/',
+      code: 'https://sourceforge.net/projects/gnuplot/'
     }
 
     self.root_path = 'nofigures.html'

--- a/lib/docs/scrapers/graphite.rb
+++ b/lib/docs/scrapers/graphite.rb
@@ -4,6 +4,7 @@ module Docs
     self.release = '1.1.4'
     self.base_url = 'https://graphite.readthedocs.io/en/latest/'
     self.links = {
+      home: 'https://graphiteapp.org/',
       code: 'https://github.com/graphite-project/graphite-web'
     }
 

--- a/lib/docs/scrapers/lua.rb
+++ b/lib/docs/scrapers/lua.rb
@@ -2,6 +2,9 @@ module Docs
   class Lua < UrlScraper
     self.type = 'lua'
     self.root_path = 'manual.html'
+    self.links = {
+      home: 'https://www.lua.org/'
+    }
 
     html_filters.push 'lua/clean_html', 'lua/entries'
 

--- a/lib/docs/scrapers/modernizr.rb
+++ b/lib/docs/scrapers/modernizr.rb
@@ -4,6 +4,10 @@ module Docs
     self.type = 'modernizr'
     self.release = '3.11.3'
     self.base_url = 'https://modernizr.com/docs/'
+    self.links = {
+      home: 'https://modernizr.com/',
+      code: 'https://github.com/Modernizr/Modernizr'
+    }
 
     html_filters.push 'modernizr/entries', 'modernizr/clean_html', 'title'
 

--- a/lib/docs/scrapers/openjdk.rb
+++ b/lib/docs/scrapers/openjdk.rb
@@ -5,6 +5,10 @@ module Docs
     self.name = 'OpenJDK'
     self.type = 'openjdk'
     self.root_path = 'overview-summary.html'
+    self.links = {
+      home: 'https://openjdk.java.net/',
+      code: 'https://github.com/openjdk/jdk'
+    }
 
     html_filters.insert_after 'internal_urls', 'openjdk/clean_urls'
     html_filters.push 'openjdk/entries', 'openjdk/clean_html'

--- a/lib/docs/scrapers/tcl_tk.rb
+++ b/lib/docs/scrapers/tcl_tk.rb
@@ -6,6 +6,10 @@ module Docs
     self.release = '8.6.6'
     self.base_url = 'https://www.tcl.tk/man/tcl/'
     self.root_path = 'contents.htm'
+    self.links = {
+      home: 'https://www.tcl.tk/',
+      code: 'https://sourceforge.net/projects/tcl/files/Tcl/'
+    }
 
     html_filters.push 'tcl_tk/entries', 'tcl_tk/clean_html', 'title'
 


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined

This is a very small change, I don't think we need to regenerate the doc sets for these now.