### PR TITLE
Update Cypress to 6.1.0

### DIFF
--- a/lib/docs/scrapers/cypress.rb
+++ b/lib/docs/scrapers/cypress.rb
@@ -4,7 +4,7 @@ module Docs
   class Cypress < UrlScraper
     self.name = 'Cypress'
     self.type = 'cypress'
-    self.release = '5.6.0'
+    self.release = '6.1.0'
     self.base_url = 'https://docs.cypress.io'
     self.root_path = '/api/api/table-of-contents.html'
     self.links = {


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
