### PR TITLE
Do not show shortcut help when typing '?' in the search box

### DIFF
--- a/assets/javascripts/app/shortcuts.coffee
+++ b/assets/javascripts/app/shortcuts.coffee
@@ -37,7 +37,7 @@ class app.Shortcuts
     return
 
   onKeypress: (event) =>
-    return if @buggyEvent(event)
+    return if @buggyEvent(event) or (event.charCode == 63 and document.activeElement.tagName == 'INPUT')
     unless event.ctrlKey or event.metaKey
       result = @handleKeypressEvent event
       event.preventDefault() if result is false


### PR DESCRIPTION
Do not show shortcuts help when '?' is typed in the search box. Fix #733.
