### PR TITLE
Correct Gtk Introduction Link 

### DIFF
--- a/lib/docs/scrapers/gtk.rb
+++ b/lib/docs/scrapers/gtk.rb
@@ -74,7 +74,7 @@ module Docs
 
     version '4.0' do
       self.release = '4.0.0'
-      self.base_url = "https://developer.gnome.org/gtk4/#{self.version}/"
+      self.base_url = "https://developer-old.gnome.org/gtk4/stable/"
 
       options[:root_title] = 'GTK 4 Reference Manual'
       options[:skip] = GTK4_SKIP

--- a/lib/docs/scrapers/gtk.rb
+++ b/lib/docs/scrapers/gtk.rb
@@ -74,7 +74,7 @@ module Docs
 
     version '4.0' do
       self.release = '4.0.0'
-      self.base_url = "https://developer-old.gnome.org/gtk4/stable/"
+      self.base_url = "https://developer-old.gnome.org/gtk4/#{self.version}/"
 
       options[:root_title] = 'GTK 4 Reference Manual'
       options[:skip] = GTK4_SKIP


### PR DESCRIPTION
Fixes #1820 

Found out that this is the correct url for gtk version 4: https://developer-old.gnome.org/gtk4/4.0/
so I changed it for the version 4.0 section inside gtk.rb.

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
