### PR TITLE
Update CoffeeScript documentation (2.6.1)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -188,7 +188,7 @@ credits = [
     'https://raw.githubusercontent.com/bcit-ci/CodeIgniter/develop/license.txt'
   ], [
     'CoffeeScript',
-    '2009-2020 Jeremy Ashkenas',
+    '2009-2021 Jeremy Ashkenas',
     'MIT',
     'https://raw.githubusercontent.com/jashkenas/coffeescript/master/LICENSE'
   ], [

--- a/lib/docs/scrapers/coffeescript.rb
+++ b/lib/docs/scrapers/coffeescript.rb
@@ -11,12 +11,12 @@ module Docs
     options[:skip_links] = true
 
     options[:attribution] = <<-HTML
-      &copy; 2009&ndash;2020 Jeremy Ashkenas<br>
+      &copy; 2009&ndash;2021 Jeremy Ashkenas<br>
       Licensed under the MIT License.
     HTML
 
     version '2' do
-      self.release = '2.5.1'
+      self.release = '2.6.1'
       self.base_url = 'https://coffeescript.org/'
 
       html_filters.push 'coffeescript/entries', 'coffeescript/clean_html', 'title'

--- a/public/icons/docs/coffeescript/SOURCE
+++ b/public/icons/docs/coffeescript/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/jashkenas/coffee-script/downloads
+https://github.com/jashkenas/coffeescript/blob/master/docs/favicon-32x32.png


### PR DESCRIPTION


If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
