### PR TITLE
Update Erlang documentation (23.2)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -283,7 +283,7 @@ credits = [
     'https://raw.githubusercontent.com/airbnb/enzyme/master/LICENSE.md'
   ], [
     'Erlang',
-    '2010-2017 Ericsson AB',
+    '2010-2020 Ericsson AB',
     'Apache',
     'https://raw.githubusercontent.com/erlang/otp/maint/LICENSE.txt'
   ], [

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -41,6 +41,12 @@ bsdtar --extract --file - --directory=docs/django\~$VERSION/
 
 Go to https://www.erlang.org/downloads and download the HTML documentation file.
 
+```ah
+mkdir --parent docs/erlang\~$VERSION/; \
+curl http://erlang.org/download/otp_doc_html_23.2.tar.gz | \
+bsdtar --extract --file - --directory=docs/erlang\~$VERSION/
+```
+
 ## Gnu
 
 ### GCC

--- a/lib/docs/filters/erlang/clean_html.rb
+++ b/lib/docs/filters/erlang/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class Erlang
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('#content .innertube')
+        @doc = at_css('#content')
 
         # frontpage
 

--- a/lib/docs/scrapers/erlang.rb
+++ b/lib/docs/scrapers/erlang.rb
@@ -36,9 +36,17 @@ module Docs
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2010&ndash;2017 Ericsson AB<br>
+      &copy; 2010&ndash;2020 Ericsson AB<br>
       Licensed under the Apache License, Version 2.0.
     HTML
+
+    version '23' do
+      self.release = '23.2'
+    end
+
+    version '22' do
+      self.release = '22.3'
+    end
 
     version '21' do
       self.release = '21.0'


### PR DESCRIPTION
If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
