### PR TITLE
Remove leftover TOC entry in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,9 +10,8 @@ Want to contribute? Great. Please review the following guidelines carefully and 
 4. [Contributing code and features](#contributing-code-and-features)
 5. [Contributing new documentations](#contributing-new-documentations)
 6. [Updating existing documentations](#updating-existing-documentations)
-7. [Other contributions](#other-contributions)
-8. [Coding conventions](#coding-conventions)
-9. [Questions?](#questions)
+7. [Coding conventions](#coding-conventions)
+8. [Questions?](#questions)
 
 ## Reporting bugs
 


### PR DESCRIPTION
Hi,

It looks like one of the Table of Contents entries in the contribution guidelines refers to a section that was deleted in https://github.com/freeCodeCamp/devdocs/commit/efdd52a7c980ec47796d24ae887cc83f3825b2c9#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44c.

This PR removes that entry, because it points to nothing.