### PR TITLE
Update NumPy documentation (1.23.0)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -623,7 +623,7 @@ credits = [
     'https://raw.githubusercontent.com/npm/npm/master/LICENSE'
   ], [
     'NumPy',
-    '2005-2021 NumPy Developers',
+    '2005-2022 NumPy Developers',
     'BSD',
     'https://raw.githubusercontent.com/numpy/numpy/master/LICENSE.txt'
   ], [

--- a/lib/docs/filters/numpy/entries.rb
+++ b/lib/docs/filters/numpy/entries.rb
@@ -5,9 +5,9 @@ module Docs
         if dt = at_css('dt')
           name = dt_to_name(dt)
         else
-          name = at_css('h1').content.strip
+          name = at_xpath('//h1/text()').text.strip
         end
-        name.remove! "\u{00B6}"
+        name.remove! %r{#\Z}
         name
       end
 
@@ -18,8 +18,12 @@ module Docs
           elsif slug.start_with?('dev')
             return 'Development'
           end
-          li_a = css('nav li.active > a')
-          return li_a.last.content if li_a && li_a.last
+          if css('nav li.toctree-l2.active .toctree-l3').length > 7
+            li_a = css('nav li.toctree-l2.active > a')
+          else
+            li_a = css('nav li.toctree-l1.active > a')
+          end
+          return li_a.last.xpath('./text()').text.remove('(  )').strip if li_a && li_a.last
         end
 
         nav_items = css('.nav.nav-pills.pull-left > li')
@@ -29,8 +33,8 @@ module Docs
         elsif nav_items[4] && nav_items[4].content !~ /Manual|Reference/
           type = nav_items[4].content
         else
-          type = at_css('h1').content.strip
-          type.remove! "\u{00B6}"
+          type = at_xpath('//h1/text()').text.strip
+          type.remove! %r{#\Z}
 
           # Handle some edge cases that aren't properly categorized in the docs
           if type.start_with?('numpy.polynomial.') || type.start_with?('numpy.poly1d.')
@@ -90,7 +94,7 @@ module Docs
         name.remove! %r{[\=\[].*}
         name.remove! %r{\A(class(method)?|exception) }
         name.remove! %r{\s—.*}
-        name.remove! '¶'
+        name.remove! %r{#\Z}
       end
     end
   end

--- a/lib/docs/scrapers/numpy.rb
+++ b/lib/docs/scrapers/numpy.rb
@@ -22,18 +22,24 @@ module Docs
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2005&ndash;2021 NumPy Developers<br>
+      &copy; 2005&ndash;2022 NumPy Developers<br>
       Licensed under the 3-clause BSD License.
     HTML
 
+    version '1.23' do
+      self.release = '1.23.0'
+      self.base_url = "https://numpy.org/doc/#{self.version}/"
+      options[:container] = nil
+    end
+
     version '1.22' do
-      self.release = '1.22.0'
+      self.release = '1.22.4'
       self.base_url = "https://numpy.org/doc/#{self.version}/"
       options[:container] = nil
     end
 
     version '1.21' do
-      self.release = '1.21.5'
+      self.release = '1.21.6'
       self.base_url = "https://numpy.org/doc/#{self.version}/"
       options[:container] = nil
     end


### PR DESCRIPTION


- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
