### PR TITLE
Add get_latest_version to latex

### DIFF
--- a/lib/docs/scrapers/latex.rb
+++ b/lib/docs/scrapers/latex.rb
@@ -1,8 +1,10 @@
+# coding: utf-8
 module Docs
   class Latex < UrlScraper
     self.name = 'LaTeX'
     self.slug = 'latex'
     self.type = 'simple'
+    self.release = 'April 2021'
     self.links = {
         home: 'https://ctan.org/pkg/latex2e-help-texinfo/'
     }
@@ -17,6 +19,13 @@ module Docs
       &copy; 2007–2018 Karl Berry<br>
       Public Domain Software
     HTML
+
+    def get_latest_version(opts)
+      body = fetch('https://latexref.xyz/', opts)
+      body = body.scan(/\(\w+\s\d+\)/)[0]
+      body.sub!('(', '')
+      body.sub!(')', '')
+    end
 
   end
 end


### PR DESCRIPTION
Add get_latest_version to the LaTeX documentation. I used the date in the header of https://latexref.xyz/dev/, this is not the version of latex, but It would be helpful to know at least when the page is modified.