### PR TITLE
fix: download db.json in production

### DIFF
--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -238,7 +238,7 @@ class DocsCLI < Thor
           dir = File.join(Docs.store_path, doc.path)
           FileUtils.mkpath(dir)
 
-          ['index.json', 'meta.json'].each do |filename|
+          ['index.json', 'meta.json', 'db.json'].each do |filename|
             json = "https://documents.devdocs.io/#{doc.path}/#{filename}?#{time}"
             begin
               open(json) do |file|


### PR DESCRIPTION
Closes https://github.com/freeCodeCamp/devdocs/issues/1910

@simon04 there's probably a better approach where we point the app at documents.devdocs.io (since https://documents.devdocs.io/bash/db.json and the like do exist), but this was the best I could up with for now!