### PR TITLE
Update Chef documentation (16.8.14)

### DIFF
--- a/lib/docs/scrapers/chef.rb
+++ b/lib/docs/scrapers/chef.rb
@@ -21,7 +21,7 @@ module Docs
     HTML
 
     version '16' do
-      self.release = '16.7.61'
+      self.release = '16.8.14'
 
       options[:container] = '.off-canvas-wrapper'
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
