### PR TITLE
Update PostgreSQL documentation (14.0)

### DIFF
--- a/lib/docs/filters/postgresql/entries.rb
+++ b/lib/docs/filters/postgresql/entries.rb
@@ -100,21 +100,14 @@ module Docs
         when 'queries-table-expressions'
           entries.concat get_heading_entries('h3[id], .sect3[id] > h3:first-child')
           entries.concat get_custom_entries('dt > .literal:first-child')
-        when 'functions-logical'
-          entries.concat get_custom_entries('> table td:first-child > code')
-        when 'functions-formatting'
-          entries.concat get_custom_entries('#FUNCTIONS-FORMATTING-TABLE td:first-child > code')
         when 'functions-admin'
-          entries.concat get_custom_entries('.table td:first-child > code')
-        when 'functions-string'
-          entries.concat get_custom_entries('> div[id^="FUNC"] td:first-child > code')
-          entries.concat get_custom_entries('> div[id^="FORMAT"] td:first-child > code')
+          entries.concat get_custom_entries('.table td:first-child > p:first-child > code.function')
         else
           if type && type.start_with?('Functions')
             entries.concat get_custom_entries('> .table td:first-child > code.literal:first-child')
             entries.concat get_custom_entries('> .table td:first-child > code.function:first-child')
             entries.concat get_custom_entries('> .table td:first-child > code:not(.literal):first-child + code.literal')
-            entries.concat get_custom_entries('> .table td:first-child > p > code.literal:first-child')
+            entries.concat get_custom_entries('> .table td:first-child > p:first-child > code.literal:first-child')
             entries.concat get_custom_entries('> .table td:first-child > p > code.function:first-child')
             entries.concat get_custom_entries('> .table td:first-child > p > code:not(.literal):first-child + code.literal')
             if slug == 'functions-comparison' && !at_css('#FUNCTIONS-COMPARISON-PRED-TABLE') # before 9.6
@@ -220,6 +213,7 @@ module Docs
           unless entries.any? { |entry| entry[0] == name }
             node['id'] = id
             entries << [name, id]
+            # puts [selector, name].join(' --> ')
           end
         end
       end

--- a/lib/docs/scrapers/postgresql.rb
+++ b/lib/docs/scrapers/postgresql.rb
@@ -55,8 +55,13 @@ module Docs
       Licensed under the PostgreSQL License.
     HTML
 
+    version '14' do
+      self.release = '14.0'
+      self.base_url = "https://www.postgresql.org/docs/#{version}/"
+    end
+
     version '13' do
-      self.release = '13.2'
+      self.release = '13.4'
       self.base_url = "https://www.postgresql.org/docs/#{version}/"
     end
 


### PR DESCRIPTION

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
