### PR TITLE
Bug: fix a misuse in get_latest_version's hostname

### DIFF
--- a/lib/docs/scrapers/eigen3.rb
+++ b/lib/docs/scrapers/eigen3.rb
@@ -26,7 +26,7 @@ module Docs
 
 
     def get_latest_version(opts)
-      tags = get_gitlab_tags("https://gitlab.com", "libeigen", "eigen", opts)
+      tags = get_gitlab_tags("gitlab.com", "libeigen", "eigen", opts)
       tags[0]['name']
     end
 


### PR DESCRIPTION
Fix an error appeared in freeCodeCamp#1742 : could not check latest version