### PR TITLE
Minor Fix PHPUnit, SocketIO

### DIFF
--- a/lib/docs/filters/phpunit/clean_html.rb
+++ b/lib/docs/filters/phpunit/clean_html.rb
@@ -2,6 +2,7 @@ module Docs
   class Phpunit
     class CleanHtmlFilter < Filter
       def call
+        @doc = at_css('.section') if not root_page?
 
         css('pre').each do |node|
           node['class'] = 'highlight'

--- a/lib/docs/filters/socketio/clean_html.rb
+++ b/lib/docs/filters/socketio/clean_html.rb
@@ -2,19 +2,16 @@ module Docs
   class Socketio
     class CleanHtmlFilter < Filter
       def call
+        @doc = at_css('article')
 
         css('p > br').each do |node|
           node.remove unless node.next.content =~ /\s*\-/
         end
 
         # version documentation message
-        css('.warning').remove
+        at_css('.warning').remove
 
-        css('header').remove
-
-        css('aside').remove
-
-        css('footer').remove
+        css('header', 'footer', 'aside').remove
 
         css('pre').each do |node|
           node.content = node.content

--- a/lib/docs/filters/socketio/entries.rb
+++ b/lib/docs/filters/socketio/entries.rb
@@ -18,12 +18,8 @@ module Docs
 
         css('h3').each_with_object([]) do |node, entries|
           name = node.content
-          name.remove! %r{\(.*}
-          name.remove! %r{\:.*}
 
-          unless entries.any? { |entry| entry[0] == name }
-            entries << [name, node['id'], self.name.remove(' API')]
-          end
+          entries << [name, node['id'], self.name.remove(' API')]
         end
       end
     end


### PR DESCRIPTION
This changes the base HTML tag for page fragments. Fixes small appearance problem on every page with the header.

Compare: 
![before](https://user-images.githubusercontent.com/546533/104074962-83756d80-51df-11eb-8947-acce6f31c5e6.png)
to:
![after](https://user-images.githubusercontent.com/546533/104074974-8b351200-51df-11eb-8e95-bbd861b45585.png)
