### PR TITLE
fix: Reflect title of web api over dom per issue #1577

### DIFF
--- a/lib/docs/scrapers/mdn/dom.rb
+++ b/lib/docs/scrapers/mdn/dom.rb
@@ -7,7 +7,8 @@ module Docs
 
     html_filters.push 'dom/clean_html', 'dom/entries'
 
-    options[:root_title] = 'DOM'
+    options[:title] = 'Web API'
+    options[:root_title] = 'Web API'
 
   end
 end


### PR DESCRIPTION
- Following recommendation in issue #1577 
- Following documentation for options title and root title: 

```md
  - `:title` [String or Boolean or Proc]
    Unless the value is `false`, adds a title to every page.
    If the value is `nil`, the title is the name of the page as determined by the [`Entries`](./filter-reference.md#entriesfilter) filter. Otherwise the title is the String or the value returned by the Proc (called for each page, with the filter instance as argument). If the Proc returns `nil` or `false`, no title is added.
  - `:root_title` [String or Boolean]
    Overrides the `:title` option for the root page only.
```

cc @U-C-S

would appreciate it if this was admitted with hacktoberfest:

A pull request is considered approved once it has an overall approving review from maintainers, or has been merged by maintainers, or has been given the 'hacktoberfest-accepted' label.*

