### PR TITLE
Harmonized CLI command version notation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,9 +68,9 @@ Follow the following steps to update documentations to their latest version:
 2. Check if the license is still correct. If you update `options[:attribution]`, also update the documentation's entry in the array in [`assets/javascripts/templates/pages/about_tmpl.coffee`](../assets/javascripts/templates/pages/about_tmpl.coffee) to match.
 3. If the documentation has a custom icon, ensure the icons in <code>public/icons/*your_scraper_name*/</code> are up-to-date. If you pull the updated icon from a place different than the one specified in the `SOURCE` file, make sure to replace the old link with the new one.
 4. If `self.links` is defined, check if the urls are still correct.
-5. Generate the docs using `thor docs:generate <doc>`.
+5. Generate the docs using `thor docs:generate <doc@version>`.
 6. Make sure `thor docs:generate` doesn't show errors and that the documentation still works well. Verify locally that everything works and that the categorization of entries is still good. Often, updates will require code changes in the scraper or its filters to tweak some new markup in the source website or to categorize new entries.
-7. Repeat steps 5 and 6 for all versions that you updated. `thor docs:generate` accepts a `--version` argument to specify which version to scrape.
+7. Repeat steps 5 and 6 for all versions that you updated.
 8. Create a PR and make sure to fill the checklist in section B of the PR template (remove the other sections).
 
 ## Coding conventions

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -118,7 +118,7 @@ class DocsCLI < Thor
     puts 'Done'
   end
 
-  desc 'download (<doc> <doc@version>... | --default | --installed | --all)', 'Download documentations'
+  desc 'download (<doc> <doc@version>... | --default | --installed | --all)', 'Download documentation packages'
   option :default, type: :boolean
   option :installed, type: :boolean
   option :all, type: :boolean
@@ -141,7 +141,7 @@ class DocsCLI < Thor
     handle_doc_not_found_error(error)
   end
 
-  desc 'package <doc> <doc@version>...', 'Package documentations'
+  desc 'package <doc> <doc@version>...', 'Create documentation packages'
   def package(*names)
     require 'unix_utils'
     docs = find_docs(names)

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -65,8 +65,7 @@ class DocsCLI < Thor
     handle_doc_not_found_error(error)
   end
 
-  desc 'generate <doc> [--version] [--verbose] [--debug] [--force] [--package]', 'Generate a documentation'
-  option :version, type: :string
+  desc 'generate (<doc> | <doc@version>) [--verbose] [--debug] [--force] [--package]', 'Generate a documentation'
   option :all, type: :boolean
   option :verbose, type: :boolean
   option :debug, type: :boolean
@@ -80,7 +79,7 @@ class DocsCLI < Thor
 
     require 'unix_utils' if options[:package]
 
-    doc = Docs.find(name, options[:version])
+    doc = find_doc(name)
 
     if doc < Docs::UrlScraper && !options[:force]
       puts <<-TEXT.strip_heredoc

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -40,8 +40,7 @@ class DocsCLI < Thor
     TTY::Pager.new.page(output)
   end
 
-  desc 'page <doc> [path] [--version] [--verbose] [--debug]', 'Generate a page (no indexing)'
-  option :version, type: :string
+  desc 'page (<doc> | <doc@version>) [path] [--verbose] [--debug]', 'Generate a page (no indexing)'
   option :verbose, type: :boolean
   option :debug, type: :boolean
   def page(name, path = '')
@@ -56,7 +55,8 @@ class DocsCLI < Thor
       Docs.install_report :filter, :request, :doc
     end
 
-    if Docs.generate_page(name, options[:version], path)
+    name, version = name.split(/@|~/)
+    if Docs.generate_page(name, version, path)
       puts 'Done'
     else
       puts "Failed!#{' (try running with --debug for more information)' unless options[:debug]}"

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -267,15 +267,17 @@ class DocsCLI < Thor
 
   private
 
-  def find_docs(names)
-    names.flat_map do |name|
-      name, version = name.split(/@|~/)
-      if version == 'all'
-        Docs.find(name, false).versions
-      else
-        Docs.find(name, version)
-      end
+  def find_doc(name)
+    name, version = name.split(/@|~/)
+    if version == 'all'
+      Docs.find(name, false).versions
+    else
+      Docs.find(name, version)
     end
+  end
+
+  def find_docs(names)
+    names.flat_map {|name| find_doc(name)}
   end
 
   def find_docs_by_slugs(slugs)


### PR DESCRIPTION
Closes #1519 

@simon04 Let's try this.  I tested using a small documentation package of which there are several versions:

```
thor docs:generate sequelize    #=> Installs sequelize~6 (latest), as expected currently, given no version
thor docs:generate sequelize@5  #=> Installs sequelize~5
```

I'm less familiar with the `docs:page` command, but it should be ok.  A `nil` version as the second component of `name.split` will be handled fine (as could already happen in`find_docs()` previously) in `Docs.generate_page()` via `Docs.find()`.

Let me know if you prefer this squashed.