### PR TITLE
Dart docs latest version

### DIFF
--- a/lib/docs/scrapers/dart.rb
+++ b/lib/docs/scrapers/dart.rb
@@ -22,12 +22,12 @@ module Docs
 
     version '2' do
       self.release = '2.12.4'
-      self.base_url = "https://api.dart.dev/stable/#{release}/index.html"
+      self.base_url = "https://api.dart.dev/stable/#{release}/"
     end
 
     version '1' do
       self.release = '1.24.3'
-      self.base_url = "https://api.dart.dev/stable/#{release}/index.html"
+      self.base_url = "https://api.dart.dev/stable/#{release}/"
     end
 
     def get_latest_version(opts)

--- a/lib/docs/scrapers/dart.rb
+++ b/lib/docs/scrapers/dart.rb
@@ -21,13 +21,13 @@ module Docs
     HTML
 
     version '2' do
-      self.release = '2.12.2'
-      self.base_url = "https://api.dart.dev/stable/#{release}/"
+      self.release = '2.12.4'
+      self.base_url = "https://api.dart.dev/stable/#{release}/index.html"
     end
 
     version '1' do
       self.release = '1.24.3'
-      self.base_url = "https://api.dart.dev/stable/#{release}/"
+      self.base_url = "https://api.dart.dev/stable/#{release}/index.html"
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
**UPDATED**

Updated latest 2.x stable version.

---

<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
