### PR TITLE
Update Python (3.10.9, 3.11.1); Update attribution (it's 2023)

### DIFF
--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -17,19 +17,19 @@ module Docs
       library/sunau.html)
 
     options[:attribution] = <<-HTML
-      &copy; 2001&ndash;2022 Python Software Foundation<br>
+      &copy; 2001&ndash;2023 Python Software Foundation<br>
       Licensed under the PSF License.
     HTML
 
     version '3.11' do
-      self.release = '3.11.0'
+      self.release = '3.11.1'
       self.base_url = "https://docs.python.org/#{self.version}/"
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.10' do
-      self.release = '3.10.8'
+      self.release = '3.10.9'
       self.base_url = "https://docs.python.org/#{self.version}/"
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/docs/python/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good


## Annotation

The scraper works very well locally, but it seems that there was some problem with `devdocs.io` for Python 3.10.

### Reproduction:
```sh
mkdir docs/python~3.10
cd docs/python~3.10
curl -L https://docs.python.org/3.10/archives/python-3.10.9-docs-html.tar.bz2 | \
    tar xj --strip-components=1
cd ../..
bundle exec thor docs:generate python@3.10
bundle exec rackup
```
gives the following output when searching for `match` (it is expected to find the new introduced `match`-statement):

![local output](https://user-images.githubusercontent.com/94523763/212040113-04ba7f17-f04d-4b7f-8fdc-7127b52ffe8d.png)

The output matches the expectation.
In contrast the output `devdocs.io` gives:

![devdocs.io output](https://user-images.githubusercontent.com/94523763/212041045-fb8084d7-8f63-4abc-8e7a-9422dd5b7d79.png)

Which doesn't show the `match`-statement at all (it's also not to be found when scroling further down or looking manually through the documentation).

I honestly don't know how that difference was possible.
