### PR TITLE
Add Phpunit version 8 and 9

### DIFF
--- a/lib/docs/filters/phpunit/clean_html.rb
+++ b/lib/docs/filters/phpunit/clean_html.rb
@@ -2,59 +2,20 @@ module Docs
   class Phpunit
     class CleanHtmlFilter < Filter
       def call
-        root_page? ? root : other
-        doc
-      end
 
-      def root
-        doc.inner_html = ' '
-      end
-
-      def other
-        @doc = doc.at_css('div.appendix, div.chapter')
-
-        css('.example-break', '.table-break').remove
-
-        css('a[id]').each do |node|
-          next unless node.content.blank?
-          node.parent['id'] = node['id']
-          node.remove
-        end
-
-        css('.titlepage').each do |node|
-          title = node.at_css('h1, .title')
-          title.content = title.content.remove(/(Chapter|Appendix)\s+\w+\.\s+/)
-          node.before(title).remove
-        end
-
-        css('.section').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('[style], [border], [valign]').each do |node|
-          node.remove_attribute('style')
-          node.remove_attribute('border')
-          node.remove_attribute('valign')
-        end
-
-        css('.warning h3', '.alert h3').each do |node|
-          node.remove if node.content == 'Note'
-        end
-
-        css('p > code.literal:first-child:last-child').each do |node|
-          next if node.previous_sibling && node.previous_sibling.content.present?
-          next if node.next_sibling && node.next_sibling.content.present?
-          node.parent.name = 'pre'
-          node.parent['class'] = 'programlisting'
-          node.parent.content = node.content
-        end
-
-        css('pre', '.term').each do |node|
-          node.content = node.content
-        end
-
-        css('pre.programlisting').each do |node|
+        css('pre').each do |node|
+          node['class'] = 'highlight'
           node['data-language'] = 'php'
+        end
+
+        if slug.match(/assertion|annotations|configuration/)
+          css('h2').each do |node|
+            node['id'] = node.content
+          end
+        end
+
+        css('h1').each do |node|
+          node.content = node.content.gsub(/\d*\./, '').strip
         end
 
         doc

--- a/lib/docs/filters/phpunit/clean_html_old.rb
+++ b/lib/docs/filters/phpunit/clean_html_old.rb
@@ -1,0 +1,64 @@
+module Docs
+  class Phpunit
+    class CleanHtmlOldFilter < Filter
+      def call
+        root_page? ? root : other
+        doc
+      end
+
+      def root
+        doc.inner_html = ' '
+      end
+
+      def other
+        @doc = doc.at_css('div.appendix, div.chapter')
+
+        css('.example-break', '.table-break').remove
+
+        css('a[id]').each do |node|
+          next unless node.content.blank?
+          node.parent['id'] = node['id']
+          node.remove
+        end
+
+        css('.titlepage').each do |node|
+          title = node.at_css('h1, .title')
+          title.content = title.content.remove(/(Chapter|Appendix)\s+\w+\.\s+/)
+          node.before(title).remove
+        end
+
+        css('.section').each do |node|
+          node.before(node.children).remove
+        end
+
+        css('[style], [border], [valign]').each do |node|
+          node.remove_attribute('style')
+          node.remove_attribute('border')
+          node.remove_attribute('valign')
+        end
+
+        css('.warning h3', '.alert h3').each do |node|
+          node.remove if node.content == 'Note'
+        end
+
+        css('p > code.literal:first-child:last-child').each do |node|
+          next if node.previous_sibling && node.previous_sibling.content.present?
+          next if node.next_sibling && node.next_sibling.content.present?
+          node.parent.name = 'pre'
+          node.parent['class'] = 'programlisting'
+          node.parent.content = node.content
+        end
+
+        css('pre', '.term').each do |node|
+          node.content = node.content
+        end
+
+        css('pre.programlisting').each do |node|
+          node['data-language'] = 'php'
+        end
+
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/phpunit/entries_old.rb
+++ b/lib/docs/filters/phpunit/entries_old.rb
@@ -1,13 +1,12 @@
 module Docs
   class Phpunit
-    class EntriesFilter < Docs::EntriesFilter
-
+    class EntriesOldFilter < Docs::EntriesFilter
       def get_name
         at_css('h1').content
       end
 
       def get_type
-        if name.in? ['Assertions', 'Annotations', 'The XML Configuration File']
+        if name.in?(%w(Assertions Annotations))
           name
         else
           'Guides'
@@ -21,7 +20,6 @@ module Docs
           [node.content, node['id']]
         end
       end
-
     end
   end
 end

--- a/lib/docs/scrapers/phpunit.rb
+++ b/lib/docs/scrapers/phpunit.rb
@@ -8,34 +8,71 @@ module Docs
       code: 'https://github.com/sebastianbergmann/phpunit'
     }
 
-    html_filters.push 'phpunit/clean_html', 'phpunit/entries', 'title'
+    options[:skip] = [
+      'bibliography.html',
+      'copyright.html'
+    ]
 
     options[:root_title] = 'PHPUnit'
     options[:title] = false
 
-    options[:skip] = %w(
+    options[:attribution] = <<-HTML
+      &copy; 2005&ndash;2020 Sebastian Bergmann<br>
+      Licensed under the Creative Commons Attribution 3.0 Unported License.
+    HTML
+
+    FILTERS = %w(phpunit/clean_html phpunit/entries title)
+
+    version '9' do
+      self.release = '9.5'
+      self.base_url = "https://phpunit.readthedocs.io/en/#{release}/"
+
+      html_filters.push FILTERS
+
+      options[:container] = '.document'
+    end
+
+    version '8' do
+      self.release = '8.5'
+      self.base_url = "https://phpunit.readthedocs.io/en/#{release}/"
+
+      html_filters.push FILTERS
+
+      options[:container] = '.document'
+    end
+
+    OLDFILTERS = %w(phpunit/clean_html_old phpunit/entries_old title)
+
+    OLDSKIP = %w(
       appendixes.index.html
       appendixes.bibliography.html
       appendixes.copyright.html)
 
-    options[:attribution] = <<-HTML
-      &copy; 2005&ndash;2017 Sebastian Bergmann<br>
-      Licensed under the Creative Commons Attribution 3.0 Unported License.
-    HTML
-
     version '6' do
       self.release = '6.5'
       self.base_url = "https://phpunit.de/manual/#{release}/en/"
+
+      html_filters.push OLDFILTERS
+
+      options[:skip] = OLDSKIP
     end
 
     version '5' do
       self.release = '5.7'
       self.base_url = "https://phpunit.de/manual/#{release}/en/"
+
+      html_filters.push OLDFILTERS
+
+      options[:skip] = OLDSKIP
     end
 
     version '4' do
       self.release = '4.8'
       self.base_url = "https://phpunit.de/manual/#{release}/en/"
+
+      options[:skip] = OLDSKIP
+
+      html_filters.push OLDFILTERS
     end
 
     def get_latest_version(opts)
@@ -43,5 +80,6 @@ module Docs
       label = doc.at_css('.rst-current-version').content.strip
       label.scan(/v: ([0-9.]+)/)[0][0]
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
