### PR TITLE
feat: migrate to Cloudflare

### DIFF
--- a/assets/javascripts/app/config.coffee.erb
+++ b/assets/javascripts/app/config.coffee.erb
@@ -12,7 +12,7 @@ app.config =
   sentry_dsn: '<%= App.sentry_dsn %>'
   version: <%= Time.now.to_i %>
   release: <%= Time.now.utc.httpdate.to_json %>
-  mathml_stylesheet: '<%= App.cdn_origin %>/mathml.css'
+  mathml_stylesheet: '/mathml.css'
   favicon_spritesheet: '<%= image_path('sprites/docs.png') %>'
   service_worker_path: '/service-worker.js'
   service_worker_enabled: <%= App.environment == :production || ENV['ENABLE_SERVICE_WORKER'] == 'true' %>

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -73,7 +73,7 @@ class App < Sinatra::Application
 
   configure :production do
     set :static, false
-    set :docs_origin, '//docs.devdocs.io'
+    set :docs_origin, '//documents.devdocs.in'
     set :csp, "default-src 'self' *; script-src 'self' 'nonce-devdocs' https://www.google-analytics.com https://secure.gaug.es https://*.jquery.com; font-src 'none'; style-src 'self' 'unsafe-inline' *; img-src 'self' * data:;"
 
     use Rack::ConditionalGet

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -73,7 +73,7 @@ class App < Sinatra::Application
 
   configure :production do
     set :static, false
-    set :docs_origin, '//documents.devdocs.in'
+    set :docs_origin, '//documents.devdocs.io'
     set :csp, "default-src 'self' *; script-src 'self' 'nonce-devdocs' https://www.google-analytics.com https://secure.gaug.es https://*.jquery.com; font-src 'none'; style-src 'self' 'unsafe-inline' *; img-src 'self' * data:;"
 
     use Rack::ConditionalGet

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -20,8 +20,6 @@ class App < Sinatra::Application
     set :root, Pathname.new(File.expand_path('../..', __FILE__))
     set :sprockets, Sprockets::Environment.new(root)
 
-    set :cdn_origin, ''
-
     set :assets_prefix, 'assets'
     set :assets_path, File.join(public_folder, assets_prefix)
     set :assets_manifest_path, File.join(assets_path, 'manifest.json')
@@ -75,9 +73,8 @@ class App < Sinatra::Application
 
   configure :production do
     set :static, false
-    set :cdn_origin, 'https://cdn.devdocs.io'
     set :docs_origin, '//docs.devdocs.io'
-    set :csp, "default-src 'self' *; script-src 'self' 'nonce-devdocs' https://cdn.devdocs.io https://www.google-analytics.com https://secure.gaug.es https://*.jquery.com; font-src 'none'; style-src 'self' 'unsafe-inline' *; img-src 'self' * data:;"
+    set :csp, "default-src 'self' *; script-src 'self' 'nonce-devdocs' https://www.google-analytics.com https://secure.gaug.es https://*.jquery.com; font-src 'none'; style-src 'self' 'unsafe-inline' *; img-src 'self' * data:;"
 
     use Rack::ConditionalGet
     use Rack::ETag
@@ -102,7 +99,6 @@ class App < Sinatra::Application
 
     Sprockets::Helpers.configure do |config|
       config.digest = true
-      config.asset_host = 'cdn.devdocs.io'
       config.manifest = Sprockets::Manifest.new(sprockets, assets_manifest_path)
     end
   end
