### PR TITLE
Avoid showing analitics notification more than once

### DIFF
--- a/assets/javascripts/app/app.coffee
+++ b/assets/javascripts/app/app.coffee
@@ -11,6 +11,7 @@
     try @initErrorTracking() catch
     return unless @browserCheck()
 
+    @showAnaliticsOne = false
     @el = $('._app')
     @localStorage = new LocalStorageStore
     @serviceWorker = new app.ServiceWorker if app.ServiceWorker.isEnabled()
@@ -216,7 +217,7 @@
   onCookieBlocked: (key, value, actual) ->
     return if @cookieBlocked
     @cookieBlocked = true
-    new app.views.Notif 'CookieBlocked', autoHide: null
+    new app.views.Notif 'CookieBlocked', autoHide: 2000
     Raven.captureMessage "CookieBlocked/#{key}", level: 'warning', extra: {value, actual}
     return
 

--- a/assets/javascripts/lib/page.coffee
+++ b/assets/javascripts/lib/page.coffee
@@ -200,7 +200,9 @@ page.track = (fn) ->
 
 track = ->
   return unless app.config.env == 'production'
+  return if app.analiticsAlreadyShown
 
+  app.analiticsAlreadyShown = true
   consentGiven = Cookies.get('analyticsConsent')
   consentAsked = Cookies.get('analyticsConsentAsked')
 
@@ -210,7 +212,7 @@ track = ->
     # Only ask for consent once per browser session
     Cookies.set('analyticsConsentAsked', '1')
 
-    new app.views.Notif 'AnalyticsConsent', autoHide: null
+    new app.views.Notif 'AnalyticsConsent', autoHide: 2000
   return
 
 @resetAnalytics = ->


### PR DESCRIPTION
I usually do not accept cookies in any website and I didn't accept cookies in Devdocs. Devdocs can be really intrusive to show a notifications telling me to accept analytics each time I click a page, this is a silly behavior so I change it to only show one time the analytics notification during each Devdocs session.

I also notice that the cookies and the analytics notifications didn't hide automatically thus I added two seconds to hide them automatically.

Look at the following image showing the notifications generated by devdocs when I did not accept the cookies:
![image](https://user-images.githubusercontent.com/52229226/123213587-6548b480-d483-11eb-92e4-b6efedcf4598.png)
