### PR TITLE
Add numpy 1.22

### DIFF
--- a/lib/docs/filters/numpy/clean_html.rb
+++ b/lib/docs/filters/numpy/clean_html.rb
@@ -2,7 +2,8 @@ module Docs
   class Numpy
     class CleanHtmlFilter < Filter
       def call
-        at_css('#spc-section-body, main > div')
+        css('.sphinx-bs.container.pb-4.docutils').remove if root_page?
+        at_css('main > div > section', '#spc-section-body, main > div')
       end
     end
   end

--- a/lib/docs/filters/numpy/entries.rb
+++ b/lib/docs/filters/numpy/entries.rb
@@ -19,7 +19,7 @@ module Docs
             return 'Development'
           end
           li_a = css('nav li.active > a')
-          return li_a.last.content if li_a
+          return li_a.last.content if li_a && li_a.last
         end
 
         nav_items = css('.nav.nav-pills.pull-left > li')

--- a/lib/docs/scrapers/numpy.rb
+++ b/lib/docs/scrapers/numpy.rb
@@ -33,13 +33,13 @@ module Docs
     end
 
     version '1.21' do
-      self.release = '1.21.4'
+      self.release = '1.21.5'
       self.base_url = "https://numpy.org/doc/#{self.version}/"
       options[:container] = nil
     end
 
     version '1.20' do
-      self.release = '1.20.1'
+      self.release = '1.20.3'
       self.base_url = "https://numpy.org/doc/#{self.version}/"
       options[:container] = nil
     end

--- a/lib/docs/scrapers/numpy.rb
+++ b/lib/docs/scrapers/numpy.rb
@@ -26,6 +26,12 @@ module Docs
       Licensed under the 3-clause BSD License.
     HTML
 
+    version '1.22' do
+      self.release = '1.22.0'
+      self.base_url = "https://numpy.org/doc/#{self.version}/"
+      options[:container] = nil
+    end
+
     version '1.21' do
       self.release = '1.21.4'
       self.base_url = "https://numpy.org/doc/#{self.version}/"


### PR DESCRIPTION

<!-- SECTION B - Updating an existing documentation to it's latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating an existing documentation to it's latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches it's data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
