### PR TITLE
Add Socketio version 2 and 3

### DIFF
--- a/lib/docs/filters/socketio/clean_html.rb
+++ b/lib/docs/filters/socketio/clean_html.rb
@@ -2,17 +2,19 @@ module Docs
   class Socketio
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.entry-content')
 
         css('p > br').each do |node|
           node.remove unless node.next.content =~ /\s*\-/
         end
 
-        css('h1, h2, h3').each do |node|
-          next if node == doc.first_element_child
-          node.name = node.name.sub(/\d/) { |i| i.to_i + 1 }
-          node['id'] = node.content.strip.parameterize
-        end
+        # version documentation message
+        css('.warning').remove
+
+        css('header').remove
+
+        css('aside').remove
+
+        css('footer').remove
 
         css('pre').each do |node|
           node.content = node.content

--- a/lib/docs/filters/socketio/entries.rb
+++ b/lib/docs/filters/socketio/entries.rb
@@ -6,7 +6,11 @@ module Docs
       end
 
       def get_type
-        'Guides'
+        if slug =~ /events|room|emit/ && version.eql?('3')
+          'Events'
+        else
+          'Guides'
+        end
       end
 
       def additional_entries

--- a/lib/docs/scrapers/socketio.rb
+++ b/lib/docs/scrapers/socketio.rb
@@ -3,8 +3,6 @@ module Docs
     self.name = 'Socket.IO'
     self.slug = 'socketio'
     self.type = 'socketio'
-    self.release = '1.4.5'
-    self.base_url = 'http://socket.io/docs/'
     self.links = {
       home: 'http://socket.io/',
       code: 'https://github.com/socketio/socket.io'
@@ -12,17 +10,27 @@ module Docs
 
     html_filters.push 'socketio/clean_html', 'socketio/entries'
 
-    options[:container] = '#content'
     options[:trailing_slash] = false
-    options[:skip] = %w(faq)
+    options[:skip] = %w(/faq /glossary)
 
     options[:attribution] = <<-HTML
-      &copy; 2014&ndash;2015 Automattic<br>
+      &copy; 2014&ndash;2020 Automattic<br>
       Licensed under the MIT License.
     HTML
+
+    version '3' do
+      self.release = '3.0.5'
+      self.base_url = "https://socket.io/docs/v#{version}"
+    end
+
+    version '2' do
+      self.release = '2.4.0'
+      self.base_url = "https://socket.io/docs/v#{version}"
+    end
 
     def get_latest_version(opts)
       get_npm_version('socket.io', opts)
     end
+
   end
 end


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
