### PR TITLE
update Ember docs

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -297,7 +297,7 @@ credits = [
     'https://raw.githubusercontent.com/elixir-lang/elixir/master/LICENSE'
   ], [
     'Ember.js',
-    '2020 Yehuda Katz, Tom Dale and Ember.js contributors',
+    '2022 Yehuda Katz, Tom Dale and Ember.js contributors',
     'MIT',
     'https://raw.githubusercontent.com/emberjs/ember.js/master/LICENSE'
   ], [

--- a/lib/docs/scrapers/ember.rb
+++ b/lib/docs/scrapers/ember.rb
@@ -49,11 +49,11 @@ module Docs
     options[:decode_and_clean_paths] = true # handle paths like @ember/application
 
     version '4' do
-      self.release = '4.4.0'
+      self.release = '4.9.0'
       self.base_urls = %w[
-        https://guides.emberjs.com/v4.4.0/
-        https://api.emberjs.com/ember/4.4/
-        https://api.emberjs.com/ember-data/4.4/
+        https://guides.emberjs.com/v4.9.0/
+        https://api.emberjs.com/ember/4.9/
+        https://api.emberjs.com/ember-data/4.9/
       ]
     end
 

--- a/lib/docs/scrapers/ember.rb
+++ b/lib/docs/scrapers/ember.rb
@@ -42,18 +42,27 @@ module Docs
     ]
 
     options[:attribution] = <<-HTML
-      &copy; 2020 Yehuda Katz, Tom Dale and Ember.js contributors<br>
+      &copy; 2022 Yehuda Katz, Tom Dale and Ember.js contributors<br>
       Licensed under the MIT License.
     HTML
 
     options[:decode_and_clean_paths] = true # handle paths like @ember/application
 
-    version '3' do
-      self.release = '3.25.0'
+    version '4' do
+      self.release = '4.4.0'
       self.base_urls = %w[
-        https://guides.emberjs.com/v3.25.0/
-        https://api.emberjs.com/ember/3.25/
-        https://api.emberjs.com/ember-data/3.25/
+        https://guides.emberjs.com/v4.4.0/
+        https://api.emberjs.com/ember/4.4/
+        https://api.emberjs.com/ember-data/4.4/
+      ]
+    end
+
+    version '3' do
+      self.release = '3.28.0'
+      self.base_urls = %w[
+        https://guides.emberjs.com/v3.28.0/
+        https://api.emberjs.com/ember/3.28/
+        https://api.emberjs.com/ember-data/3.28/
       ]
     end
 


### PR DESCRIPTION
* update Ember 3 to latest 3.x version (3.28)
* add Ember 4 documentation to latest LTS (4.4)

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
