### PR TITLE
Add get_latest_verison for R

### DIFF
--- a/lib/docs/scrapers/r.rb
+++ b/lib/docs/scrapers/r.rb
@@ -49,5 +49,10 @@ module Docs
       doc/manual/R-lang.html
     )
 
+    def get_latest_version(opts)
+      body = fetch('https://cran.r-project.org/src/base/NEWS', opts)
+      body.match(/CHANGES IN R ([\d.]+):/)[1]
+    end
+
   end
 end


### PR DESCRIPTION
Was missing from the R pr. Uses the NEWS (i.e. changelog) file hosted by the r project.
```
> bundler exec thor updates:check r
+---------------+-----------------+----------------+
|          Up-to-date documentations (1)           |
+---------------+-----------------+----------------+
| Documentation | Scraper version | Latest version |
+---------------+-----------------+----------------+
| R             | 4.1.0           | 4.1.0          |
+---------------+-----------------+----------------+
```