### PR TITLE
Update OpenJDK documentation (19)

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -176,6 +176,13 @@ Search 'Openjdk' in https://www.debian.org/distrib/packages, find the `openjdk-$
 download it, extract it with `dpkg -x $PACKAGE ./` and move `./usr/share/doc/openjdk-16-jre-headless/api/`
 to `path/to/devdocs/docs/openjdk~$VERSION`
 
+```
+curl http://ftp.at.debian.org/debian/pool/main/o/openjdk-19/openjdk-19-doc_19+36-2_all.deb &&
+tar xf openjdk-19-doc_19+36-2_all.deb
+tar xf data.tar.xz
+mv ./usr/share/doc/openjdk-19-jre-headless/api/ path/to/devdocs/docs/openjdk~$VERSION
+```
+
 If you use or have access to a Debian-based GNU/Linux distribution you can run the following command:
 ```sh
 apt download openjdk-$VERSION-doc

--- a/lib/docs/scrapers/openjdk.rb
+++ b/lib/docs/scrapers/openjdk.rb
@@ -37,6 +37,16 @@ module Docs
 
     NEWFILTERS = ['openjdk/entries_new', 'openjdk/clean_html_new']
 
+    version '19' do
+      self.release = '19'
+      self.root_path = 'index.html'
+      self.base_url = 'https://docs.oracle.com/en/java/javase/19/docs/api/'
+
+      html_filters.push NEWFILTERS
+
+      options[:container] = 'main'
+    end
+
     version '18' do
       self.release = '18'
       self.root_path = 'index.html'


### PR DESCRIPTION

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
