### PR TITLE
Update Babel documentation

### DIFF
--- a/lib/docs/scrapers/babel.rb
+++ b/lib/docs/scrapers/babel.rb
@@ -30,11 +30,11 @@ module Docs
     HTML
 
     version '7' do
-      self.release = '7.16.4'
+      self.release = '7.20.15'
     end
 
     version '6' do
-      self.release = '6.26.1'
+      self.release = '6.26.3'
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Notes:
- Updated all Babel versions that needed to be updated

Question:
- Why both maintaining Babel `7.x` and `6.x` when they both fetch from the same resource and provide exactly the same informations? Wouldn't it be easier to drop `6.x` then?