### PR TITLE
Update SaltStack documentation to version 3003

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -738,7 +738,7 @@ credits = [
     'https://raw.githubusercontent.com/ReactiveX/rxjs/master/LICENSE.txt'
   ], [
     'Salt Stack',
-    '2019 SaltStack',
+    '2021 SaltStack',
     'Apache',
     'https://raw.githubusercontent.com/saltstack/salt/develop/LICENSE'
   ], [

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -202,19 +202,6 @@ tar -xf ruby.tar; cd ruby-$RELEASE; ./configure && make html; mv .ext/html path/
 To generate the htmls file you have to run `make` command but it does not install Ruby in your system, only generates html files so you have not
 to worry about cleaning or removing a new Ruby installation.
 
-## Salt Stack
-
-Replace `2019.2` with the correct tag.
-
-```sh
-git clone https://github.com/saltstack/salt.git --branch 2019.2 --depth 1
-cd salt/doc
-pip install sphinx
-make html
-```
-
-The generated html is in `salt/doc/_build/html`. Copy it to
-
 ## Scala
 
 See `lib/docs/scrapers/scala.rb`

--- a/lib/docs/scrapers/salt_stack.rb
+++ b/lib/docs/scrapers/salt_stack.rb
@@ -3,11 +3,11 @@ module Docs
   class SaltStack < FileScraper
     self.type = 'simple'
     self.slug = 'saltstack'
-    self.release = '2019.2.0'
-    self.base_url = 'https://docs.saltstack.com/en/latest/'
+    self.release = '3003'
+    self.base_url = 'https://docs.saltproject.io/en/latest/'
     self.root_path = 'ref/index.html'
     self.links = {
-      home: 'https://www.saltstack.com/',
+      home: 'https://www.saltproject.io/',
       code: 'https://github.com/saltstack/salt'
     }
 
@@ -17,7 +17,7 @@ module Docs
     options[:container] = '.body-content > .section'
 
     options[:attribution] = <<-HTML
-      &copy; 2019 SaltStack.<br>
+      &copy; 2021 SaltStack.<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 

--- a/lib/docs/scrapers/salt_stack.rb
+++ b/lib/docs/scrapers/salt_stack.rb
@@ -1,6 +1,5 @@
 module Docs
-  # The official documentation website is heavily rate-limited
-  class SaltStack < FileScraper
+  class SaltStack < UrlScraper
     self.type = 'simple'
     self.slug = 'saltstack'
     self.release = '3003'


### PR DESCRIPTION
Update version, project page, and copyright year.
It may also an idea to change slug to `salt` or `saltproject`, but I'm not certain of that.

<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->


<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
