### PR TITLE
Fix sidebar when the mouse leaves the window

### DIFF
--- a/assets/javascripts/views/sidebar/sidebar.coffee
+++ b/assets/javascripts/views/sidebar/sidebar.coffee
@@ -28,8 +28,12 @@ class app.views.Sidebar extends app.View
 
     app.on 'ready', @onReady
 
-    $.on document.documentElement, 'mouseleave', (event) => @display() unless event.clientX <= 0
+    $.on document.documentElement, 'mouseleave', => @hide()
     $.on document.documentElement, 'mouseenter', => @resetDisplay(forceNoHover: false)
+    return
+
+  hide: ->
+    @removeClass 'show'
     return
 
   display: ->


### PR DESCRIPTION
Fix #1243. Now the sidebar is hidden whenever the mouse leaves the window, regardless the side from the mouse left the window.