### PR TITLE
Update Dart (2.18.5)

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -238,8 +238,8 @@ credits = [
   ], [
     'Dart',
     '2012 the Dart project authors',
-    'CC BY-SA',
-    'https://creativecommons.org/licenses/by-sa/4.0/'
+    'BSD 3-Clause "New" or "Revised" License',
+    'https://raw.githubusercontent.com/dart-lang/sdk/main/LICENSE'
   ], [
     'date-fns',
     '2021 Sasha Koss and Lesha Koss',

--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -23,7 +23,7 @@ and put it in `/path/to/devdocs/docs/`
 Or run the following commands in your terminal:
 
 ```sh
-curl https://storage.googleapis.com/dart-archive/channels/stable/release/$RELEASE/api-docs/dartdocs-gen-api-zip > dartApi.zip; \
+curl https://storage.googleapis.com/dart-archive/channels/stable/release/$RELEASE/api-docs/dartdocs-gen-api.zip > dartApi.zip; \
 unzip dartApi.zip; mv gen-dartdocs docs/dart~$VERSION
 ```
 

--- a/lib/docs/scrapers/dart.rb
+++ b/lib/docs/scrapers/dart.rb
@@ -17,11 +17,11 @@ module Docs
 
     options[:attribution] = <<-HTML
       &copy; 2012 the Dart project authors<br>
-      Licensed under the Creative Commons Attribution-ShareAlike License v4.0.
+      Licensed under the BSD 3-Clause "New" or "Revised" License.
     HTML
 
     version '2' do
-      self.release = '2.17.0'
+      self.release = '2.18.5'
       self.base_url = "https://api.dart.dev/stable/#{release}/"
     end
 


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/docs/dart/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
