### PR TITLE
Restore old URLs to TypeScript documentation

### DIFF
--- a/lib/docs/filters/typescript/clean_html.rb
+++ b/lib/docs/filters/typescript/clean_html.rb
@@ -2,15 +2,14 @@ module Docs
   class Typescript
     class CleanHtmlFilter < Filter
 
-      def call
-        if slug.include?('index')
-          root
-        elsif slug == ('tsconfig/')
-          tsconfig
-        else
-          other
-        end
+      LANGUAGE_REPLACE = {
+        'cmd' => 'shell',
+        'sh' => 'shell',
+        'tsx' => 'typescript+html'
+      }
 
+      def call
+        root_page? ? root : other
         doc
       end
 
@@ -24,21 +23,23 @@ module Docs
       end
 
       def other
-        @doc = at_css('article > .whitespace > .markdown')
+        if base_url.path == '/docs/handbook/'
+          @doc = at_css('article > .whitespace > .markdown')
+        else # tsconfig page
+          @doc = at_css('.markdown > div')
 
-        css('.anchor').remove
+          at_css('h2').remove
+        end
 
-        css('a:contains("Try")').remove
+        css('.anchor', 'a:contains("Try")', 'h2 a', 'h3 a', 'svg', '#full-option-list').remove
+
         css('pre').each do |node|
+          language = node.at_css('.language-id') ? node.at_css('.language-id').content : 'typescript'
+          node.css('.language-id').remove
           node.content = node.content
-          node['data-language'] = 'typescript'
+          node['data-language'] = LANGUAGE_REPLACE[language] || language
           node.remove_attribute('class')
         end
-      end
-
-      def tsconfig
-        css('h2 a', 'h3 a').remove
-        css('svg').remove
       end
 
     end

--- a/lib/docs/filters/typescript/entries.rb
+++ b/lib/docs/filters/typescript/entries.rb
@@ -11,25 +11,19 @@ module Docs
       end
 
       def additional_entries
-        entries = []
+        base_url.path == '/' ? tsconfig_entries : handbook_entries
+      end
 
-        css('h2').each do |node|
-
-          if slug == 'tsconfig/'
-            node.css('a').remove
-          end
-
-          entries << [node.content, node['id'], name]
+      def tsconfig_entries
+        css('h3 > code').each_with_object [] do |node, entries|
+          entries << [node.content, node.parent['id']]
         end
+      end
 
-        if slug == 'tsconfig/'
-          css('h3').each do |node|
-            node.css('a').remove
-            entries << [node.content, node['id'], name]
-          end
+      def handbook_entries
+        css('h2').each_with_object [] do |node, entries|
+          entries << [node.content, node['id']]
         end
-
-        entries
       end
 
     end

--- a/lib/docs/scrapers/typescript.rb
+++ b/lib/docs/scrapers/typescript.rb
@@ -1,13 +1,19 @@
 module Docs
   class Typescript < UrlScraper
+    include MultipleBaseUrls
+
     self.name = 'TypeScript'
     self.type = 'simple'
     self.release = '4.1.3'
-    self.base_url = 'https://www.typescriptlang.org/'
-    self.root_path = 'docs/handbook/index.html'
-    self.initial_paths = [
-      'tsconfig/'
+    self.base_urls = [
+      'https://www.typescriptlang.org/docs/handbook/',
+      'https://www.typescriptlang.org/'
     ]
+
+    def initial_urls
+      [ 'https://www.typescriptlang.org/docs/handbook/',
+        'https://www.typescriptlang.org/tsconfig' ]
+    end
 
     self.links = {
       home: 'https://www.typescriptlang.org',
@@ -19,23 +25,14 @@ module Docs
     options[:container] = 'main'
 
     options[:skip] = [
-      'docs/handbook/react-&-webpack.html'
+      'react-&-webpack.html'
     ]
 
     options[:skip_patterns] = [
       /2/,
-      /release-notes/
+      /release-notes/,
+      /play\//
     ]
-
-    options[:only_patterns] = [
-      /docs\/handbook\//,
-      /tsconfig\//
-    ]
-
-    options[:fix_urls] = -> (url) do
-      url.gsub!(/docs\/handbook\/index.html/, "index.html")
-      url
-    end
 
     options[:attribution] = <<-HTML
       &copy; 2012-2020 Microsoft<br>


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

The previous update changed the URLs of all the TypeScript pages. This is generally considered poor form because it messes with search indexes and bookmarks. DevDocs has a mapping function to remap old URLs to new URLs, but it's much easier to just keep the URLs the same if possible.

It is actually possible to add the tsconfig file to the docset without changing the old URLs. It doesn't even take much code. This relies on theMultipleBaseUrls module for UrlScraper, which isn't typically used and isn't documented anywhere.

This also improves the syntax highlighting.