### PR TITLE
Fix Erlang lib/ entries and func Types sec

### DIFF
--- a/assets/stylesheets/pages/_erlang.scss
+++ b/assets/stylesheets/pages/_erlang.scss
@@ -6,4 +6,10 @@
   .note { @extend %note; }
   .warning { @extend %note, %note-red; }
   .note .label, .warning .label { font-weight: var(--boldFontWeight); }
+
+  .since {
+	  color: var(--textColorLight);
+	  font-weight: normal;
+	  font-size: small;
+  }
 }

--- a/lib/docs/filters/erlang/clean_html.rb
+++ b/lib/docs/filters/erlang/clean_html.rb
@@ -30,34 +30,47 @@ module Docs
 
         # others
 
+        # Remove JS on-hover highlighting
+        css('h3.title-link', 'h4.data-type-name', 'h4.func-head').each do |node|
+          node.remove_attribute('onmouseover')
+          node.remove_attribute('onmouseout')
+        end
+
         css('a[name]').each do |node|
-          # parent = node.parent
-          # parent = parent.parent while parent.name == 'span'
-          (node.next_element || node.parent)['id'] ||= node['name']
           node.before(node.children).remove
         end
 
         css('h3').each do |node|
-          node.name = 'h2'
           content = node.content
           node.content = content.capitalize if content == content.upcase
         end
 
-        css('p > .bold_code:first-child ~ br:last-child').each do |node|
-          parent = node.parent
-          parent.name = 'h3'
-          parent.css('> br').remove
-          parent.css('> code').each do |code|
-            code.css('*:not(a):not(br)').each { |n| n.before(n.children).remove }
-            code.inner_html = code.inner_html.gsub('<br>', "\n").strip
+        # Subsume "Types" heading under function head heading
+        css('h4.func-head + .fun-types > h3.func-types-title')
+          .each { |node| node.name = 'h5' }
+
+        css('h3', 'h4', 'h5').each do |node|
+          node.name = node.name.sub(/\d/) { |i| i.to_i - 1 }
+        end
+
+        # Convert <span/> code blocks to <code/> if inline otherwise
+        # <pre><code/></pre>.
+        css('span.bold_code', 'span.code', '.func-head > span.title-name').each do |node|
+          node.remove_attribute('class')
+          node.css('span.bold_code', 'span.code')
+            .each { |n| n.before(n.children).remove }
+          if node.at_css('br') then
+            node.name = 'pre'
+            node.inner_html = "<code>" +
+                              node.inner_html.remove(/\n/).gsub('<br>', "\n").strip +
+                              "</code>"
+          else
+            node.name = 'code'
+            node.inner_html = node.inner_html.strip.gsub(/\s+/, ' ')
           end
         end
 
-        css('pre:not(.REFTYPES) *:not(a)', 'a[href^=javascript]').each do |node|
-          node.before(node.children).remove
-        end
-
-        css('pre:not(.REFTYPES)').each do |node|
+        css('*:not(.REFTYPES) > pre').each do |node|
           node['data-language'] = 'erlang'
           node.inner_html = node.inner_html.strip_heredoc
         end
@@ -70,23 +83,7 @@ module Docs
           end
         end
 
-        css('.REFTYPES').each do |node|
-          next unless node.parent
-          html = "<pre>"
-          while node['class'] == 'REFTYPES'
-            node.inner_html = node.inner_html.remove(/\n/).gsub('<br>', "\n")
-            node.css('*:not(a)').each { |n| n.before(n.children).remove }
-            html << node.inner_html.strip + "\n"
-            node = node.next_element
-            node.previous_element.remove
-          end
-          html.gsub! %r{\n{2,}}, "\n"
-          html.strip!
-          html << "</pre>"
-          node.before(html)
-        end
-
-        css('.REFTYPES').remove
+        css('a[href^=javascript]').each { |n| n.before(n.children).remove }
 
         css('table').each do |node|
           node.remove_attribute('border')
@@ -98,8 +95,6 @@ module Docs
           node.remove_attribute('align')
           node.remove_attribute('valign')
         end
-
-        css('.bold_code').remove_attr('class')
 
         doc
       end

--- a/lib/docs/filters/erlang/clean_html.rb
+++ b/lib/docs/filters/erlang/clean_html.rb
@@ -12,8 +12,6 @@ module Docs
           node.before(node.children).remove
         end
 
-        css('> br').remove
-
         css('> font[size="+1"]:first-child').each do |node|
           node.name = 'h1'
         end
@@ -31,13 +29,9 @@ module Docs
         # others
 
         # Remove JS on-hover highlighting
-        css('h3.title-link', 'h4.data-type-name', 'h4.func-head').each do |node|
+        css('h3.title-link', 'h4.title-link', 'div.data-type-name', 'div.func-head').each do |node|
           node.remove_attribute('onmouseover')
           node.remove_attribute('onmouseout')
-        end
-
-        css('a[name]').each do |node|
-          node.before(node.children).remove
         end
 
         css('h3').each do |node|
@@ -49,12 +43,19 @@ module Docs
         css('h4.func-head + .fun-types > h3.func-types-title')
           .each { |node| node.name = 'h5' }
 
