### PR TITLE
docs: remove mention of Travis in favour of Actions

### DIFF
--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -49,16 +49,16 @@ In addition to the [publicly-documented commands](https://github.com/freeCodeCam
   Packages can also be automatically generated during the scraping process by passing the `--package` option to `thor docs:generate`.
 
 - `thor docs:upload`
-  
+
   This command does two operations:
-  
-    1. sync the files for the specified documentations with S3 (used by the Heroku app);
-    2. upload the documentations' packages to DevDocs's S3 bundle zone (used by the `thor docs:download` command).
-  
+
+  1. sync the files for the specified documentations with S3 (used by the Heroku app);
+  2. upload the documentations' packages to DevDocs's S3 bundle zone (used by the `thor docs:download` command).
+
   For the command to work, you must have the AWS CLI configured as indicated above.
-  
+
   **Important:** the app should always be deployed immediately after this command has finished running. Do not run this command unless you are able and ready to deploy DevDocs.
-  
+
   To upload all documentations that are packaged on your computer, run `thor docs:upload --packaged`.
   To test your configuration and the effect of this command without uploading anything, pass the `--dryrun` option.
 
@@ -72,21 +72,21 @@ In addition to the [publicly-documented commands](https://github.com/freeCodeCam
 
 ## Deploying DevDocs
 
-Once docs have been uploaded via `thor docs:upload` (if applicable), you can push to the DevDocs main branch (or merge the PR containing the updates). If the Travis build succeeds, the Heroku application will be deployed automatically.
+Once docs have been uploaded via `thor docs:upload` (if applicable), you can push to the DevDocs main branch (or merge the PR containing the updates). This triggers a GitHub action which starts by running the tests. If they succeed, the Heroku application will be deployed automatically.
 
 - If you're deploying documentation updates, verify that the documentations work properly once the deploy is done. Keep in mind that you'll need to wait a few seconds for the service worker to finish caching the new assets. You should see a "DevDocs has been updated" notification appear when the caching is done, after which you need to refresh the page to see the changes.
 - If you're deploying frontend changes, monitor [Sentry](https://sentry.io/devdocs/devdocs-js/) for new JS errors once the deploy is done.
 - If you're deploying server changes, monitor New Relic (accessible through [the Heroku dashboard](https://dashboard.heroku.com/apps/devdocs)) for Ruby exceptions and throughput or response time changes once the deploy is done.
 
-If any issue arises, run `heroku rollback` to rollback to the previous version of the app (this can also be done via Heroku's UI). Note that this will not revert changes made to documentation files that were uploaded via `thor docs:upload`.  Try and fix the issue as quickly as possible, then re-deploy the app. Reach out to other maintainers if you need help.
+If any issue arises, run `heroku rollback` to rollback to the previous version of the app (this can also be done via Heroku's UI). Note that this will not revert changes made to documentation files that were uploaded via `thor docs:upload`. Try and fix the issue as quickly as possible, then re-deploy the app. Reach out to other maintainers if you need help.
 
-If this is your first deploy, make sure another maintainer is around to assist. 
+If this is your first deploy, make sure another maintainer is around to assist.
 
 ## Infrastructure
 
-The bundled documents are available at downloads.devdocs.io and the documents themselves at documents.devdocs.io.  Download and document requests are proxied to S3 buckets devdocs-downloads.s3.amazonaws.com and devdocs-documents.s3.amazonaws.com respectively.
+The bundled documents are available at downloads.devdocs.io and the documents themselves at documents.devdocs.io. Download and document requests are proxied to S3 buckets devdocs-downloads.s3.amazonaws.com and devdocs-documents.s3.amazonaws.com respectively.
 
-New proxy VMs should be created from the `devdocs-proxy` snapshot.  Before adding them to the load-balancer, it's necessary to add their IP addresses to the aws:SourceIp lists for both buckets, or their requests will be rejected.
+New proxy VMs should be created from the `devdocs-proxy` snapshot. Before adding them to the load-balancer, it's necessary to add their IP addresses to the aws:SourceIp lists for both buckets, or their requests will be rejected.
 
 When creating a new proxy VM and the `devdocs-proxy` snapshot is not available, then the new vm should be provisioned as follows:
 
@@ -106,10 +106,10 @@ rm -rf /etc/nginx/.* 2> /dev/null
 git clone https://github.com/freeCodeCamp/devdocs-nginx-config.git /etc/nginx
 
 # at this point we need to add the certs from Cloudflare and test the config
-nginx -t 
+nginx -t
 
-# if nginx is already running, just 
-# ps aux | grep nginx 
+# if nginx is already running, just
+# ps aux | grep nginx
 # find the number and kill it
 
 nginx


### PR DESCRIPTION
I mostly wanted to deploy to the new Heroku stack and be obvious about it, but I noticed the docs could be updated while I was at it.