### PR TITLE
fix: replace calls to `File.exists?` with `File.exist?`

### DIFF
--- a/lib/docs/core/scrapers/file_scraper.rb
+++ b/lib/docs/core/scrapers/file_scraper.rb
@@ -22,7 +22,7 @@ module Docs
     private
 
     def assert_source_directory_exists
-      unless Dir.exists?(source_directory)
+      unless Dir.exist?(source_directory)
         raise SetupError, "The #{self.class.name} scraper requires the original documentation files to be stored in the \"#{source_directory}\" directory."
       end
     end

--- a/lib/docs/storage/file_store.rb
+++ b/lib/docs/storage/file_store.rb
@@ -30,7 +30,7 @@ module Docs
     end
 
     def file_exist?(path)
-      File.exists?(path)
+      File.exist?(path)
     end
 
     def file_mtime(path)
@@ -46,7 +46,7 @@ module Docs
         next if file == path
         Find.prune if File.basename(file)[0] == '.'
         yield file
-        Find.prune unless File.exists?(file)
+        Find.prune unless File.exist?(file)
       end
     end
   end

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -175,7 +175,7 @@ class DocsCLI < Thor
 
     # Verify files are present
     docs.each do |doc|
-      unless Dir.exists?(File.join(Docs.store_path, doc.path))
+      unless Dir.exist?(File.join(Docs.store_path, doc.path))
         puts "ERROR: directory #{File.join(Docs.store_path, doc.path)} not found."
         return
       end

--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -180,7 +180,7 @@ class DocsCLI < Thor
         return
       end
 
-      unless File.exists?(File.join(Docs.store_path, "#{doc.path}.tar.gz"))
+      unless File.exist?(File.join(Docs.store_path, "#{doc.path}.tar.gz"))
         puts "ERROR: package for '#{doc.slug}' documentation not found. Run 'thor docs:package #{doc.slug}' to create it."
         return
       end


### PR DESCRIPTION
This prints warnings about being deprecated, so replace it with the call that the deprecated function wraps.

See: https://github.com/ruby/ruby/blob/ruby_2_7/file.c#L1752-L1781