### PR TITLE
manifest.json: revert display from `minimal-ui` to `standalone`

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "DevDocs",
   "description": "API Documentation Browser",
   "start_url": "/",
-  "display": "minimal-ui",
+  "display": "standalone",
   "background_color": "#EEEEEE",
   "icons": [
     {


### PR DESCRIPTION
This reverts commit f0bf95683741e5a0251a3d255d7edace78a6c147.
"Adds a back button to the UI"

First, minimal-ui takes up valuable mobile screen space. We should value the users screen space, and I believe users often install PWA's _specifically_ to recover screen space taken by [browser chrome](1).

Second, devdocs already shows navigation arrows on mobile. A better solution to a lack of back button (on desktop? where?) would be to show those same navigation arrows there, rather than use minimal-ui. Mobile users have back gestures and many PC users have hardware navigation buttons. I could not find a use case for this "back button".

Bullets:
 * `minimal-ui` takes valuable space on mobile
 * Mobile already has navigation buttons
 
[1]: https://developer.mozilla.org/en-US/docs/Glossary/chrome