### PR TITLE
fix: clip hover state breaking column layout

### DIFF
--- a/assets/stylesheets/components/_content.scss
+++ b/assets/stylesheets/components/_content.scss
@@ -398,7 +398,12 @@
   padding: .375rem;
   cursor: pointer;
 
-  pre:hover > & { display: block; }
+  pre:hover > & {
+    display: block;
+    top: 0.1875rem;
+    padding: 0;
+  }
+
   &:hover { opacity: 1; }
 
   > svg {


### PR DESCRIPTION
Minor positioning/padding changes to the "copy to clipboard" icon's style rule to prevent visible layout changes from occurring while in the :hover state. fixes #1739