### PR TITLE
Update webpack documentation (5.59.1)

### DIFF
--- a/lib/docs/filters/webpack/entries.rb
+++ b/lib/docs/filters/webpack/entries.rb
@@ -22,16 +22,16 @@ module Docs
 
       def additional_entries
         if slug.start_with?('configuration')
-          css('h2[id] code').each_with_object [] do |node, entries|
-            next if node.previous.try(:content).present?
-            entries << [node.content, node.parent['id']]
+          css('h2[id]').each_with_object [] do |node, entries|
+            next if version.to_f < 5 && node.previous.try(:content).present?
+            entries << [node.content, node['id']]
           end
         elsif slug.start_with?('api') && slug != 'api/parser'
           css('.header[id] code').each_with_object [] do |node, entries|
-            next if node.previous.try(:content).present? || node.next.try(:content).present?
+            next if version.to_f < 5 && (node.previous.try(:content).present? || node.next.try(:content).present?)
             name = node.content.sub(/\(.*\)/, '()')
             name.prepend "#{self.name.split(':').first}: "
-            entries << [name, node.parent['id']]
+            entries << [name, node['id']]
           end
         else
           []

--- a/lib/docs/scrapers/webpack.rb
+++ b/lib/docs/scrapers/webpack.rb
@@ -36,7 +36,7 @@ module Docs
     HTML
 
     version '5' do
-      self.release = '5.41.1'
+      self.release = '5.59.1'
       self.base_url = 'https://webpack.js.org/'
     end
 


### PR DESCRIPTION

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
