### PR TITLE
Update ESLint documentation (8.0.1)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -288,7 +288,7 @@ credits = [
     'https://raw.githubusercontent.com/erlang/otp/maint/LICENSE.txt'
   ], [
     'ESLint',
-    'JS Foundation and other contributors',
+    'OpenJS Foundation and other contributors',
     'MIT',
     'https://raw.githubusercontent.com/eslint/eslint/master/LICENSE'
   ], [

--- a/lib/docs/scrapers/eslint.rb
+++ b/lib/docs/scrapers/eslint.rb
@@ -2,7 +2,7 @@ module Docs
   class Eslint < UrlScraper
     self.name = 'ESLint'
     self.type = 'simple'
-    self.release = '7.30.0'
+    self.release = '8.0.1'
     self.base_url = 'https://eslint.org/docs/'
     self.root_path = 'user-guide/getting-started'
     self.links = {
@@ -17,7 +17,7 @@ module Docs
     options[:replace_paths] = { 'user-guide' => 'user-guide/' }
 
     options[:attribution] = <<-HTML
-      &copy; JS Foundation and other contributors<br>
+      &copy; OpenJS Foundation and other contributors<br>
       Licensed under the MIT License.
     HTML
 


### PR DESCRIPTION

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