@@ -202,7 +198,7 @@ class App < Sinatra::Application
 
     def service_worker_asset_urls
       @@service_worker_asset_urls ||= [
-        javascript_path('application', asset_host: false),
+        javascript_path('application'),
         stylesheet_path('application'),
         image_path('sprites/docs.png'),
         image_path('sprites/docs@2x.png'),

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -203,7 +203,7 @@ class DocsCLI < Thor
     docs.each do |doc|
       filename = "#{doc.path}.tar.gz"
       print "[S3 bundle] Uploading #{filename}..."
-      cmd = "aws s3 cp #{File.join(Docs.store_path, filename)} s3://devdocs-downloads/bundles/#{filename} --profile devdocs"
+      cmd = "aws s3 cp #{File.join(Docs.store_path, filename)} s3://devdocs-downloads/#{filename} --profile devdocs"
       cmd << ' --dryrun' if options[:dryrun]
       system(cmd)
     end
@@ -337,7 +337,7 @@ class DocsCLI < Thor
 
   def download_doc(doc)
     target_path = File.join(Docs.store_path, doc.path)
-    open "https://downloads.devdocs.io/bundles/#{doc.path}.tar.gz" do |file|
+    open "https://downloads.devdocs.io/#{doc.path}.tar.gz" do |file|
       FileUtils.mkpath(target_path)
       file.close
       tar = UnixUtils.gunzip(file.path)

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -197,8 +197,7 @@ class DocsCLI < Thor
     end
     puts '[S3] Done syncing.'
 
-    # Upload packages to dl.devdocs.io (used by the "thor docs:download" command)
-    # TODO(MIGRATION): replace this with an S3 bucket upload.
+    # Upload packages to downloads.devdocs.io (used by the "thor docs:download" command)
     puts '[S3 bundle] Begin uploading.'
 
     docs.each do |doc|

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -202,7 +202,7 @@ class DocsCLI < Thor
 
     docs.each do |doc|
       filename = "#{doc.path}.tar.gz"
-      print "[S3 bundle] Uploading #{filename}..."
+      puts "[S3 bundle] Uploading #{filename}..."
       cmd = "aws s3 cp #{File.join(Docs.store_path, filename)} s3://devdocs-downloads/#{filename} --profile devdocs"
       cmd << ' --dryrun' if options[:dryrun]
       system(cmd)

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -198,6 +198,7 @@ class DocsCLI < Thor
     puts '[S3] Done syncing.'
 
     # Upload packages to dl.devdocs.io (used by the "thor docs:download" command)
+    # TODO(MIGRATION): replace this with an S3 bucket upload.
     puts '[MaxCDN] Begin uploading.'
     Net::SFTP.start('ftp.devdocs-dl.devdocs.netdna-cdn.com', ENV['DEVDOCS_DL_USERNAME'], password: ENV['DEVDOCS_DL_PASSWORD']) do |sftp|
       docs.each do |doc|

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -191,7 +191,7 @@ class DocsCLI < Thor
     puts '[S3] Begin syncing.'
     docs.each do |doc|
       puts "[S3] Syncing #{doc.path}..."
-      cmd = "aws s3 sync #{File.join(Docs.store_path, doc.path)} s3://devdocs-staging-documents/#{doc.path} --delete --profile devdocs"
+      cmd = "aws s3 sync #{File.join(Docs.store_path, doc.path)} s3://devdocs-documents/#{doc.path} --delete --profile devdocs"
       cmd << ' --dryrun' if options[:dryrun]
       system(cmd)
     end
@@ -204,7 +204,7 @@ class DocsCLI < Thor
     docs.each do |doc|
       filename = "#{doc.path}.tar.gz"
       print "[S3 bundle] Uploading #{filename}..."
-      cmd = "aws s3 cp #{File.join(Docs.store_path, filename)} s3://devdocs-staging-downloads/bundles/#{filename} --profile devdocs"
+      cmd = "aws s3 cp #{File.join(Docs.store_path, filename)} s3://devdocs-downloads/bundles/#{filename} --profile devdocs"
       cmd << ' --dryrun' if options[:dryrun]
       system(cmd)
     end

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -241,7 +241,7 @@ class DocsCLI < Thor
           FileUtils.mkpath(dir)
 
           ['index.json', 'meta.json'].each do |filename|
-            json = "https://documents.devdocs.in/#{doc.path}/#{filename}?#{time}"
+            json = "https://documents.devdocs.io/#{doc.path}/#{filename}?#{time}"
             begin
               open(json) do |file|
                 mutex.synchronize do
@@ -338,7 +338,7 @@ class DocsCLI < Thor
 
   def download_doc(doc)
     target_path = File.join(Docs.store_path, doc.path)
-    open "https://downloads.devdocs.in/bundles/#{doc.path}.tar.gz" do |file|
+    open "https://downloads.devdocs.io/bundles/#{doc.path}.tar.gz" do |file|
       FileUtils.mkpath(target_path)
       file.close
       tar = UnixUtils.gunzip(file.path)

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -4,8 +4,8 @@
   <Description>Search API documentation</Description>
   <Tags>devdocs</Tags>
   <Url type="text/html" method="get" template="https://devdocs.io/#q={searchTerms}"/>
-  <Image height="16" width="16" type="image/vnd.microsoft.icon">https://cdn.devdocs.io/favicon.ico</Image>
-  <Image height="64" width="64" type="image/x-icon">https://cdn.devdocs.io/images/icon-64.png</Image>
+  <Image height="16" width="16" type="image/vnd.microsoft.icon">https://devdocs.io/favicon.ico</Image>
+  <Image height="64" width="64" type="image/x-icon">https://devdocs.io/images/icon-64.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
   <moz:SearchForm>https://devdocs.io</moz:SearchForm>
   <Url type="application/opensearchdescription+xml" rel="self" template="https://devdocs.io/opensearch.xml"/>

--- a/views/index.erb
+++ b/views/index.erb
@@ -9,7 +9,7 @@
   <meta property="og:description" content="Fast, offline, and free documentation browser for developers. Search 100+ docs in one web app including HTML, CSS, JavaScript, PHP, Ruby, Python, Go, C, C++, and many more.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="<%= canonical_origin %>">
-  <meta property="og:image" content="<%= App.cdn_origin %>/images/icon-320.png">
+  <meta property="og:image" content="/images/icon-320.png">
   <meta name="apple-mobile-web-app-title" content="DevDocs">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -21,22 +21,22 @@
   <link rel="manifest" href="/manifest.json">
   <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="DevDocs Search">
   <link rel="alternate" href="<%= canonical_origin %>/feed" title="DevDocs" type="application/atom+xml">
-  <link rel="icon" type="image/x-icon" href="<%= App.cdn_origin %>/favicon.ico">
-  <link rel="fluid-icon" href="<%= App.cdn_origin %>/images/fluid-icon.png" title="DevDocs">
-  <link rel="apple-touch-icon" sizes="72x72" href="<%= App.cdn_origin %>/images/apple-icon-72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="<%= App.cdn_origin %>/images/apple-icon-76.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="<%= App.cdn_origin %>/images/apple-icon-114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="<%= App.cdn_origin %>/images/apple-icon-120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="<%= App.cdn_origin %>/images/apple-icon-144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="<%= App.cdn_origin %>/images/apple-icon-152.png">
-  <link rel="apple-touch-icon" sizes="160x160" href="<%= App.cdn_origin %>/images/apple-icon-160.png">
-  <link rel="mask-icon" href="<%= App.cdn_origin %>/images/webkit-mask-icon.svg" color="#398df0">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="fluid-icon" href="/images/fluid-icon.png" title="DevDocs">
+  <link rel="apple-touch-icon" sizes="72x72" href="/images/apple-icon-72.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="/images/apple-icon-76.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="/images/apple-icon-114.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/images/apple-icon-120.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="/images/apple-icon-144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/images/apple-icon-152.png">
+  <link rel="apple-touch-icon" sizes="160x160" href="/images/apple-icon-160.png">
+  <link rel="mask-icon" href="/images/webkit-mask-icon.svg" color="#398df0">
   <%= stylesheet_tag 'application' %>
 </head>
 <body>
 <noscript class="_fail">DevDocs requires JavaScript to run.</noscript>
 <%= erb :app -%>
-<%= javascript_tag 'application', asset_host: false %>
+<%= javascript_tag 'application' %>
 <%= javascript_tag 'docs' %><% unless App.production? %>
 <%= javascript_tag 'debug' %><% end %>
 </body>

--- a/views/other.erb
+++ b/views/other.erb
@@ -6,18 +6,18 @@
   <% if doc_index_page? %><meta name="description" content="<%= @doc['name'] %> <%= @doc['release'] %> API documentation with instant search, offline support, keyboard shortcuts, mobile version, and more."><% else %><meta name="robots" content="noindex"><% end %>
   <meta name="format-detection" content="telephone=no">
   <meta name="theme-color" content="#eee">
-  <meta property="og:image" content="<%= App.cdn_origin %>/images/icon-320.png">
+  <meta property="og:image" content="/images/icon-320.png">
   <title>DevDocs<%= " &mdash; #{@doc['full_name']} documentation" if doc_index_page? %></title>
   <link rel="canonical" href="<%= canonical_origin %><%= request.path %>">
   <link rel="manifest" href="/manifest.json">
-  <link rel="icon" type="image/x-icon" href="<%= App.cdn_origin %>/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Search DevDocs">
   <%= stylesheet_tag 'application' %>
 </head>
 <body data-doc="<%= CGI::escape_html @doc.to_json %>">
 <noscript class="_fail">DevDocs requires JavaScript to run.</noscript>
 <%= erb :app -%>
-<%= javascript_tag 'application', asset_host: false %><% unless App.production? %>
+<%= javascript_tag 'application' %><% unless App.production? %>
 <%= javascript_tag 'debug' %><% end %>
 </body>
 </html>


### PR DESCRIPTION
NOTE: this should not be merged immediately, but it could use a second (or third!) look. @MasterEnoc I saw you've been contributing a load of PRs recently, so if you have chance to glance at this, that would be great.

This should update all the references to MaxCDN to either point to a new S3 bucket (for uploads) or to a subdomain that's handled by Cloudflare.  

Previously the cdn.devdocs.io resources were redirected (by Cloudflare) to MaxCDN.  Now they're just served by Cloudflare.  The path is simply CF -> Heroku, but everything is cached on CF.  I don't believe this will cause any serious cache invalidation issues, simply because everything that needs to be updated regularly gets a new hash each update.  Some images don't get cache-busting hashes, but they're only cached for a day so it should not be a huge problem.

The other major change is that an S3 bucket is used for downloads instead of MaxCDN's push zone.  This bucket is behind CF and our proxies.