### PR TITLE
Mention formalized coding conventions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,6 +79,9 @@ Follow the following steps to update documentations to their latest version:
 * no trailing whitespace; blank lines should have no spaces; new line at end-of-file
 * use the same coding style as the rest of the codebase
 
+These conventions are formalized in [our `.editorconfig` file](../.editorconfig).
+Check out [EditorConfig.org](https://editorconfig.org/) to learn how to make your tools adhere to it.
+
 ## Questions?
 
 If you have any questions, please feel free to ask them on the contributor chat room on [Gitter](https://gitter.im/FreeCodeCamp/DevDocs).


### PR DESCRIPTION
Correction of https://github.com/freeCodeCamp/devdocs/pull/1173 ;-)

I noticed that in your CONTRIBUTING.md, [the "Coding conventions" section](https://github.com/freeCodeCamp/devdocs/blame/40df521a7cef562aa72a01a59aa58d92828c906e/.github/CONTRIBUTING.md#L78-L80) contained some details that were later [automated in the .editorconfig](https://github.com/freeCodeCamp/devdocs/blame/40df521a7cef562aa72a01a59aa58d92828c906e/.editorconfig#L5-L6).