### PR TITLE
Update crystal to 0.36.1

### DIFF
--- a/lib/docs/filters/crystal/clean_html.rb
+++ b/lib/docs/filters/crystal/clean_html.rb
@@ -2,14 +2,17 @@ module Docs
   class Crystal
     class CleanHtmlFilter < Filter
       def call
-        slug.start_with?('docs') ? book : api
+        slug.start_with?('reference') ? book : api
         doc
       end
 
       def book
-        @doc = at_css('.page-inner section')
+        @doc = at_css('main article')
+
+        css('.headerlink').remove
 
         css('pre > code').each do |node|
+          node.parent['data-language'] = 'crystal'
           node.parent['data-language'] = node['class'][/lang-(\w+)/, 1] if node['class']
           node.parent.content = node.parent.content
         end

--- a/lib/docs/filters/crystal/entries.rb
+++ b/lib/docs/filters/crystal/entries.rb
@@ -2,10 +2,11 @@ module Docs
   class Crystal
     class EntriesFilter < Docs::EntriesFilter
       def get_name
-        if slug.start_with?('docs/')
-          name = at_css('.page-inner h1').content.strip
+        if slug.start_with?('reference/')
+          name = at_css('main h1').content.strip
+          name.remove! '¶'
 
-          if slug.start_with?('docs/syntax_and_semantics')
+          if slug.start_with?('reference/syntax_and_semantics')
             name.prepend "#{slug.split('/')[2].titleize}: " if slug.split('/').length > 3
           elsif slug.split('/').length > 1
             chapter = slug.split('/')[1].titleize.capitalize
@@ -23,9 +24,9 @@ module Docs
       def get_type
         return if root_page?
 
-        if slug.start_with?('docs/syntax_and_semantics')
+        if slug.start_with?('reference/syntax_and_semantics')
           'Book: Language'
-        elsif slug.start_with?('docs/')
+        elsif slug.start_with?('reference/')
           'Book'
         else
           hierarchy = at_css('.superclass-hierarchy')

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -2,7 +2,7 @@ module Docs
   class Crystal < UrlScraper
     self.type = 'crystal'
     self.base_url = 'https://crystal-lang.org/'
-    self.initial_paths = %w(docs/index.html)
+    self.initial_paths = %w(reference/index.html)
     self.links = {
       home: 'https://crystal-lang.org/',
       code: 'https://github.com/crystal-lang/crystal'
@@ -11,7 +11,7 @@ module Docs
     html_filters.push 'crystal/entries', 'crystal/clean_html'
 
     options[:attribution] = ->(filter) {
-      if filter.slug.start_with?('docs')
+      if filter.slug.start_with?('reference')
         <<-HTML
           To the extent possible under law, the persons who contributed to this work
           have waived<br>all copyright and related or neighboring rights to this work
@@ -29,12 +29,12 @@ module Docs
       self.release = '0.36.1'
       self.root_path = "api/#{release}/index.html"
 
-      options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]
+      options[:only_patterns] = [/\Aapi\/#{release}\//, /\Areference\//]
       options[:skip_patterns] = [/debug/i]
 
       options[:replace_paths] = {
         "api/#{release}/" => "api/#{release}/index.html",
-        'docs/' => 'docs/index.html'
+        'reference/' => 'reference/index.html'
       }
     end
 

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -26,7 +26,7 @@ module Docs
     }
 
     version do
-      self.release = '0.35.1'
+      self.release = '0.36.1'
       self.root_path = "api/#{release}/index.html"
 
       options[:only_patterns] = [/\Adocs\//, /\Aapi\/#{release}\//]


### PR DESCRIPTION
closes #1476

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
