### PR TITLE
Update octave scraper to 7.2.0

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -645,7 +645,7 @@ credits = [
     'Octave',
     '1996–2022 The Octave Project Developers',
     'Octave',
-    'https://docs.octave.org/v7.1.0/'
+    'https://docs.octave.org/v7.2.0/'
   ], [
     'OpenJDK',
     '1993, 2022, Oracle and/or its affiliates. All rights reserved.<br>Licensed under the GNU General Public License, version 2, with the Classpath Exception.<br>Various third party code in OpenJDK is licensed under different licenses.<br>Java and OpenJDK are trademarks or registered trademarks of Oracle and/or its affiliates.',

--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -645,7 +645,7 @@ credits = [
     'Octave',
     '1996–2022 The Octave Project Developers',
     'Octave',
-    'https://octave.org/doc/v7.1.0/'
+    'https://docs.octave.org/v7.1.0/'
   ], [
     'OpenJDK',
     '1993, 2022, Oracle and/or its affiliates. All rights reserved.<br>Licensed under the GNU General Public License, version 2, with the Classpath Exception.<br>Various third party code in OpenJDK is licensed under different licenses.<br>Java and OpenJDK are trademarks or registered trademarks of Oracle and/or its affiliates.',

--- a/lib/docs/scrapers/octave.rb
+++ b/lib/docs/scrapers/octave.rb
@@ -30,7 +30,7 @@ module Docs
     HTML
 
     version '7' do
-      self.release = '7.1.0'
+      self.release = '7.2.0'
       self.base_url = "https://docs.octave.org/v#{self.release}/"
     end
 

--- a/lib/docs/scrapers/octave.rb
+++ b/lib/docs/scrapers/octave.rb
@@ -31,17 +31,17 @@ module Docs
 
     version '7' do
       self.release = '7.1.0'
-      self.base_url = "https://octave.org/doc/v#{self.release}/"
+      self.base_url = "https://docs.octave.org/v#{self.release}/"
     end
 
     version '6' do
       self.release = '6.4.0'
-      self.base_url = "https://octave.org/doc/v#{self.release}/"
+      self.base_url = "https://docs.octave.org/v#{self.release}/"
     end
 
     version '5' do
       self.release = '5.2.0'
-      self.base_url = "https://octave.org/doc/v#{self.release}/"
+      self.base_url = "https://docs.octave.org/v#{self.release}/"
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
