### PR TITLE
Update TypeScript documentation (New Handbook)

### DIFF
--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -116,6 +116,7 @@
         'pages/tcl_tk',
         'pages/tensorflow',
         'pages/terraform',
+        'pages/typescript',
         'pages/underscore',
         'pages/vue',
         'pages/webpack',

--- a/assets/stylesheets/pages/_typescript.scss
+++ b/assets/stylesheets/pages/_typescript.scss
@@ -1,0 +1,4 @@
+._typescript {
+  @extend %simple;
+  .deprecated { @extend %label-red; }
+}

--- a/lib/docs/filters/typescript/clean_html.rb
+++ b/lib/docs/filters/typescript/clean_html.rb
@@ -24,7 +24,11 @@ module Docs
 
       def other
         if base_url.path == '/docs/handbook/'
+          deprecated = at_css('#deprecated-content')
+          deprecated.css('h3', '#deprecated-icon').remove if deprecated
+          deprecated.add_class('deprecated') if deprecated
           @doc = at_css('article > .whitespace > .markdown')
+          doc.child.before(deprecated) if deprecated
         else # tsconfig page
           @doc = at_css('.markdown > div')
 
@@ -36,9 +40,14 @@ module Docs
         css('pre').each do |node|
           language = node.at_css('.language-id') ? node.at_css('.language-id').content : 'typescript'
           node.css('.language-id').remove
-          node.content = node.content
+          if node.at_css('.line').nil?
+            node.content = node.content
+          else
+            node.content = node.css('.line').map(&:content).join("\n")
+          end
           node['data-language'] = LANGUAGE_REPLACE[language] || language
           node.remove_attribute('class')
+          node.remove_attribute('style')
         end
       end
 

--- a/lib/docs/filters/typescript/entries.rb
+++ b/lib/docs/filters/typescript/entries.rb
@@ -2,15 +2,31 @@ module Docs
   class Typescript
     class EntriesFilter < Docs::EntriesFilter
 
+      DEPRECATED_PAGES = %w(
+        advanced-types
+        basic-types
+        classes
+        functions
+        generics
+        interfaces
+        literal-types
+        unions-and-intersections
+      )
+
       def get_name
         at_css('h1') ? at_css('h1').content : at_css('h2').content
       end
 
       def get_type
-        name
+        if DEPRECATED_PAGES.include? slug
+          'Handbook (deprecated)'
+        else
+          name
+        end
       end
 
       def additional_entries
+        return [] if DEPRECATED_PAGES.include? slug
         base_url.path == '/' ? tsconfig_entries : handbook_entries
       end
 

--- a/lib/docs/scrapers/typescript.rb
+++ b/lib/docs/scrapers/typescript.rb
@@ -3,8 +3,8 @@ module Docs
     include MultipleBaseUrls
 
     self.name = 'TypeScript'
-    self.type = 'simple'
-    self.release = '4.2.2'
+    self.type = 'typescript'
+    self.release = '4.2.3'
     self.base_urls = [
       'https://www.typescriptlang.org/docs/handbook/',
       'https://www.typescriptlang.org/'
@@ -29,7 +29,6 @@ module Docs
     ]
 
     options[:skip_patterns] = [
-      /2/,
       /release-notes/,
       /play\//
     ]


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/

![image](https://user-images.githubusercontent.com/782446/110186147-9dfd4900-7e14-11eb-81a2-980add1621bc.png)



- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
