### PR TITLE
Fix table overflow when there is long data that exceeds page width

### DIFF
--- a/assets/stylesheets/global/_base.scss
+++ b/assets/stylesheets/global/_base.scss
@@ -134,6 +134,9 @@ table {
   border-collapse: separate;
   border-spacing: 0;
   border-radius: 3px;
+  display: inline-block;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 caption {


### PR DESCRIPTION
Fixes https://github.com/freeCodeCamp/devdocs/issues/1749

Add extra styling to allow

- short tables to maintain current style (via `display: inline-block`)
- long tables to overflow with a scroll that does not affect page layout (via `overflow-x: auto` and `max-width: 100%`)

* * *

**Preview of problem**

https://devdocs.io/dom/document/domcontentloaded_event#browser_compatibility

<img width="469" alt="image" src="https://user-images.githubusercontent.com/892961/193450471-13b9e44b-b82b-47c8-9dda-0b0679a3cfe6.png">

https://devdocs.io/javascript/classes/private_class_fields#browser_compatibility

<img width="645" alt="image" src="https://user-images.githubusercontent.com/892961/193450620-ac7645be-1a4b-478e-b8bc-7b9425fca0c8.png">


* * * 

**Preview of fix**
<img width="491" alt="image" src="https://user-images.githubusercontent.com/892961/193450451-14c28e22-4048-4a5b-bb81-e4f7a3c8a6d7.png">

<img width="536" alt="image" src="https://user-images.githubusercontent.com/892961/193450491-fd2fe18f-e35d-4ff6-84c5-d99a2dbea3e9.png">
