### PR TITLE
bundle update ffi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.3.6)
-    ffi (1.12.2)
+    ffi (1.15.5)
     fspath (3.1.2)
     highline (2.0.3)
     html-pipeline (2.12.0)


### PR DESCRIPTION
When running the `bundle install` command on my M1 Mac, it fails with the following error message:

<details>
<summary>Error message</summary>

```
Fetching ffi 1.12.2
Installing ffi 1.12.2 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/Users/Nicolas/.rvm/gems/ruby-2.7.5/gems/ffi-1.12.2/ext/ffi_c
/Users/Nicolas/.rvm/rubies/ruby-2.7.5/bin/ruby -I
/Users/Nicolas/.rvm/rubies/ruby-2.7.5/lib/ruby/2.7.0 -r
./siteconf20220211-65489-1lin374.rb extconf.rb
checking for ffi_call() in -lffi... yes
checking for ffi_closure_alloc()... yes
checking for shlwapi.h... no
checking for rb_thread_call_without_gvl()... yes
checking for ruby_native_thread_p()... yes
checking for ruby_thread_has_gvl_p()... yes
checking for ffi_prep_cif_var()... yes
checking for ffi_raw_call()... yes
checking for ffi_prep_raw_closure()... yes
creating extconf.h
creating Makefile

current directory:
/Users/Nicolas/.rvm/gems/ruby-2.7.5/gems/ffi-1.12.2/ext/ffi_c
make "DESTDIR=" clean

current directory:
/Users/Nicolas/.rvm/gems/ruby-2.7.5/gems/ffi-1.12.2/ext/ffi_c
make "DESTDIR="
compiling AbstractMemory.c
compiling ArrayType.c
compiling Buffer.c
compiling Call.c
compiling ClosurePool.c
compiling DynamicLibrary.c
compiling Function.c
Function.c:867:17: error: implicit declaration of function
'ffi_prep_closure' is invalid in C99
[-Werror,-Wimplicit-function-declaration]
ffiStatus = ffi_prep_closure(code, &fnInfo->ffi_cif, callback_invoke,
closure);
                ^
1 error generated.
make: *** [Function.o] Error 1

make failed, exit code 2

Gem files will remain installed in
/Users/Nicolas/.rvm/gems/ruby-2.7.5/gems/ffi-1.12.2 for inspection.
Results logged to
/Users/Nicolas/.rvm/gems/ruby-2.7.5/extensions/arm64-darwin-21/2.7.0/ffi-1.12.2/gem_make.out

An error occurred while installing ffi (1.12.2), and Bundler cannot
continue.
Make sure that `gem install ffi -v '1.12.2' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  typhoeus was resolved to 1.3.1, which depends on
    ethon was resolved to 0.12.0, which depends on
      ffi
```

</details>

This issue seems to be fixed by updating the ffi dependency. This PR does exactly that.