### PR TITLE
Typescript: add 'tsconfig' section and update scraper to 4.1.3

### DIFF
--- a/lib/docs/filters/typescript/clean_html.rb
+++ b/lib/docs/filters/typescript/clean_html.rb
@@ -1,8 +1,16 @@
 module Docs
   class Typescript
     class CleanHtmlFilter < Filter
+
       def call
-        root_page? ? root : other
+        if slug.include?('index')
+          root
+        elsif slug == ('tsconfig/')
+          tsconfig
+        else
+          other
+        end
+
         doc
       end
 
@@ -27,6 +35,12 @@ module Docs
           node.remove_attribute('class')
         end
       end
+
+      def tsconfig
+        css('h2 a', 'h3 a').remove
+        css('svg').remove
+      end
+
     end
   end
 end

--- a/lib/docs/filters/typescript/entries.rb
+++ b/lib/docs/filters/typescript/entries.rb
@@ -3,7 +3,7 @@ module Docs
     class EntriesFilter < Docs::EntriesFilter
 
       def get_name
-        return at_css('h2').content
+        at_css('h1') ? at_css('h1').content : at_css('h2').content
       end
 
       def get_type
@@ -11,9 +11,25 @@ module Docs
       end
 
       def additional_entries
-        css('h2').each_with_object [] do |node,entries|
+        entries = []
+
+        css('h2').each do |node|
+
+          if slug == 'tsconfig/'
+            node.css('a').remove
+          end
+
           entries << [node.content, node['id'], name]
         end
+
+        if slug == 'tsconfig/'
+          css('h3').each do |node|
+            node.css('a').remove
+            entries << [node.content, node['id'], name]
+          end
+        end
+
+        entries
       end
 
     end

--- a/lib/docs/scrapers/typescript.rb
+++ b/lib/docs/scrapers/typescript.rb
@@ -2,9 +2,13 @@ module Docs
   class Typescript < UrlScraper
     self.name = 'TypeScript'
     self.type = 'simple'
-    self.release = '4.1.2'
-    self.base_url = 'https://www.typescriptlang.org/docs/handbook/'
-    self.root_path = 'index.html'
+    self.release = '4.1.3'
+    self.base_url = 'https://www.typescriptlang.org/'
+    self.root_path = 'docs/handbook/index.html'
+    self.initial_paths = [
+      'tsconfig/'
+    ]
+
     self.links = {
       home: 'https://www.typescriptlang.org',
       code: 'https://github.com/Microsoft/TypeScript'
@@ -15,13 +19,23 @@ module Docs
     options[:container] = 'main'
 
     options[:skip] = [
-      'react-&-webpack.html',
+      'docs/handbook/react-&-webpack.html'
     ]
 
     options[:skip_patterns] = [
       /2/,
-      /release-notes/,
+      /release-notes/
     ]
+
+    options[:only_patterns] = [
+      /docs\/handbook\//,
+      /tsconfig\//
+    ]
+
+    options[:fix_urls] = -> (url) do
+      url.gsub!(/docs\/handbook\/index.html/, "index.html")
+      url
+    end
 
     options[:attribution] = <<-HTML
       &copy; 2012-2020 Microsoft<br>
@@ -31,5 +45,6 @@ module Docs
     def get_latest_version(opts)
       get_latest_github_release('Microsoft', 'TypeScript', opts)
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Add the documentation requested in #1404 and updates Typescript scraper.
