### PR TITLE
Update Redis documentation (6.0.9)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -688,7 +688,7 @@ credits = [
     'https://raw.githubusercontent.com/ReactiveX/reactivex.github.io/develop/LICENSE'
   ], [
     'Redis',
-    '2009-2018 Salvatore Sanfilippo',
+    '2009-2020 Salvatore Sanfilippo',
     'CC BY-SA',
     'https://creativecommons.org/licenses/by-sa/4.0/'
   ], [

--- a/lib/docs/scrapers/redis.rb
+++ b/lib/docs/scrapers/redis.rb
@@ -1,11 +1,11 @@
 module Docs
   class Redis < UrlScraper
     self.type = 'redis'
-    self.release = '5.0.0'
+    self.release = '6.0.9'
     self.base_url = 'https://redis.io/commands'
     self.links = {
       home: 'https://redis.io/',
-      code: 'https://github.com/antirez/redis'
+      code: 'https://github.com/redis/redis'
     }
 
     html_filters.push 'redis/entries', 'redis/clean_html', 'title'
@@ -16,7 +16,7 @@ module Docs
     options[:follow_links] = ->(filter) { filter.root_page? }
 
     options[:attribution] = <<-HTML
-      &copy; 2009&ndash;2018 Salvatore Sanfilippo<br>
+      &copy; 2009&ndash;2020 Salvatore Sanfilippo<br>
       Licensed under the Creative Commons Attribution-ShareAlike License 4.0.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
