### PR TITLE
Changes the timelimit between spacebar and last keypress

### DIFF
--- a/assets/javascripts/app/shortcuts.coffee
+++ b/assets/javascripts/app/shortcuts.coffee
@@ -59,7 +59,7 @@ class app.Shortcuts
         @trigger 'escape'
         false
       when 32
-        if event.target.type is 'search' and (not @lastKeypress or @lastKeypress < Date.now() - 500)
+        if event.target.type is 'search' and (not @lastKeypress or @lastKeypress < Date.now() - 3000)
           @trigger 'pageDown'
           false
       when 33


### PR DESCRIPTION
Related to the issue [#1553](https://github.com/freeCodeCamp/devdocs/issues/1553). Changed the allowed timelimit between spacebar and last keypress from 500ms to 3000ms.
