### PR TITLE
chore: use global config repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,3 @@
 {
-  "labels": ["renovate"],
-  "extends": ["config:base"],
-  "branchConcurrentLimit": 20,
-  "dependencyDashboard": true,
-  "major": {
-    "dependencyDashboardApproval": true
-  },
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    }
-  ]
+  "extends": ["github>freecodecamp/renovate-config"]
 }


### PR DESCRIPTION
Moving to a standardized set of rules we have been using elsewhere.