### PR TITLE
Update Sequelize documentation (6.3.5)

### DIFF
--- a/lib/docs/scrapers/sequelize.rb
+++ b/lib/docs/scrapers/sequelize.rb
@@ -3,8 +3,6 @@ module Docs
     self.name = 'Sequelize'
     self.slug = 'sequelize'
     self.type = 'simple'
-    self.release = '5.21.1'
-    self.base_url = 'https://sequelize.org/master/'
     self.links = {
       home: 'https://sequelize.org/',
       code: 'https://github.com/sequelize/sequelize'
@@ -21,6 +19,21 @@ module Docs
       Copyright &copy; 2014&ndash;present Sequelize contributors<br>
       Licensed under the MIT License.
     HTML
+
+    version '6' do
+      self.release = '6.3.5'
+      self.base_url = "https://sequelize.org/master/"
+    end
+
+    version '5' do
+      self.release = '5.22.0'
+      self.base_url = "https://sequelize.org/v#{version}/"
+    end
+
+    version '4' do
+      self.release = '4.44.4'
+      self.base_url = "https://sequelize.org/v#{version}/"
+    end
 
     # Method to fetch the most recent version of the project
     def get_latest_version(opts)


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
