### PR TITLE
update Ember docs to latest version

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -273,7 +273,7 @@ credits = [
     'https://www.gnu.org/licenses/gpl-3.0.html'
   ], [
     'Ember.js',
-    '2017 Yehuda Katz, Tom Dale and Ember.js contributors',
+    '2020 Yehuda Katz, Tom Dale and Ember.js contributors',
     'MIT',
     'https://raw.githubusercontent.com/emberjs/ember.js/master/LICENSE'
   ], [

--- a/lib/docs/filters/ember/clean_html.rb
+++ b/lib/docs/filters/ember/clean_html.rb
@@ -2,8 +2,14 @@ module Docs
   class Ember
     class CleanHtmlFilter < Filter
       def call
-        css('hr', '.edit-page').remove
+        css('hr', '.edit-page', '.heading__link__edit', 'aside').remove
 
+        base_url.host.start_with?('api') ? api : guide
+
+        doc
+      end
+
+      def api
         # Remove code highlighting
         css('.highlight').each do |node|
           node.before(%(<div class="pre-title"><code>#{node.at_css('thead').content.strip}</code></div>)) if node.at_css('thead')
@@ -13,12 +19,6 @@ module Docs
           node['data-language'] = node['data-language'].sub(/(hbs|handlebars)/, 'html')
         end
 
-        base_url.path.start_with?('/api') ? api : guide
-
-        doc
-      end
-
-      def api
         css('h1 .access').each do |node|
           node.replace(" (#{node.content})")
         end
@@ -72,7 +72,13 @@ module Docs
       end
 
       def guide
-        @doc = at_css('article')
+        # Remove code highlighting
+        css('.filename').each do |node|
+          node.content = node.at_css('pre code').content
+          node.name = 'pre'
+          node['data-language'] = node['class'][/(javascript|js|html|hbs|handlebars)/, 1]
+          node['data-language'] = node['data-language'].sub(/(hbs|handlebars)/, 'html')
+        end
 
         if root_page?
           at_css('h1').content = 'Ember.js'

--- a/lib/docs/filters/ember/clean_html.rb
+++ b/lib/docs/filters/ember/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class Ember
     class CleanHtmlFilter < Filter
       def call
-        css('hr', '.edit-page', '.heading__link__edit', 'aside').remove
+        css('hr', '.edit-page', '.heading__link__edit', 'aside', '.old-version-warning').remove
 
         base_url.host.start_with?('api') ? api : guide
 

--- a/lib/docs/filters/ember/entries.rb
+++ b/lib/docs/filters/ember/entries.rb
@@ -17,15 +17,17 @@ module Docs
       def get_type
         if base_url.host.start_with?('api')
           name = self.name.remove(/ \(.*/)
-          if name.start_with?('@') || name == 'rsvp'
-            'Packages'
-          elsif name == 'Function'
-            'Functions'
+          if name == 'Function'
+            '3. Functions'
+          elsif at_css('h1').content.start_with?('Package')
+            '2. Packages'
           else
-            'Classes'
+            name = name.remove(' (methods)').remove(' (properties)').remove(' (events)')
+            # Reference gets sorted to the top by default, need to have it with other classes so add a zero width space
+            name == 'Reference' ? 'Reference​' : name
           end
         else
-          'Guide'
+          '1. Guide'
         end
       end
 

--- a/lib/docs/scrapers/ember.rb
+++ b/lib/docs/scrapers/ember.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Docs
   class Ember < UrlScraper
     include MultipleBaseUrls
@@ -5,11 +7,11 @@ module Docs
     self.name = 'Ember.js'
     self.slug = 'ember'
     self.type = 'ember'
-    self.release = '2.15.0'
-    self.base_urls = [
-      'https://guides.emberjs.com/v2.15.0/',
-      'https://emberjs.com/api/ember/2.15/',
-      'https://emberjs.com/api/ember-data/2.14/'
+    self.release = '3.25.0'
+    self.base_urls = %w[
+      https://guides.emberjs.com/v3.25.0/
+      https://api.emberjs.com/ember/3.25/
+      https://api.emberjs.com/ember-data/3.25/
     ]
     self.links = {
       home: 'https://emberjs.com/',
@@ -21,10 +23,10 @@ module Docs
     options[:trailing_slash] = false
 
     options[:container] = ->(filter) do
-      if filter.base_url.path.start_with?('/api')
-        'main article'
-      else
+      if filter.base_url.host.start_with?('api')
         'main'
+      else
+        'main article'
       end
     end
 
@@ -39,26 +41,29 @@ module Docs
     options[:skip_patterns] = [
       /\._/,
       /contributing/,
-      /classes\/String/,
-      /namespaces\/Ember/,
-      /namespaces\/DS/
+      /tutorial/,
+      /js-primer/,
+      /in-depth-topics$/,
+      /managing-dependencies$/
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2017 Yehuda Katz, Tom Dale and Ember.js contributors<br>
+      &copy; 2020 Yehuda Katz, Tom Dale and Ember.js contributors<br>
       Licensed under the MIT License.
     HTML
 
+    options[:decode_and_clean_paths] = true # handle paths like @ember/application
+
     def initial_urls
       %w(
-        https://guides.emberjs.com/v2.15.0/
-        https://emberjs.com/api/ember/2.15/classes/Ember
-        https://emberjs.com/api/ember-data/2.14/classes/DS
+        https://guides.emberjs.com/v3.25.0/
+        https://api.emberjs.com/ember/3.25/
+        https://api.emberjs.com/ember-data/3.25/
       )
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://emberjs.com/api/ember/release', opts)
+      doc = fetch_doc('https://api.emberjs.com/ember/release', opts)
       doc.at_css('.sidebar > .select-container .ember-power-select-selected-item').content.strip
     end
   end

--- a/lib/docs/scrapers/ember.rb
+++ b/lib/docs/scrapers/ember.rb
@@ -7,12 +7,6 @@ module Docs
     self.name = 'Ember.js'
     self.slug = 'ember'
     self.type = 'ember'
-    self.release = '3.25.0'
-    self.base_urls = %w[
-      https://guides.emberjs.com/v3.25.0/
-      https://api.emberjs.com/ember/3.25/
-      https://api.emberjs.com/ember-data/3.25/
-    ]
     self.links = {
       home: 'https://emberjs.com/',
       code: 'https://github.com/emberjs/ember.js'
@@ -54,12 +48,23 @@ module Docs
 
     options[:decode_and_clean_paths] = true # handle paths like @ember/application
 
-    def initial_urls
-      %w(
+    version '3' do
+      self.release = '3.25.0'
+      self.base_urls = %w[
         https://guides.emberjs.com/v3.25.0/
         https://api.emberjs.com/ember/3.25/
         https://api.emberjs.com/ember-data/3.25/
-      )
+      ]
+    end
+
+    version '2' do
+      self.release = '2.18.0'
+      self.base_urls = %w[
+        https://guides.emberjs.com/v2.18.0/
+        https://api.emberjs.com/ember/2.18/
+        https://api.emberjs.com/ember-data/2.18/
+      ]
+      options[:skip_patterns].push(/handlebars-basics$/)
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
* fix ember parsing to handle current guides/docs

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [X ] Updated the versions and releases in the scraper file
- [X ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
