### PR TITLE
Update Sequelize documentation (6.23.2)

### DIFF
--- a/lib/docs/filters/sequelize/clean_html.rb
+++ b/lib/docs/filters/sequelize/clean_html.rb
@@ -2,26 +2,9 @@ module Docs
   class Sequelize
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.content')
+        @doc = at_css('article', '.content')
 
-        # Clean up the home page
-        if root_page? || subpath == "index.html"
-          # Remove logo
-          css('.manual-user-index > div > div.logo').remove
-
-          # Convert title to proper h1 element
-          at_css('.manual-user-index > div > div.sequelize').name = 'h1'
-
-          # Remove badges (NPM, Travis, test coverage, etc.)
-          css('.manual-user-index > p:nth-child(4)').remove
-
-          # Remove image cards pointing to entries of the manual
-          css('.manual-cards').remove
-
-          # Pull the header out of its container
-          header = at_css('h1')
-          header.parent.parent.parent.add_previous_sibling header
-        else
+        if at_css('header > h1')
           # Pull the header out of its container
           header = at_css('h1')
           header.parent.add_previous_sibling header
@@ -36,18 +19,13 @@ module Docs
         end
 
         # Add syntax highlighting to code blocks
-        css('pre > code[class^="lang-"]').each do |node|
-          pre = node.parent
-          # Convert the existing language definitions to Prism-compatible attributes
-          pre['data-language'] = 'javascript' if node['class'] == 'lang-js' || node['class'] == 'lang-javascript'
-          pre['data-language'] = 'json'       if node['class'] == 'lang-json'
-          pre['data-language'] = 'shell'      if node['class'] == 'lang-sh' || node['class'] == 'lang-bash'
-          pre['data-language'] = 'sql'        if node['class'] == 'lang-sql'
-          pre['data-language'] = 'typescript' if node['class'] == 'lang-ts'
+        css('pre[class^="prism-code language-"]').each do |node|
+          node['data-language'] = node['class'][/language-(\w+)/, 1] if node['class'] and node['class'][/language-(\w+)/]
+          node.content = node.css('.token-line').map(&:content).join("\n")
         end
 
         # Return the cleaned-up document
-        doc
+        at_css('.markdown') || doc
       end
     end
   end

--- a/lib/docs/filters/sequelize/entries.rb
+++ b/lib/docs/filters/sequelize/entries.rb
@@ -8,19 +8,19 @@ module Docs
 
       # Assign the pages to main categories
       def get_type
-        if path.start_with?('manual/')
+        if base_url.path.include?('/docs/')
           'Manual'
-        elsif path.include?('lib/data-types')
+        elsif path.include?('src/data-types')
           'datatypes'
-        elsif path.include?('lib/errors/validation')
+        elsif path.include?('src/errors/validation')
           'errors/validation'
-        elsif path.include?('lib/errors/database')
+        elsif path.include?('src/errors/database')
           'errors/database'
-        elsif path.include?('lib/errors/connection')
+        elsif path.include?('src/errors/connection')
           'errors/connection'
-        elsif path.include?('lib/errors')
+        elsif path.include?('src/errors')
           'errors'
-        elsif path.include?('lib/associations')
+        elsif path.include?('src/associations')
           'associations'
         elsif path.include?('master/variable')
           'variables'
@@ -28,6 +28,11 @@ module Docs
           'classes'
         end
       end
+
+      def include_default_entry?
+        at_css('.card > h2:contains("📄️")').nil?
+      end
+
     end
   end
 end

--- a/lib/docs/scrapers/sequelize.rb
+++ b/lib/docs/scrapers/sequelize.rb
@@ -1,5 +1,7 @@
 module Docs
   class Sequelize < UrlScraper
+    include MultipleBaseUrls
+
     self.name = 'Sequelize'
     self.slug = 'sequelize'
     self.type = 'simple'
@@ -20,9 +22,20 @@ module Docs
       Licensed under the MIT License.
     HTML
 
+    def initial_urls
+      [
+        "https://sequelize.org/docs/v6/",
+        "https://sequelize.org/api/v6/identifiers.html",
+      ]
+    end
+
     version '6' do
-      self.release = '6.5.0'
-      self.base_url = "https://sequelize.org/master/"
+      self.release = '6.23.2'
+      self.base_url = "https://sequelize.org/docs/v6/"
+      self.base_urls = [
+        "https://sequelize.org/docs/v6/",
+        "https://sequelize.org/api/v6/",
+      ]
     end
 
     version '5' do


### PR DESCRIPTION

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
