### PR TITLE
fix: allow 0.1 interval steps for spaceTimeout

### DIFF
--- a/assets/javascripts/templates/pages/settings_tmpl.coffee
+++ b/assets/javascripts/templates/pages/settings_tmpl.coffee
@@ -60,7 +60,7 @@ app.templates.settingsPage = (settings) -> """
         <input type="checkbox" form="settings" name="spaceScroll" value="1"#{if settings.spaceScroll then ' checked' else ''}>Use spacebar to scroll during search
       </label>
       <label class="_settings-label">
-        <input type="number" form="settings" name="spaceTimeout" min="0" max="5" value="#{settings.spaceTimeout}"> Delay until you can scroll by pressing space
+        <input type="number" step="0.1" form="settings" name="spaceTimeout" min="0" max="5" value="#{settings.spaceTimeout}"> Delay until you can scroll by pressing space
         <small>Time in seconds</small>
       </label>
     </div>


### PR DESCRIPTION
If the step is not specified, the default validation requires that the values are integers. Since the default value is 0.5, this prevented the settings from being changed.

Now the step is 0.1 which should give enough control without clashing with the default

Closes: https://github.com/freeCodeCamp/devdocs/issues/1578