### PR TITLE
Update scikit-learn documentation (1.1.3)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -847,7 +847,7 @@ credits = [
     'https://scikit-image.org/docs/dev/license.html'
   ], [
     'scikit-learn',
-    '2007-2020 The scikit-learn developers',
+    '2007-2022 The scikit-learn developers',
     'BSD',
     'https://raw.githubusercontent.com/scikit-learn/scikit-learn/master/COPYING'
   ], [

--- a/lib/docs/filters/scikit_learn/clean_html.rb
+++ b/lib/docs/filters/scikit_learn/clean_html.rb
@@ -16,6 +16,10 @@ module Docs
           end
         end
 
+        # Most often comes with a link with the same text so we're removing
+        # these.
+        css('.sphx-glr-thumbnail-title').each do |node| node.remove end
+
         css('.sphx-glr-signature').remove
 
         doc

--- a/lib/docs/scrapers/scikit_learn.rb
+++ b/lib/docs/scrapers/scikit_learn.rb
@@ -3,8 +3,8 @@ module Docs
     self.name = 'scikit-learn'
     self.slug = 'scikit_learn'
     self.type = 'sphinx'
-    self.release = '0.24.1'
-    self.base_url = 'https://scikit-learn.org/0.24/'
+    self.release = '1.1.3'
+    self.base_url = "https://scikit-learn.org/1.1/"
     self.root_path = 'index.html'
     self.force_gzip = true
     self.links = {
@@ -14,7 +14,7 @@ module Docs
 
     html_filters.push 'scikit_learn/entries', 'scikit_learn/clean_html', 'sphinx/clean_html', 'title'
 
-    options[:container] = ->(filter) { filter.root_page? ? 'body > .container' : '.section' }
+    options[:container] = ->(filter) { filter.root_page? ? 'body > .container' : '#sk-page-content-wrapper > .body' }
     options[:skip] = %w(modules/generated/sklearn.experimental.enable_iterative_imputer.html
                         modules/generated/sklearn.experimental.enable_hist_gradient_boosting.html)
     options[:only_patterns] = [/\Amodules/, /\Adatasets/, /\Atutorial/, /\Aauto_examples/]
@@ -24,7 +24,7 @@ module Docs
     options[:max_image_size] = 256_000
 
     options[:attribution] = <<-HTML
-      &copy; 2007&ndash;2020 The scikit-learn developers<br>
+      &copy; 2007&ndash;2022 The scikit-learn developers<br>
       Licensed under the 3-clause BSD License.
     HTML
 


### PR DESCRIPTION
Resolves #1854.

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
