### PR TITLE
Make arrow scroll copy dynamic on help page

### DIFF
--- a/assets/javascripts/templates/pages/help_tmpl.coffee
+++ b/assets/javascripts/templates/pages/help_tmpl.coffee
@@ -1,6 +1,7 @@
 app.templates.helpPage = ->
   ctrlKey = if $.isMac() then 'cmd' else 'ctrl'
   navKey = if $.isMac() then 'cmd' else 'alt'
+  arrowScroll = app.settings.get('arrowScroll')
 
   aliases_one = {}
   aliases_two = {}
@@ -66,12 +67,12 @@ app.templates.helpPage = ->
   <h3 class="_shortcuts-title">Sidebar</h3>
   <dl class="_shortcuts-dl">
     <dt class="_shortcuts-dt">
-      #{if app.settings.cache.arrowScroll then '<code class="_shortcut-code">shift</code> + ' else ''}
+      #{if arrowScroll then '<code class="_shortcut-code">shift</code> + ' else ''}
       <code class="_shortcut-code">&darr;</code>
       <code class="_shortcut-code">&uarr;</code>
     <dd class="_shortcuts-dd">Move selection
     <dt class="_shortcuts-dt">
-      #{if app.settings.cache.arrowScroll then '<code class="_shortcut-code">shift</code> + ' else ''}
+      #{if arrowScroll then '<code class="_shortcut-code">shift</code> + ' else ''}
       <code class="_shortcut-code">&rarr;</code>
       <code class="_shortcut-code">&larr;</code>
     <dd class="_shortcuts-dd">Show/hide sub-list
@@ -92,7 +93,7 @@ app.templates.helpPage = ->
       <code class="_shortcut-code">#{navKey} + &rarr;</code>
     <dd class="_shortcuts-dd">Go back/forward
     <dt class="_shortcuts-dt">
-      #{if app.settings.cache.arrowScroll
+      #{if arrowScroll
           '<code class="_shortcut-code">&darr;</code> ' +
           '<code class="_shortcut-code">&uarr;</code>'
         else

--- a/assets/javascripts/templates/pages/help_tmpl.coffee
+++ b/assets/javascripts/templates/pages/help_tmpl.coffee
@@ -66,10 +66,12 @@ app.templates.helpPage = ->
   <h3 class="_shortcuts-title">Sidebar</h3>
   <dl class="_shortcuts-dl">
     <dt class="_shortcuts-dt">
+      #{if app.settings.cache.arrowScroll then '<code class="_shortcut-code">shift</code> + ' else ''}
       <code class="_shortcut-code">&darr;</code>
       <code class="_shortcut-code">&uarr;</code>
     <dd class="_shortcuts-dd">Move selection
     <dt class="_shortcuts-dt">
+      #{if app.settings.cache.arrowScroll then '<code class="_shortcut-code">shift</code> + ' else ''}
       <code class="_shortcut-code">&rarr;</code>
       <code class="_shortcut-code">&larr;</code>
     <dd class="_shortcuts-dd">Show/hide sub-list
@@ -90,11 +92,15 @@ app.templates.helpPage = ->
       <code class="_shortcut-code">#{navKey} + &rarr;</code>
     <dd class="_shortcuts-dd">Go back/forward
     <dt class="_shortcuts-dt">
-      <code class="_shortcut-code">alt + &darr;</code>
-      <code class="_shortcut-code">alt + &uarr;</code>
-      <br>
-      <code class="_shortcut-code">shift + &darr;</code>
-      <code class="_shortcut-code">shift + &uarr;</code>
+      #{if app.settings.cache.arrowScroll
+          '<code class="_shortcut-code">&darr;</code> ' +
+          '<code class="_shortcut-code">&uarr;</code>'
+        else
+          '<code class="_shortcut-code">alt + &darr;</code> ' +
+          '<code class="_shortcut-code">alt + &uarr;</code>' +
+          '<br>' +
+          '<code class="_shortcut-code">shift + &darr;</code> ' +
+          '<code class="_shortcut-code">shift + &uarr;</code>'}
     <dd class="_shortcuts-dd">Scroll step by step<br><br>
     <dt class="_shortcuts-dt">
       <code class="_shortcut-code">space</code>

--- a/assets/javascripts/templates/tip_tmpl.coffee
+++ b/assets/javascripts/templates/tip_tmpl.coffee
@@ -3,8 +3,8 @@ app.templates.tipKeyNav = () -> """
     <strong>ProTip</strong>
     <span class="_notif-info">(click to dismiss)</span>
   <p class="_notif-text">
-    Hit #{if app.settings.cache.arrowScroll then '<code class="_label">shift</code> +' else ''} <code class="_label">&darr;</code> <code class="_label">&uarr;</code> <code class="_label">&larr;</code> <code class="_label">&rarr;</code> to navigate the sidebar.<br>
-    Hit <code class="_label">space / shift space</code>#{if app.settings.cache.arrowScroll then ' or <code class="_label">&darr;/&uarr;</code>' else ', <code class="_label">alt &darr;/&uarr;</code> or <code class="_label">shift &darr;/&uarr;</code>'} to scroll the page.
+    Hit #{if app.settings.get('arrowScroll') then '<code class="_label">shift</code> +' else ''} <code class="_label">&darr;</code> <code class="_label">&uarr;</code> <code class="_label">&larr;</code> <code class="_label">&rarr;</code> to navigate the sidebar.<br>
+    Hit <code class="_label">space / shift space</code>#{if app.settings.get('arrowScroll') then ' or <code class="_label">&darr;/&uarr;</code>' else ', <code class="_label">alt &darr;/&uarr;</code> or <code class="_label">shift &darr;/&uarr;</code>'} to scroll the page.
   <p class="_notif-text">
     <a href="/help#shortcuts" class="_notif-link">See all keyboard shortcuts</a>
 """


### PR DESCRIPTION
# Outcome

This is a follow up to #1418 that updates the arrow scroll copy on the `/help` page depending on if arrow scrolling is enabled in preferences.

#### Help page, arrow scrolling enabled

![Screenshot_2020-12-14 DevDocs](https://user-images.githubusercontent.com/1121087/102151807-83748e80-3e28-11eb-8e01-af322ad35e12.png)

#### Help page, arrow scrolling disabled

![Screenshot_2020-12-14 DevDocs(1)](https://user-images.githubusercontent.com/1121087/102151817-8a9b9c80-3e28-11eb-8395-cf80fe09b3db.png)