### PR TITLE
Remove skip paths of non-existent MDN pages

### DIFF
--- a/lib/docs/scrapers/mdn/html.rb
+++ b/lib/docs/scrapers/mdn/html.rb
@@ -10,12 +10,6 @@ module Docs
 
     options[:root_title] = 'HTML'
 
-    options[:skip] = %w(
-      /index
-      /Element/shadow
-      /Element/webkit-meter-optimum-value
-    )
-
     options[:replace_paths] = {
       '/Element/h1' => '/Element/Heading_Elements',
       '/Element/h2' => '/Element/Heading_Elements',

--- a/lib/docs/scrapers/mdn/javascript.rb
+++ b/lib/docs/scrapers/mdn/javascript.rb
@@ -11,13 +11,6 @@ module Docs
 
     options[:root_title] = 'JavaScript'
 
-    # Don't want
-    options[:skip] = %w(
-      /Methods_Index
-      /Properties_Index
-      /Operators/Legacy_generator_function
-      /Statements/Legacy_generator_function)
-
     # Duplicates
     options[:skip].concat %w(
       /Global_Objects

--- a/lib/docs/scrapers/mdn/javascript.rb
+++ b/lib/docs/scrapers/mdn/javascript.rb
@@ -12,7 +12,7 @@ module Docs
     options[:root_title] = 'JavaScript'
 
     # Duplicates
-    options[:skip].concat %w(
+    options[:skip] = %w(
       /Global_Objects
       /Operators
       /Statements)

--- a/lib/docs/scrapers/mdn/svg.rb
+++ b/lib/docs/scrapers/mdn/svg.rb
@@ -21,8 +21,6 @@ module Docs
       end
     end
 
-    options[:skip] = %w(/Compatibility_sources /FAQ)
-
     options[:fix_urls] = ->(url) do
       url.sub! 'https://developer.mozilla.org/en-US/Web/SVG', Svg.base_url
       url.sub! 'https://developer.mozilla.org/en-US/docs/SVG', Svg.base_url


### PR DESCRIPTION
This PR is just optional cleanup. Feel free to reject. I just saw this when working on my other PR. 

I'm pretty sure MDN has removed these pages nowadays, so I think the scraper doesn't need to skip them anymore.