### PR TITLE
Fix MDN iframe height

### DIFF
--- a/assets/stylesheets/pages/_mdn.scss
+++ b/assets/stylesheets/pages/_mdn.scss
@@ -132,7 +132,50 @@
     dd { margin: 0; }
   }
 
-  iframe.interactive {
-    width: 100%;
+  .interactive {
+      width: 100%;
+      height: 680px;    
+      &.is-js-height {
+        height: 520px;
+      }
+      &.is-shorter-height {
+        height: 440px;
+      }
+      &.is-taller-height {
+        height: 730px;
+      }
+      &.is-tabbed-shorter-height {
+        height: 490px;
+      }
+      &.is-tabbed-standard-height {
+        height: 550px;
+      }
+      &.is-tabbed-taller-height {
+        height: 780px;
+      }
+    }
+  @media screen and (min-width: 993px) {
+    .interactive {
+      height: 380px;
+
+      &.is-js-height {
+        height: 450px;
+      }
+      &.is-shorter-height {
+        height: 370px;
+      }
+      &.is-taller-height {
+        height: 660px;
+      }
+      &.is-tabbed-shorter-height {
+        height: 360px;
+      }
+      &.is-tabbed-standard-height {
+        height: 430px;
+      }
+      &.is-tabbed-taller-height {
+        height: 640px;
+      }
+    }
   }
 }


### PR DESCRIPTION
I found that the height of the [_MDN.scss](https://github.com/freeCodeCamp/devdocs/blob/main/assets/stylesheets/pages/_mdn.scss) file was not rendering the iframe .content class correctly and using its default 200px height as compared to the original.

This commit tries to fix the iframe element have a higher default height to make the scrollbar go away and copy the original website's css to make the iframe become taller on mobile and thin screens.


## Before:
![old full](https://user-images.githubusercontent.com/109556932/188112439-c4921d29-48be-440e-80bb-b6b9b89a5753.png)
![old thin](https://user-images.githubusercontent.com/109556932/188112472-b958a656-28a8-4810-8a33-8bc88b1cb943.png)

## After:
![new full](https://user-images.githubusercontent.com/109556932/188112532-0a94f8a4-a3de-45cc-859e-71cdb8c763a9.png)
![new thin](https://user-images.githubusercontent.com/109556932/188112538-700ca19c-ea74-405e-83c0-19f6aaf6a445.png)


This solution generally improves the readability but isn't a perfect fix since the media query can't calculate for the sidebar width as far as I am aware. The iframe overflow is tuned for a 1920x1080 screen but will be off by a few pixels depending on the screen size.