### PR TITLE
Update Sinon version 7 and add version 8 and 9

### DIFF
--- a/lib/docs/filters/sinon/clean_html.rb
+++ b/lib/docs/filters/sinon/clean_html.rb
@@ -20,7 +20,13 @@ module Docs
           node['data-language'] = 'javascript'
         end
 
+        css('#banner-message').remove
+
+        # Removes duplicate title
+        css('#json-p').remove
+
         doc
+
       end
     end
   end

--- a/lib/docs/scrapers/sinon.rb
+++ b/lib/docs/scrapers/sinon.rb
@@ -14,12 +14,31 @@ module Docs
     options[:container] = '.content .container'
 
     options[:attribution] = <<-HTML
-      &copy; 2010&ndash;2018 Christian Johansen<br>
+      &copy; 2010&ndash;2020 Christian Johansen<br>
       Licensed under the BSD License.
     HTML
 
+    # Links in page point to '../page' what makes devdocs points to non-existent links
+    options[:fix_urls] = -> (url) do
+      if !(url =~ /releases\/v\d*/)
+        url.gsub!(/.*releases\//, "")
+      end
+
+      url
+    end
+
+    version '9' do
+      self.release = '9.2.2'
+      self.base_url = "https://sinonjs.org/releases/v#{release}/"
+    end
+
+    version '8' do
+      self.release = '8.1.1'
+      self.base_url = "https://sinonjs.org/releases/v#{release}/"
+    end
+
     version '7' do
-      self.release = '7.1.1'
+      self.release = '7.5.0'
       self.base_url = "https://sinonjs.org/releases/v#{release}/"
     end
 
@@ -54,8 +73,9 @@ module Docs
     end
 
     def get_latest_version(opts)
-      body = fetch('https://sinonjs.org/', opts)
-      body.scan(/\/releases\/v([0-9.]+)/)[0][0]
+      tags = get_github_tags('sinonjs', 'sinon', opts)
+      tags[0]['name'][1..-1]
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
