### PR TITLE
Add documentation for WebExtensions

### DIFF
--- a/lib/docs/filters/web_extensions/clean_html.rb
+++ b/lib/docs/filters/web_extensions/clean_html.rb
@@ -1,0 +1,14 @@
+module Docs
+  class WebExtensions
+    class CleanHtmlFilter < Filter
+      def call
+
+        # Remove all the cruft.
+        content = at_css('main#content')
+        content.at_css('aside.metadata').remove
+
+        content
+      end
+    end
+  end
+end

--- a/lib/docs/filters/web_extensions/clean_html.rb
+++ b/lib/docs/filters/web_extensions/clean_html.rb
@@ -2,12 +2,7 @@ module Docs
   class WebExtensions
     class CleanHtmlFilter < Filter
       def call
-
-        # Remove all the cruft.
-        content = at_css('main#content')
-        content.at_css('aside.metadata').remove
-
-        content
+        doc
       end
     end
   end

--- a/lib/docs/filters/web_extensions/entries.rb
+++ b/lib/docs/filters/web_extensions/entries.rb
@@ -1,26 +1,22 @@
 module Docs
   class WebExtensions
     class EntriesFilter < Docs::EntriesFilter
+      TYPE_BY_PATH = {
+        'manifest.json' => 'manifest.json',
+        'user_interface' => 'User Interface',
+        'WebRequest' => 'webRequest',
+      }
+
       def get_name
-        at_css('main#content h1').text
+        at_css('h1').text
       end
 
       def get_type
         slug_parts = slug.split('/')
         if slug_parts[0] == 'API' and slug_parts.length() > 1
-          if slug_parts[1] == 'WebRequest'
-            return 'webRequest'
-          else
-            return slug_parts[1]
-          end
-        elsif slug_parts[0] == 'manifest.json'
-          return slug_parts[0]
-        elsif slug_parts[0] == 'user_interface'
-          return 'User Interface'
-        elsif slug_parts.length() > 1
-          return slug_parts[0]
+          return TYPE_BY_PATH.fetch(slug_parts[1], slug_parts[1])
         else
-          return 'Miscellaneous'
+          return TYPE_BY_PATH.fetch(slug_parts[0], slug_parts.length() > 1 ? slug_parts[0] : 'Miscellaneous')
         end
       end
     end

--- a/lib/docs/filters/web_extensions/entries.rb
+++ b/lib/docs/filters/web_extensions/entries.rb
@@ -1,0 +1,28 @@
+module Docs
+  class WebExtensions
+    class EntriesFilter < Docs::EntriesFilter
+      def get_name
+        at_css('main#content h1').text
+      end
+
+      def get_type
+        slug_parts = slug.split('/')
+        if slug_parts[0] == 'API' and slug_parts.length() > 1
+          if slug_parts[1] == 'WebRequest'
+            return 'webRequest'
+          else
+            return slug_parts[1]
+          end
+        elsif slug_parts[0] == 'manifest.json'
+          return slug_parts[0]
+        elsif slug_parts[0] == 'user_interface'
+          return 'User Interface'
+        elsif slug_parts.length() > 1
+          return slug_parts[0]
+        else
+          return 'Miscellaneous'
+        end
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/mdn/web_extensions.rb
+++ b/lib/docs/scrapers/mdn/web_extensions.rb
@@ -1,8 +1,7 @@
 module Docs
-  class WebExtensions < UrlScraper
+  class WebExtensions < Mdn
     self.name = 'Web Extensions'
     self.slug = 'web_extensions'
-    self.type = 'simple'
     self.links = {
       home: 'https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions'
     }
@@ -14,13 +13,6 @@ module Docs
     options[:skip_patterns] = [
       /\/contributors\.txt$/
     ]
-
-    options[:attribution] = -> (filter) {
-    <<-HTML
-      <a href="#{filter.current_url}">#{filter.result()[:entries][0].name}</a> &copy; 2005-2021 Mozilla and individual contributors.<br>
-      Licensed under the <a href="https://creativecommons.org/licenses/by-sa/2.5/">Creative Commons Attribution-ShareAlike license</a>
-    HTML
-    }
 
   end
 end

--- a/lib/docs/scrapers/web_extensions.rb
+++ b/lib/docs/scrapers/web_extensions.rb
@@ -1,0 +1,26 @@
+module Docs
+  class WebExtensions < UrlScraper
+    self.name = 'Web Extensions'
+    self.slug = 'web_extensions'
+    self.type = 'simple'
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions'
+    }
+
+    self.base_url = 'https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions'
+
+    html_filters.push 'web_extensions/entries', 'web_extensions/clean_html'
+
+    options[:skip_patterns] = [
+      /\/contributors\.txt$/
+    ]
+
+    options[:attribution] = -> (filter) {
+    <<-HTML
+      <a href="#{filter.current_url}">#{filter.result()[:entries][0].name}</a> &copy; 2005-2021 Mozilla and individual contributors.<br>
+      Licensed under the <a href="https://creativecommons.org/licenses/by-sa/2.5/">Creative Commons Attribution-ShareAlike license</a>
+    HTML
+    }
+
+  end
+end


### PR DESCRIPTION
WebExtensions from https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions

NB.:
- for lighter scraping I ran the [MDN content](https://github.com/mdn/content) locally with `yarn ; yarn start`.
- According to [the MDN copyright page](https://developer.mozilla.org/en-US/docs/MDN/About#copyrights_and_licenses), the source page should be cited with the attribution.
- There is no official icon for webextensions

- [x] Tested the scraper on a local copy of DevDocs
- [x] Ensured that the docs are styled similarly to other docs on DevDocs