### PR TITLE
Update Erlang (25.1.2)

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -65,7 +65,7 @@ Go to https://www.erlang.org/downloads and download the HTML documentation file.
 
 ```ah
 mkdir --parent docs/erlang\~$VERSION/; \
-curl http://erlang.org/download/otp_doc_html_$RELEASE.tar.gz | \
+curl -L https://github.com/erlang/otp/releases/download/OTP-$RELEASE/otp_doc_html_$RELEASE.tar.gz | \
 bsdtar --extract --file - --directory=docs/erlang\~$VERSION/
 ```
 

--- a/lib/docs/filters/erlang/clean_html.rb
+++ b/lib/docs/filters/erlang/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class Erlang
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('#content')
+        @doc = at_css('#content .innertube', '#content')
 
         # frontpage
 

--- a/lib/docs/scrapers/erlang.rb
+++ b/lib/docs/scrapers/erlang.rb
@@ -41,7 +41,7 @@ module Docs
     HTML
 
     version '25' do
-      self.release = '25.0'
+      self.release = '25.1'
     end
 
     version '24' do


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/docs/erlang/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
