### PR TITLE
fix(lib): use semver for minor versioning

### DIFF
--- a/lib/docs/core/doc.rb
+++ b/lib/docs/core/doc.rb
@@ -211,7 +211,6 @@ module Docs
         break if i >= scraper_parts.length or i >= latest_parts.length
         return 'Outdated major version' if i == 0 and latest_parts[i] > scraper_parts[i]
         return 'Outdated major version' if i == 1 and latest_parts[i] > scraper_parts[i] and latest_parts[0] == 0 and scraper_parts[0] == 0
-        return 'Outdated major version' if i == 1 and latest_parts[i] > scraper_parts[i] and latest_parts[0] == 1 and scraper_parts[0] == 1
         return 'Outdated minor version' if i == 1 and latest_parts[i] > scraper_parts[i]
         return 'Up-to-date' if latest_parts[i] < scraper_parts[i]
       end

--- a/test/lib/docs/core/doc_test.rb
+++ b/test/lib/docs/core/doc_test.rb
@@ -398,7 +398,7 @@ class DocsDocTest < MiniTest::Spec
       assert_equal 'Up-to-date', instance.outdated_state('1.2.2', '1.2.3')
       assert_equal "Outdated major version", instance.outdated_state('1', '2')
       assert_equal "Up-to-date", instance.outdated_state('1.0.2', '1.0.3')
-      assert_equal "Outdated major version", instance.outdated_state('1.2', '1.3')
+      assert_equal "Outdated minor version", instance.outdated_state('1.2', '1.3')
       assert_equal "Outdated minor version", instance.outdated_state('2.2', '2.3')
       assert_equal "Outdated major version", instance.outdated_state('9', '10')
       assert_equal "Outdated major version", instance.outdated_state('99', '101')


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION A - Adding a new scraper -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#contributing-new-documentations -->

If you’re adding a new scraper, please ensure that you have:

- [ ] Tested the scraper on a local copy of DevDocs
- [ ] Ensured that the docs are styled similarly to other docs on DevDocs
<!-- If the docs don’t have an icon, delete the next four items: -->
- [ ] Added these files to the <code>public/icons/*your_scraper_name*/</code> directory:
  - [ ] `16.png`: a 16×16 pixel icon for the doc
  - [ ] `16@2x.png`: a 32×32 pixel icon for the doc
  - [ ] `SOURCE`: A text file containing the URL to the page the image can be found on or the URL of the original image itself

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [ ] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ ] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

---

**Open for Discussion**

- [Original commit making change](https://github.com/freeCodeCamp/devdocs/commit/200e39ce9042fd4e254208837644486c4c2d89a6)
- `1.X` updates currently count for MAJOR changes
- This goes against https://semver.org/

Originally, I noticed this because in the monthly version report, Rust going from `1.65` to `1.67` was marked under the MAJOR updates. There are many other examples

**This PR**

- Mark `1.X` updates as MINOR