+        css('p > a[name]').each do |node|
+          parent = node.parent
+          parent.name = 'h4'
+          parent['id'] ||= node['name']
+          parent.css('> br:last-child').remove
+        end
+        css('a[name]:empty').each { |n| (n.next_element || n.parent)['id'] ||= n['name'] }
+
         css('h3', 'h4', 'h5').each do |node|
           node.name = node.name.sub(/\d/) { |i| i.to_i - 1 }
         end
 
-        # Convert <span/> code blocks to <code/> if inline otherwise
-        # <pre><code/></pre>.
+        # Convert <span/> code blocks to <code/> if inline otherwise <pre><code/></pre>
         css('span.bold_code', 'span.code', '.func-head > span.title-name').each do |node|
           node.remove_attribute('class')
           node.css('span.bold_code', 'span.code')
@@ -73,14 +74,6 @@ module Docs
         css('*:not(.REFTYPES) > pre').each do |node|
           node['data-language'] = 'erlang'
           node.inner_html = node.inner_html.strip_heredoc
-        end
-
-        css('.REFBODY').each do |node|
-          if node.element_children.length == 0
-            node.name = 'p'
-          else
-            node.before(node.children).remove
-          end
         end
 
         css('a[href^=javascript]').each { |n| n.before(n.children).remove }

--- a/lib/docs/filters/erlang/entries.rb
+++ b/lib/docs/filters/erlang/entries.rb
@@ -2,14 +2,14 @@ module Docs
   class Erlang
     class EntriesFilter < Docs::EntriesFilter
       def get_name
-        name = at_css('h1').content.strip
+        name = at_css('#content h1').content.strip
         name << " (#{type.remove('Guide: ')})" if name == '1 Introduction'
         name.sub! %r{\A(\d+)}, '\1.'
         name
       end
 
       def get_type
-        name = at_css('h1').content.strip
+        name = at_css('#content h1').content.strip
 
         if subpath.start_with?('lib/')
           type = subpath[/lib\/(.+?)[\-\/]/, 1]
@@ -44,7 +44,7 @@ module Docs
         if subpath.start_with?('lib/')
           names = Set.new
           entry_nodes.each_with_object [] do |node, entries|
-            id = node['id']
+            id = node['id'] || node['name']
             name = id.remove %r{\-\d*\z}
             name << ' (type)' if name.sub!(/\Atype-/, '')
             name.prepend "#{self.name}:"
@@ -66,7 +66,13 @@ module Docs
 
       def entry_nodes
         @entry_nodes ||= if subpath.start_with?('lib/')
-          css('article.func > h4', 'article.data-types-body > h4').entries
+          r18_funs = css('p + div.REFBODY').each_with_object [] do |node, result|
+            result.concat(node.previous_element.css('a[name]').to_a)
+          end
+          css('article.data-types-body > h4', 'article.func > h4',
+              'div.data-type-name a[name]', 'div.exports-body > a[name]',
+              'div.fun-type a[name]').entries +
+            r18_funs
         elsif subpath.start_with?('erts')
           link = at_css(".flipMenu a[href='#{File.basename(subpath, '.html')}']")
           list = link.parent.parent

--- a/lib/docs/filters/erlang/entries.rb
+++ b/lib/docs/filters/erlang/entries.rb
@@ -44,10 +44,9 @@ module Docs
         if subpath.start_with?('lib/')
           names = Set.new
           entry_nodes.each_with_object [] do |node, entries|
-            id = node['name']
+            id = node['id']
             name = id.remove %r{\-\d*\z}
             name << ' (type)' if name.sub!(/\Atype-/, '')
-            name.remove! 'Module:'
             name.prepend "#{self.name}:"
             entries << [name, id] if names.add?(name)
           end
@@ -67,9 +66,7 @@ module Docs
 
       def entry_nodes
         @entry_nodes ||= if subpath.start_with?('lib/')
-          css('p + div.REFBODY').each_with_object [] do |node, result|
-            result.concat(node.previous_element.css('a[name]').to_a)
-          end
+          css('article.func > h4', 'article.data-types-body > h4').entries
         elsif subpath.start_with?('erts')
           link = at_css(".flipMenu a[href='#{File.basename(subpath, '.html')}']")
           list = link.parent.parent

--- a/lib/docs/filters/erlang/pre_clean_html.rb
+++ b/lib/docs/filters/erlang/pre_clean_html.rb
@@ -4,15 +4,6 @@ module Docs
       def call
         css('.flipMenu li[title] > a').remove unless subpath.start_with?('erts') # perf
 
-        css('.REFTYPES').each do |node|
-          node.name = 'pre'
-        end
-
-        css('span.bold_code', 'span.code').each do |node|
-          node.name = 'code'
-          node.inner_html = node.inner_html.strip.gsub(/\s+/, ' ')
-        end
-
         doc
       end
     end


### PR DESCRIPTION
This pull request

* Makes lib/ entries get indexed correctly;
* Stops the types associated with functions from being filtered away, and orders their "Types" heading under the function heading; and
* Cleans out onmouseover/onmouseout attributes.

Closes #795

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good