### PR TITLE
Elixir: include source link in section headers

### DIFF
--- a/assets/stylesheets/pages/_elixir.scss
+++ b/assets/stylesheets/pages/_elixir.scss
@@ -4,4 +4,9 @@
   .type-detail { margin-bottom: 2em; }
   .type-detail pre { margin-left: -1rem; }
   ._mobile & .type-detail pre { margin-left: 0; }
+
+  a.source {
+    float: right;
+    font-size: .9em;
+  }
 }

--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -25,7 +25,7 @@ module Docs
       end
 
       def api
-        css('.hover-link', '.view-source', 'footer').remove
+        css('.hover-link', 'footer', ':not(.detail-header) > .view-source').remove
 
         css('.summary').each do |node|
           node.name = 'dl'
@@ -51,7 +51,11 @@ module Docs
           detail.css('.detail-header').each do |node|
             node.name = 'h3'
             node['id'] = id
+
+            source_href = node.at_css('.view-source').attr('href')
+
             node.content = node.at_css('.signature').inner_text
+            node << %(<a href="#{source_href}" class="source">Source</a>)
           end
 
           detail.css('.docstring h2').each do |node|

--- a/lib/docs/filters/elixir/entries.rb
+++ b/lib/docs/filters/elixir/entries.rb
@@ -45,7 +45,8 @@ module Docs
 
         css('.detail-header').map do |node|
           id = node['id']
-          name = node.content.strip
+          # ignore text of children, i.e. source link
+          name = node.children.select(&:text?).map(&:content).join.strip
 
           name.remove! %r{\(.*\)}
           name.remove! 'left '


### PR DESCRIPTION
This implements #763 just for Elixir without solving the general
issue. The style used is similar to the one of the Go docs.

![2021-05-24-103603_2098x834_scrot](https://user-images.githubusercontent.com/307954/119320443-dece6680-bc7b-11eb-8c9e-ae0de679854c.png)
