### PR TITLE
add elixir 1.12 documentation

### DIFF
--- a/assets/stylesheets/pages/_elixir.scss
+++ b/assets/stylesheets/pages/_elixir.scss
@@ -4,4 +4,9 @@
   .type-detail { margin-bottom: 2em; }
   .type-detail pre { margin-left: -1rem; }
   ._mobile & .type-detail pre { margin-left: 0; }
+
+  a.source {
+    float: right;
+    font-size: .9em;
+  }
 }

--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -25,7 +25,7 @@ module Docs
       end
 
       def api
-        css('.hover-link', '.view-source', 'footer').remove
+        css('.hover-link', 'footer', ':not(.detail-header) > .view-source').remove
 
         css('.summary').each do |node|
           node.name = 'dl'
@@ -51,7 +51,11 @@ module Docs
           detail.css('.detail-header').each do |node|
             node.name = 'h3'
             node['id'] = id
+
+            source_href = node.at_css('.view-source').attr('href')
+
             node.content = node.at_css('.signature').inner_text
+            node << %(<a href="#{source_href}" class="source">Source</a>)
           end
 
           detail.css('.docstring h2').each do |node|

--- a/lib/docs/filters/elixir/entries.rb
+++ b/lib/docs/filters/elixir/entries.rb
@@ -45,7 +45,8 @@ module Docs
 
         css('.detail-header').map do |node|
           id = node['id']
-          name = node.content.strip
+          # ignore text of children, i.e. source link
+          name = node.children.select(&:text?).map(&:content).join.strip
 
           name.remove! %r{\(.*\)}
           name.remove! 'left '

--- a/lib/docs/scrapers/elixir.rb
+++ b/lib/docs/scrapers/elixir.rb
@@ -33,6 +33,19 @@ module Docs
         "https://elixir-lang.org/getting-started/introduction.html" ]
     end
 
+    version '1.12' do
+      self.release = '1.12.0'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
     version '1.11' do
       self.release = '1.11.2'
       self.base_urls = [


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
