### PR TITLE
Update WordPress documentation (5.6)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -853,7 +853,7 @@ credits = [
     'https://github.com/pallets/werkzeug/blob/master/LICENSE.rst'
   ], [
     'Wordpress',
-    '2003-2019 WordPress Foundation',
+    '2003-2020 WordPress Foundation',
     'GPLv2+',
     'https://wordpress.org/about/license/'
   ], [

--- a/lib/docs/scrapers/wordpress.rb
+++ b/lib/docs/scrapers/wordpress.rb
@@ -2,7 +2,7 @@ module Docs
   class Wordpress < UrlScraper
     self.name = 'WordPress'
     self.type = 'wordpress'
-    self.release = '5.5.3'
+    self.release = '5.6'
     self.base_url = 'https://developer.wordpress.org/reference/'
     self.initial_paths = %w(
       functions/
@@ -32,7 +32,7 @@ module Docs
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2003&ndash;2019 WordPress Foundation<br>
+      &copy; 2003&ndash;2020 WordPress Foundation<br>
       Licensed under the GNU GPLv2+ License.
     HTML
 


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
