### PR TITLE
Fix broken links

### DIFF
--- a/public/icons/docs/backbone/SOURCE
+++ b/public/icons/docs/backbone/SOURCE
@@ -1,1 +1,1 @@
-http://backbonejs.org/docs/images/favicon.ico
+https://github.com/jashkenas/backbone/blob/master/favicon.ico

--- a/public/icons/docs/cakephp/SOURCE
+++ b/public/icons/docs/cakephp/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/cakephp/cakephp-api-docs/blob/master/templates/cakephp/resources/favicon.png
+https://github.com/cakephp/cakephp-api-docs/tree/2.x/static/assets/resources/favicons

--- a/public/icons/docs/clojure/SOURCE
+++ b/public/icons/docs/clojure/SOURCE
@@ -1,1 +1,1 @@
-http://en.wikipedia.org/wiki/File:Clojure_logo.gif
+https://en.wikipedia.org/wiki/File:Clojure_logo.svg

--- a/public/icons/docs/cordova/SOURCE
+++ b/public/icons/docs/cordova/SOURCE
@@ -1,1 +1,1 @@
-http://cordova.apache.org/artwork.html
+https://cordova.apache.org/artwork/

--- a/public/icons/docs/crystal/SOURCE
+++ b/public/icons/docs/crystal/SOURCE
@@ -1,1 +1,1 @@
-https://crystal-lang.org/images/favico.ico
+https://crystal-lang.org/media/

--- a/public/icons/docs/cypress/SOURCE
+++ b/public/icons/docs/cypress/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/cypress-io/cypress-documentation/raw/develop/themes/cypress/source/img/favicon.ico
+https://github.com/cypress-io/cypress/tree/develop/assets

--- a/public/icons/docs/dart/SOURCE
+++ b/public/icons/docs/dart/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/dart-lang/logos
+https://dart.dev/brand

--- a/public/icons/docs/django/SOURCE
+++ b/public/icons/docs/django/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/django/djangoproject.com/raw/master/static/favicon.ico
+https://github.com/django/djangoproject.com/blob/main/djangoproject/static/img/favicon.ico

--- a/public/icons/docs/docker/SOURCE
+++ b/public/icons/docs/docker/SOURCE
@@ -1,1 +1,2 @@
-https://www.docker.com/brand-guidelines
+https://www.docker.com/company/newsroom/media-resources/
+https://www.docker.com/legal/trademark-guidelines/

--- a/public/icons/docs/elixir/SOURCE
+++ b/public/icons/docs/elixir/SOURCE
@@ -1,2 +1,2 @@
-http://elixir-lang.org/docs/stable/elixir/assets/logo.png
-with permission from José Valim (https://twitter.com/josevalim/status/657125748659126272)
+https://raw.githubusercontent.com/elixir-lang/elixir-lang.github.com/main/images/logo/logo-dark.png#gh-dark-mode-only
+https://elixir-lang.org/images/logo/logo.png

--- a/public/icons/docs/ember/SOURCE
+++ b/public/icons/docs/ember/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/tschundeee/emberjsfavicon
+https://emberjs.com/logos/

--- a/public/icons/docs/gnu_cobol/SOURCE
+++ b/public/icons/docs/gnu_cobol/SOURCE
@@ -1,1 +1,1 @@
-https://sourceforge.net/p/open-cobol/icon
+https://gnucobol.sourceforge.io/images/shire_200.png

--- a/public/icons/docs/immutable/SOURCE
+++ b/public/icons/docs/immutable/SOURCE
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/facebook/immutable-js/master/pages/src/static/favicon.png
+https://github.com/immutable-js/immutable-js/blob/main/website/public/favicon.png

--- a/public/icons/docs/jasmine/SOURCE
+++ b/public/icons/docs/jasmine/SOURCE
@@ -1,1 +1,1 @@
-https://github.com/jasmine/jasmine.github.io/tree/main/images
+https://github.com/jasmine/jasmine/blob/main/images/jasmine_favicon.png


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION A - Adding a new scraper -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#contributing-new-documentations -->

If you’re adding a new scraper, please ensure that you have:

- [x] Tested the scraper on a local copy of DevDocs
- [x] Ensured that the docs are styled similarly to other docs on DevDocs
<!-- If the docs don’t have an icon, delete the next four items: -->
- [ ] Added these files to the <code>public/icons/*your_scraper_name*/</code> directory:
  - [ ] `16.png`: a 16×16 pixel icon for the doc
  - [ ] `16@2x.png`: a 32×32 pixel icon for the doc
  - [ ] `SOURCE`: A text file containing the URL to the page the image can be found on or the URL of the original image itself

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
