### PR TITLE
Update SQLite documentation (3.34.0)

### DIFF
--- a/assets/stylesheets/pages/_sqlite.scss
+++ b/assets/stylesheets/pages/_sqlite.scss
@@ -4,3 +4,9 @@
   dt { @extend %block-label, %label-blue; }
   .todo { @extend %note, %note-red; }
 }
+
+svg {
+  text.fill { fill: var(--textColor); }
+  .fill { fill: var(--textColorLighter); }
+  .stroke { fill: none; stroke-width: 2.16; stroke: var(--textColorLighter); }
+}

--- a/lib/docs/filters/core/clean_text.rb
+++ b/lib/docs/filters/core/clean_text.rb
@@ -5,6 +5,7 @@ module Docs
     EMPTY_NODES_RGX = /<(?!td|th|iframe|mspace)(\w+)[^>]*>[[:space:]]*<\/\1>/
 
     def call
+      return html if context[:clean_text] == false
       html.strip!
       while html.gsub!(EMPTY_NODES_RGX, ''); end
       html

--- a/lib/docs/filters/sqlite/clean_html.rb
+++ b/lib/docs/filters/sqlite/clean_html.rb
@@ -7,13 +7,14 @@ module Docs
         css('.rightsidebar', 'hr', '.sh_mark', '.fancy_toc > a', '.fancy_toc_mark', 'h[style*="none"]',
             'a[href$="intro.html"] > h2', 'a[href$="intro"] > h2', '#document_title + #toc_header',
             '#document_title ~ #toc').remove
+        css('a[href$="intro.html"]:empty', 'a[href$="intro"]:empty').remove
 
         css('.fancy_title', '> h2[align=center]', '#document_title').each do |node|
           node.name = 'h1'
         end
 
         unless at_css('h1')
-          if at_css('h2').content == context[:html_title]
+          if at_css('h2') && at_css('h2').content == context[:html_title]
             at_css('h2').name = 'h1'
           else
             doc.child.before("<h1>#{context[:html_title]}</h1>")
@@ -81,8 +82,26 @@ module Docs
           node.remove_attribute('onclick')
         end
 
-        css('*[align]').remove_attr('align')
+        css('svg *[style], svg *[fill]').each do |node|
+          # transform style in SVG diagrams, e.g. on https://sqlite.org/lang_insert.html
+          if node['style'] == 'fill:rgb(0,0,0)' or node['fill'] == 'rgb(0,0,0)'
+            node.add_class('fill')
+            node.remove_attribute('fill')
+          elsif node['style'] == 'fill:none;stroke-width:2.16;stroke:rgb(0,0,0);'
+            node.add_class('stroke')
+          elsif node['style'] == 'fill:none;stroke-width:3.24;stroke:rgb(211,211,211);'
+            node.add_class('stroke')
+          elsif node['style']
+            raise NotImplementedError, "SVG style #{node['style']}"
+          end
+          node.remove_attribute('style')
+        end
+
+        css('.imgcontainer > div[style]').add_class('imgcontainer')
         css('*[style]:not(.imgcontainer)').remove_attr('style')
+        css('.imgcontainer').remove_class('imgcontainer')
+
+        css('*[align]').remove_attr('align')
         css('table[border]').remove_attr('border')
 
         doc

--- a/lib/docs/scrapers/sqlite.rb
+++ b/lib/docs/scrapers/sqlite.rb
@@ -2,7 +2,7 @@ module Docs
   class Sqlite < FileScraper
     self.name = 'SQLite'
     self.type = 'sqlite'
-    self.release = '3.33.0'
+    self.release = '3.34.0'
     self.base_url = 'https://sqlite.org/'
     self.root_path = 'docs.html'
     self.initial_paths = %w(keyword_index.html)
@@ -14,6 +14,7 @@ module Docs
     html_filters.insert_before 'clean_html', 'sqlite/clean_js_tables'
     html_filters.push 'sqlite/entries', 'sqlite/clean_html'
 
+    options[:clean_text] = false  # keep SVG elements
     options[:only_patterns] = [/\.html\z/]
     options[:skip_patterns] = [/releaselog/, /consortium/]
     options[:skip] = %w(


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
