### PR TITLE
Update zig docs (master)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -953,7 +953,7 @@ credits = [
     'https://raw.githubusercontent.com/yiisoft/yii/master/LICENSE'
   ], [
     'Zig',
-    '2015–2021, Zig contributors',
+    '2015–2022, Zig contributors',
     'MIT',
     'https://raw.githubusercontent.com/ziglang/zig/master/LICENSE'
   ]

--- a/lib/docs/scrapers/zig.rb
+++ b/lib/docs/scrapers/zig.rb
@@ -2,8 +2,8 @@ module Docs
   class Zig < UrlScraper
     self.name = 'Zig'
     self.type = 'simple'
-    self.release = '0.9.0'
-    self.base_url = 'https://ziglang.org/documentation/0.9.0/'
+    self.release = 'master'
+    self.base_url = 'https://ziglang.org/documentation/master/'
     self.links = {
       home: 'https://ziglang.org/',
       code: 'https://github.com/ziglang/zig'
@@ -13,7 +13,7 @@ module Docs
 
     options[:follow_links] = false
     options[:attribution] = <<-HTML
-      &copy; 2015–2021, Zig contributors
+      &copy; 2015–2022, Zig contributors
     HTML
 
     def get_latest_version(opts)


### PR DESCRIPTION
Zig is currently using master for the latest versions, including docs. Making devdocs follow this would be pretty nice for everyone using both zig and devdocs.

<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
