### PR TITLE
Add links.{code,home} for MDN scrapers

### DIFF
--- a/lib/docs/scrapers/http.rb
+++ b/lib/docs/scrapers/http.rb
@@ -8,6 +8,15 @@ module Docs
       'https://developer.mozilla.org/en-US/docs/Web/HTTP',
       'https://datatracker.ietf.org/doc/html/',
     ]
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Web/HTTP',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/web/http'
+    }
+
+    options[:attribution] = <<-HTML
+      &copy; 2005&ndash;2023 MDN contributors.<br>
+      Licensed under the Creative Commons Attribution-ShareAlike License v2.5 or later.
+    HTML
 
     html_filters.push 'http/clean_html', 'http/entries', 'title'
 

--- a/lib/docs/scrapers/mdn/css.rb
+++ b/lib/docs/scrapers/mdn/css.rb
@@ -4,6 +4,10 @@ module Docs
     self.name = 'CSS'
     self.base_url = 'https://developer.mozilla.org/en-US/docs/Web/CSS'
     self.root_path = '/Reference'
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Web/CSS',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/web/css'
+    }
 
     html_filters.push 'css/clean_html', 'css/entries'
 

--- a/lib/docs/scrapers/mdn/dom.rb
+++ b/lib/docs/scrapers/mdn/dom.rb
@@ -5,6 +5,10 @@ module Docs
     self.name = 'Web APIs'
     self.slug = 'dom'
     self.base_url = 'https://developer.mozilla.org/en-US/docs/Web/API'
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Web/API',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/web/api'
+    }
 
     html_filters.push 'dom/clean_html', 'dom/entries'
 

--- a/lib/docs/scrapers/mdn/html.rb
+++ b/lib/docs/scrapers/mdn/html.rb
@@ -5,6 +5,10 @@ module Docs
     # release = '2023-01-06'
     self.name = 'HTML'
     self.base_url = 'https://developer.mozilla.org/en-US/docs/Web/HTML'
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Web/HTML',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/web/html'
+    }
 
     html_filters.push 'html/clean_html', 'html/entries'
 

--- a/lib/docs/scrapers/mdn/javascript.rb
+++ b/lib/docs/scrapers/mdn/javascript.rb
@@ -6,6 +6,10 @@ module Docs
     # release = '2023-01-06'
     self.name = 'JavaScript'
     self.base_url = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference'
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/web/javascript'
+    }
 
     html_filters.push 'javascript/clean_html', 'javascript/entries'
 

--- a/lib/docs/scrapers/mdn/mdn.rb
+++ b/lib/docs/scrapers/mdn/mdn.rb
@@ -2,6 +2,10 @@ module Docs
   class Mdn < UrlScraper
     self.abstract = true
     self.type = 'mdn'
+    self.links = {
+      home: 'https://developer.mozilla.org',
+      code: 'https://github.com/mdn/content'
+    }
 
     html_filters.push 'mdn/clean_html', 'mdn/compat_tables'
 

--- a/lib/docs/scrapers/mdn/svg.rb
+++ b/lib/docs/scrapers/mdn/svg.rb
@@ -6,6 +6,10 @@ module Docs
     # release = '2022-09-06'
     self.name = 'SVG'
     self.base_url = 'https://developer.mozilla.org/en-US/docs/Web/SVG'
+    self.links = {
+      home: 'https://developer.mozilla.org/en-US/docs/Web/SVG',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/web/svg'
+    }
 
     html_filters.push 'svg/clean_html', 'svg/entries'
 

--- a/lib/docs/scrapers/mdn/web_extensions.rb
+++ b/lib/docs/scrapers/mdn/web_extensions.rb
@@ -4,9 +4,9 @@ module Docs
     self.name = 'Web Extensions'
     self.slug = 'web_extensions'
     self.links = {
-      home: 'https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions'
+      home: 'https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions',
+      code: 'https://github.com/mdn/content/tree/main/files/en-us/mozilla/add-ons/webextensions'
     }
-
     self.base_url = 'https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions'
 
     html_filters.push 'web_extensions/entries', 'web_extensions/clean_html'


### PR DESCRIPTION
### Problem

If you go to the Credits section on https://devdocs.io/about some links are not working. For example, the first one, CSS, has these links:
CSS  https://devdocs.io/undefined
Source code https://devdocs.io/undefined

For HTTP, "Copyright/License" is also "undefined".

### Proposed fix

This PR: 
- adds the `self.links` info to MDN scrapers, so that the links should be able to point to something. 
- adds `options[:attribution]` to the HTTP scraper.