### PR TITLE
fix: prevent Deploy action running on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
-
+    if: github.repository == 'freeCodeCamp/devdocs'
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Set up Ruby


### PR DESCRIPTION
While it would not deploy when a fork updates, due to lack of an api key, it is inefficient. Also, it's potentially confusing to see a failing check on your fork when you haven't broken anything.

I've tested it on my own fork: https://github.com/ojeytonwilliams/devdocs/commit/c2b38c19fa6e9392f2837f75f57c5a0ed8875a38