### PR TITLE
LaTeX / jq improvements

### DIFF
--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -67,6 +67,7 @@
         'pages/haproxy',
         'pages/haskell',
         'pages/jekyll',
+        'pages/jq',
         'pages/jquery',
         'pages/julia',
         'pages/knockout',

--- a/assets/stylesheets/pages/_jq.scss
+++ b/assets/stylesheets/pages/_jq.scss
@@ -1,0 +1,26 @@
+._jq {
+  @extend %simple;
+
+  .manual-example table {
+	  border: none;
+
+	  & td {
+		  @extend %pre;
+		  &.jqprogram { font-weight: bold; }
+		  border: none;
+	  }
+
+	  & th {
+		  color: var(--textColor);
+		  background: var(--contentBackground);
+		  text-align: right;
+		  border: none;
+	  }
+
+	  & tr:not(:first-child) th:not(:empty) {
+		  &, & + td {
+			  border-top: 1px solid var(--boxBorder);
+		  }
+	  }
+  }
+}

--- a/lib/docs/filters/jq/clean_html.rb
+++ b/lib/docs/filters/jq/clean_html.rb
@@ -2,7 +2,19 @@ module Docs
   class Jq
     class CleanHtmlFilter < Filter
       def call
-        at_css('div#manualcontent')
+        content = at_css('div#manualcontent')
+
+        css('.manual-example').each do |node|
+          container = node.parent
+          example_header = doc.document.create_element('h4')
+          example_header.content = container.at_css('a[data-toggle="collapse"]').content
+          node.children.before(example_header)
+
+          node.remove_class('collapse')
+          container.replace(node)
+        end
+
+        content
       end
     end
   end

--- a/lib/docs/filters/latex/clean_html.rb
+++ b/lib/docs/filters/latex/clean_html.rb
@@ -13,6 +13,10 @@ module Docs
 
         css('h1, h2, h3, h4').each { |node| node.content = node.content.sub /^[0-9A-Z]+(\.[0-9]+)* /, '' }
 
+        css('div.example').each do |node|
+          node.replace(node.children)
+        end
+
         css('pre').each do |node|
           node.delete 'class'
           node['data-language'] = 'latex'

--- a/lib/docs/scrapers/jq.rb
+++ b/lib/docs/scrapers/jq.rb
@@ -2,7 +2,7 @@ module Docs
   class Jq < UrlScraper
     self.name = 'jq'
     self.slug = 'jq'
-    self.type = 'simple'
+    self.type = 'jq'
     self.release = '1.6'
     self.links = {
       home: 'https://stedolan.github.io/jq/'


### PR DESCRIPTION
These are some slight improvements 
- on the LaTeX scraper, to reduce code surrounding `<pre>` tags
- on the jq scraper, to style the examples as code − which they weren’t so far − and change the collapsing links / html mechanisms with a proper heading.
  
  The now look like:
  
  ![image](https://user-images.githubusercontent.com/6126377/119824095-d2edd900-bef5-11eb-97cf-4ceabefdf34d.png)
  ![image](https://user-images.githubusercontent.com/6126377/119824296-092b5880-bef6-11eb-8e20-8a78a51d769a.png)
  
  Instead of (previously):
  ![image](https://user-images.githubusercontent.com/6126377/119824969-c28a2e00-bef6-11eb-913e-a15730a1feb4.png)
  ![image](https://user-images.githubusercontent.com/6126377/119824920-b4d4a880-bef6-11eb-95be-b1d3c6d03383.png)

