### PR TITLE
Add Ruby version 3

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -163,6 +163,18 @@ tar xj --strip-components=1
 ### Ruby / Minitest
 ### Ruby on Rails
 ### Ruby
+Download the tarball of Ruby from https://www.ruby-lang.org/en/downloads/, extract it, run
+`./configure && make html` in your terminal (while your are in the ruby directory) and move
+`.ext/html` to `path/to/devdocs/docs/ruby~$VERSION/`.
+
+Or run the following commands in your terminal:
+```sh
+curl https://cache.ruby-lang.org/pub/ruby/$VERSION/ruby-$RELEASE.tar.gz > ruby.tar; \
+tar -xf ruby.tar; cd ruby-$RELEASE; ./configure && make html; mv .ext/html path/to/devdocs/docs/ruby~$VERSION
+```
+
+To generate the htmls file you have to run `make` command but it does not install Ruby in your system, only generates html files so you have not
+to worry about cleaning or removing a new Ruby installation.
 
 ## Salt Stack
 

--- a/lib/docs/scrapers/rdoc/ruby.rb
+++ b/lib/docs/scrapers/rdoc/ruby.rb
@@ -63,11 +63,15 @@ module Docs
       /\AXMP/]
 
     options[:attribution] = <<-HTML
-      Ruby Core &copy; 1993&ndash;2017 Yukihiro Matsumoto<br>
+      Ruby Core &copy; 1993&ndash;2020 Yukihiro Matsumoto<br>
       Licensed under the Ruby License.<br>
       Ruby Standard Library &copy; contributors<br>
       Licensed under their own licenses.
     HTML
+
+    version '3' do
+      self.release = '3.0.0'
+    end
 
     version '2.7' do
       self.release = '2.7.2'
@@ -102,6 +106,7 @@ module Docs
           return version
         end
       end
+
     end
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
