### PR TITLE
Update sass dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,14 +17,14 @@ group :app do
   gem 'sinatra-contrib'
   gem 'rack-ssl-enforcer'
   gem 'thin'
-  gem 'sprockets'
+  gem 'sprockets', '>= 4.0.0'
   gem 'sprockets-helpers'
   gem 'erubi'
   gem 'browser'
-  gem 'sass'
+  gem 'sassc'
   gem 'coffee-script'
   gem 'chunky_png'
-  gem 'sprockets-sass'
+  # gem 'sprockets-sass'
   gem 'image_optim'
   gem 'image_optim_pack', platforms: :ruby
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,15 +71,9 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rr (1.2.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -92,13 +86,11 @@ GEM
       rack-protection (= 2.0.7)
       sinatra (= 2.0.7)
       tilt (~> 2.0)
-    sprockets (3.7.2)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-helpers (1.2.1)
       sprockets (>= 2.2)
-    sprockets-sass (2.0.0.beta2)
-      sprockets (>= 2.0, < 4.0)
     strings (0.1.6)
       strings-ansi (~> 0.1)
       unicode-display_width (~> 1.5)
@@ -154,12 +146,11 @@ DEPENDENCIES
   rack-test
   rake
   rr
-  sass
+  sassc
   sinatra
   sinatra-contrib
-  sprockets
+  sprockets (>= 4.0.0)
   sprockets-helpers
-  sprockets-sass
   terminal-table
   thin
   thor

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -95,7 +95,7 @@ class App < Sinatra::Application
       ]
 
     sprockets.js_compressor = Uglifier.new output: { beautify: true, indent_level: 0 }
-    sprockets.css_compressor = :sass
+    sprockets.css_compressor = :sassc
 
     Sprockets::Helpers.configure do |config|
       config.digest = true


### PR DESCRIPTION
Sass gem is deprecated and should be updated to Sassc. To add the Sassc gem, sprockets needs to be updated to version 4.0.0 or greater and sprockets-sass is not needed since it does not support Sassc and has not been updated since 2016.

Sprockets 4.0.0 has changed the way to pre-compile files, looks like a ['manifest.js' file is needed to pre-compile
files](https://github.com/rails/sprockets/blob/master/UPGRADING.md), at least with files that need two or more preprocessors, but I have not been able to make it work in this way.
