### PR TITLE
Fix all Elixir 1.13 names detected as "Settings"

### DIFF
--- a/lib/docs/filters/elixir/entries.rb
+++ b/lib/docs/filters/elixir/entries.rb
@@ -3,11 +3,11 @@ module Docs
     class EntriesFilter < Docs::EntriesFilter
       def get_name
         css('h1 .app-vsn').remove
+        name = (at_css('h1 > span') or at_css('h1')).content.strip
 
         if current_url.path.start_with?('/getting-started')
-          (at_css('h1 > span') or at_css('h1')).content.strip.remove(/\.\z/)
+          name.remove(/\.\z/)
         else
-          name = at_css('h1').content.strip
           name = name.split(' ').first unless name.start_with?('mix ') # ecto
           name
         end


### PR DESCRIPTION
A partial fix was already included in the initial patch in #1746,
but it was only applied to a subset of titles.

I tested the new scraper for both Elixir 1.13 and the previous 1.12 and it still looks good