### PR TITLE
Update Drupal UrlScraper

### DIFF
--- a/lib/docs/filters/drupal/entries.rb
+++ b/lib/docs/filters/drupal/entries.rb
@@ -20,7 +20,7 @@ module Docs
         elsif subpath =~ /core!themes/
           'themes'
         else
-          css('.breadcrumb > a')[1].content
+          css('.breadcrumb a')[1].content
         end
       end
 

--- a/lib/docs/scrapers/drupal.rb
+++ b/lib/docs/scrapers/drupal.rb
@@ -10,7 +10,7 @@ module Docs
     html_filters.push 'drupal/entries', 'drupal/clean_html', 'title'
 
     options[:decode_and_clean_paths] = true
-    options[:container] = '#page-inner'
+    options[:container] = '#page'
     options[:title] = false
     options[:root_title] = 'Drupal'
 


### PR DESCRIPTION
This updates Drupal 7 and 8 and adds Drupal 9 and 10.

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
