### PR TITLE
Fix docs:download --default

### DIFF
--- a/lib/docs.rb
+++ b/lib/docs.rb
@@ -44,7 +44,7 @@ module Docs
   end
 
   def self.defaults
-    %w(css 'Web APIs' html http javascript).map(&method(:find))
+    %w(css dom html http javascript).map(&method(:find))
   end
 
   def self.installed


### PR DESCRIPTION
This PR fixes a bug related to #1577 (*Rename DOM to Web API*).

6ad0784fbeb5f5cf98304efd6e0942cce48decf7 breaks the `bundle exec thor docs:download --default` command, which currently fails with the following error message:

```
ERROR: could not find doc "'Web".
Run "thor docs:list" to see the list of docs and versions.
```