### PR TITLE
Update CMake documentation (3.26)

### DIFF
--- a/lib/docs/scrapers/cmake.rb
+++ b/lib/docs/scrapers/cmake.rb
@@ -4,7 +4,7 @@ module Docs
     self.type = 'sphinx_simple'
     self.links = {
       home: 'https://cmake.org/',
-      code: 'https://cmake.org/gitweb?p=cmake.git;a=summary'
+      code: 'https://gitlab.kitware.com/cmake/cmake/'
     }
 
     html_filters.push 'cmake/clean_html', 'sphinx/clean_html', 'cmake/entries', 'title'
@@ -16,9 +16,14 @@ module Docs
     options[:skip_patterns] = [/\Agenerator/, /\Acpack_gen/, /\Ainclude/, /\Arelease/, /tutorial\/(\w*%20)+/]
 
     options[:attribution] = <<-HTML
-      &copy; 2000&ndash;2022 Kitware, Inc. and Contributors<br>
+      &copy; 2000&ndash;2023 Kitware, Inc. and Contributors<br>
       Licensed under the BSD 3-clause License.
     HTML
+
+    version '3.26' do
+      self.release = '3.26'
+      self.base_url = "https://cmake.org/cmake/help/v#{self.version}/"
+    end
 
     version '3.25' do
       self.release = '3.25'


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [X] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [X] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Notes:
- added `CMake` version `3.26`
- updated code-link, as the previous one was just a redirect
- updated attribution to match the current year