### PR TITLE
Update ruby version specified in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Unless you wish to contribute to the project, we recommend using the hosted vers
 
 DevDocs is made of two pieces: a Ruby scraper that generates the documentation and metadata, and a JavaScript app powered by a small Sinatra app.
 
-DevDocs requires Ruby 2.6.x, libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
+DevDocs requires Ruby 2.7.4, libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
 
 ```sh
 git clone https://github.com/freeCodeCamp/devdocs.git && cd devdocs


### PR DESCRIPTION
Setting up the project locally and noticed that following the quick start will lead you to download v2.6 which rvm will then complain about. This PR makes the readme match the version specified in [`.ruby-version`](https://github.com/freeCodeCamp/devdocs/blob/main/.ruby-version)

```bash
~/repos > ruby --version
ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-darwin18]

~/repos > cd devdocs
Required ruby-2.7.4 is not installed.
To install do: 'rvm install "ruby-2.7.4"'
```
