### PR TITLE
Update versions of currently supported python versions

### DIFF
--- a/lib/docs/filters/python/entries_v3.rb
+++ b/lib/docs/filters/python/entries_v3.rb
@@ -78,7 +78,8 @@ module Docs
         end
 
         css('.glossary > dt[id]').each do |node|
-          entries << [node.content, node['id']]
+          name = node.content.remove("\u{00b6}")
+          entries << [name, node['id']]
         end
 
         css('.function > dt[id]', '.method > dt[id]', '.staticmethod > dt[id]', '.classmethod > dt[id]').each do |node|

--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -22,35 +22,35 @@ module Docs
     HTML
 
     version '3.11' do
-      self.release = '3.11.0rc2'
+      self.release = '3.11.0'
       self.base_url = "https://docs.python.org/#{self.version}/"
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.10' do
-      self.release = '3.10.7'
+      self.release = '3.10.8'
       self.base_url = "https://docs.python.org/#{self.version}/"
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.9' do
-      self.release = '3.9.4'
+      self.release = '3.9.14'
       self.base_url = 'https://docs.python.org/3.9/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.8' do
-      self.release = '3.8.6'
+      self.release = '3.8.14'
       self.base_url = 'https://docs.python.org/3.8/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.7' do
-      self.release = '3.7.9'
+      self.release = '3.7.14'
       self.base_url = 'https://docs.python.org/3.7/'
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'


### PR DESCRIPTION
If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
