### PR TITLE
fix: set branch to master in deploy action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: Deploy
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
$default-branch did not seem to catch merges to master, so this PR names the branch that should trigger the action.