### PR TITLE
Fix CodeIgniter scraper

### DIFF
--- a/lib/docs/filters/codeigniter/entries.rb
+++ b/lib/docs/filters/codeigniter/entries.rb
@@ -22,12 +22,12 @@ module Docs
       def additional_entries
         entries = []
 
-        css('.class').each do |node|
+        css('.class', '.interface').each do |node|
           class_name = node.at_css('dt > .descname').content.split('\\').last
           class_id = node.at_css('dt[id]')['id']
           entries << [class_name, class_id]
 
-          node.css('.method').each do |n|
+          node.css('.method', '.staticmethod').each do |n|
             next unless n.at_css('dt[id]')
             name = n.at_css('.descname').content
             name = "#{class_name}::#{name}()"
@@ -40,6 +40,13 @@ module Docs
           name = "#{node.at_css('.descname').content}()"
           id = node.at_css('dt[id]')['id']
           type = self.type.start_with?('User guide') ? 'Functions' : self.type
+          entries << [name, id, type]
+        end
+
+        css('.const').each do |node|
+          name = node.at_css('.descname').content
+          id = node.at_css('dt[id]')['id']
+          type = self.type.start_with?('User guide') ? 'Global Constants' : self.type
           entries << [name, id, type]
         end
 

--- a/lib/docs/filters/sphinx/clean_html.rb
+++ b/lib/docs/filters/sphinx/clean_html.rb
@@ -20,8 +20,8 @@ module Docs
         css('div[class*="highlight-"]', 'div[class*="hl-"]').each do |node|
           pre = node.at_css('pre')
           pre.content = pre.content
-          lang = node['class'][/code (\w+) highlight/, 1] || node['class'][/highlight\-(\w+)/, 1] || node['class'][/hl\-(\w+)/, 1]
-          lang = 'php' if lang == 'ci'
+          lang = node['class'][/code (\w+) highlight/, 1] || node['class'][/highlight\-([\w\+]+)/, 1] || node['class'][/hl\-(\w+)/, 1]
+          lang = 'php' if lang == 'ci'|| lang == 'html+php'
           lang = 'markup' if lang == 'html+django'
           lang = 'bash' if lang == 'bash'
           lang = 'python' if lang == 'default' || lang.start_with?('python') || lang.start_with?('ipython')

--- a/lib/docs/scrapers/codeigniter.rb
+++ b/lib/docs/scrapers/codeigniter.rb
@@ -10,8 +10,6 @@ module Docs
 
     html_filters.push 'codeigniter/entries', 'sphinx/clean_html'
 
-    options[:container] = '.document'
-
     options[:skip] = %w(
       license.html
       changelog.html
@@ -26,6 +24,7 @@ module Docs
     options[:skip_patterns] = [
       /\Acontributing/,
       /\Adocumentation/,
+      /\Achangelogs/,
       /\Ainstallation\/upgrade/
     ]
 
@@ -37,11 +36,15 @@ module Docs
     version '4' do
       self.release = '4.0.4'
       self.base_url = 'https://codeigniter.com/userguide4/'
+
+      options[:container] = '.document > div'
     end
 
     version '3' do
       self.release = '3.1.8'
       self.base_url = 'https://codeigniter.com/userguide3/'
+
+      options[:container] = '.document'
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

This isn't a version update, but a modification that adds some missing entries. The HTML tags changed slightly between v3 and v4 of CodeIgniter and a few entries were missing.
