### PR TITLE
fix: remove reference to dom_events

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -30,7 +30,7 @@ class App < Sinatra::Application
     set :docs_origin, File.join('', docs_prefix)
     set :docs_path, File.join(public_folder, docs_prefix)
     set :docs_manifest_path, File.join(docs_path, 'docs.json')
-    set :default_docs, %w(css dom dom_events html http javascript)
+    set :default_docs, %w(css dom html http javascript)
     set :news_path, File.join(root, assets_prefix, 'javascripts', 'news.json')
 
     set :csp, false

--- a/lib/docs.rb
+++ b/lib/docs.rb
@@ -44,7 +44,7 @@ module Docs
   end
 
   def self.defaults
-    %w(css dom dom_events html http javascript).map(&method(:find))
+    %w(css dom html http javascript).map(&method(:find))
   end
 
   def self.installed


### PR DESCRIPTION
Since the MDN scrapers have been updated (here: https://github.com/freeCodeCamp/devdocs/commit/a0776af91320fdbeb6e00e115fea8b77153ae42c) this no longer exists.

I noticed the problem when I tried to `thor docs:download --default` (everything else seemed fine).