### PR TITLE
laravel: add Laravel 10 documentation with improvements

### DIFF
--- a/lib/docs/filters/laravel/clean_html.rb
+++ b/lib/docs/filters/laravel/clean_html.rb
@@ -9,9 +9,16 @@ module Docs
         end
 
         # Remove code highlighting
-        css('pre').each do |node|
-          node.content = node.content
-          node['data-language'] = 'php'
+        css('pre > code').each do |node|
+          if node['data-lang'].eql?('nothing')
+            # Ignore 'nothing' language
+          else
+            node.parent['data-language'] = node['data-lang']
+          end
+          # Prism uses `\n` to determine lines. Otherwise the lines will be
+          # compacted.
+          node.parent.content = node.css('.line').map(&:content).join("\n")
+          node.remove
         end
 
         doc

--- a/lib/docs/filters/laravel/entries.rb
+++ b/lib/docs/filters/laravel/entries.rb
@@ -18,7 +18,7 @@ module Docs
           return heading ? "Guides: #{heading.content.strip}" : 'Guides'
         end
 
-        type = slug.remove(%r{api/\d.[0-9x]/}).remove('Illuminate/').remove(/\/\w+?\z/).gsub('/', '\\')
+        type = slug.remove(%r{api/[1-9]?\d.[0-9x]/}).remove('Illuminate/').remove(/\/\w+?\z/).gsub('/', '\\')
 
         if type.end_with?('Console')
           type.split('\\').first

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -14,20 +14,34 @@ module Docs
     }
 
     options[:skip_patterns] = [
-      %r{\A/api/\d\.[0-9x]/\.html},
-      %r{\A/api/\d\.[0-9x]/panel\.html},
-      %r{\A/api/\d\.[0-9x]/namespaces\.html},
-      %r{\A/api/\d\.[0-9x]/interfaces\.html},
-      %r{\A/api/\d\.[0-9x]/traits\.html},
-      %r{\A/api/\d\.[0-9x]/doc-index\.html},
-      %r{\A/api/\d\.[0-9x]/Illuminate\.html},
-      %r{\A/api/\d\.[0-9x]/search\.html} ]
+      %r{\A/api/[1-9]?\d\.[0-9x]/\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/panel\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/namespaces\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/interfaces\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/traits\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/doc-index\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/Illuminate\.html},
+      %r{\A/api/[1-9]?\d\.[0-9x]/search\.html} ]
 
     options[:attribution] = <<-HTML
       &copy; Taylor Otwell<br>
       Licensed under the MIT License.<br>
       Laravel is a trademark of Taylor Otwell.
     HTML
+
+    version '10' do
+      self.release = '10.10.0'
+      self.root_path = '/api/10.x/index.html'
+      self.initial_paths = %w(/docs/10.x/installation /api/10.x/classes.html)
+
+      options[:only_patterns] = [%r{\A/api/10\.x/}, %r{\A/docs/10\.x/}]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{10.x/+}, "10.x/"
+        url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?![1-9]?\d)}, "#{Laravel.base_url}/docs/10.x/"
+        url
+      end
+    end
 
     version '9' do
       self.release = '9.3.8'

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -44,7 +44,7 @@ module Docs
     end
 
     version '9' do
-      self.release = '9.3.8'
+      self.release = '9.52.7'
       self.root_path = '/api/9.x/index.html'
       self.initial_paths = %w(/docs/9.x/installation /api/9.x/classes.html)
 
@@ -58,7 +58,7 @@ module Docs
     end
 
     version '8' do
-      self.release = '8.4.1'
+      self.release = '8.83.27'
       self.root_path = '/api/8.x/index.html'
       self.initial_paths = %w(/docs/8.x/installation /api/8.x/classes.html)
 
@@ -71,7 +71,7 @@ module Docs
     end
 
     version '7' do
-      self.release = '7.30.1'
+      self.release = '7.30.6'
       self.root_path = '/api/7.x/index.html'
       self.initial_paths = %w(/docs/7.x/installation /api/7.x/classes.html)
 
@@ -84,7 +84,7 @@ module Docs
     end
 
     version '6' do
-      self.release = '6.20.0'
+      self.release = '6.20.44'
       self.root_path = '/api/6.x/index.html'
       self.initial_paths = %w(/docs/6.x/installation /api/6.x/classes.html)
 

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -30,7 +30,7 @@ module Docs
     HTML
 
     version '10' do
-      self.release = '10.10.0'
+      self.release = '10.13.0'
       self.root_path = '/api/10.x/index.html'
       self.initial_paths = %w(/docs/10.x/installation /api/10.x/classes.html)
 
@@ -44,7 +44,7 @@ module Docs
     end
 
     version '9' do
-      self.release = '9.52.7'
+      self.release = '9.52.8'
       self.root_path = '/api/9.x/index.html'
       self.initial_paths = %w(/docs/9.x/installation /api/9.x/classes.html)
 

--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -65,6 +65,7 @@ module Docs
       options[:only_patterns] = [%r{\A/api/8\.x/}, %r{\A/docs/8\.x/}]
 
       options[:fix_urls] = ->(url) do
+        url.sub! %r{8.x/+}, "8.x/"
         url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/8.x/"
         url
       end
@@ -78,6 +79,7 @@ module Docs
       options[:only_patterns] = [%r{\A/api/7\.x/}, %r{\A/docs/7\.x/}]
 
       options[:fix_urls] = ->(url) do
+        url.sub! %r{7.x/+}, "7.x/"
         url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/7.x/"
         url
       end
@@ -91,6 +93,7 @@ module Docs
       options[:only_patterns] = [%r{\A/api/6\.x/}, %r{\A/docs/6\.x/}]
 
       options[:fix_urls] = ->(url) do
+        url.sub! %r{6.x/+}, "6.x/"
         url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?!\d)}, "#{Laravel.base_url}/docs/6.x/"
         url
       end


### PR DESCRIPTION
If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Laravel 10 is released a few months ago but I really want to make the documentation available in devdocs.
Therefore, I am creating this PR with some improvements for Laravel Developers.

I have:
- Added Laravel 10 version block
- Updated regex pattern for detecting two digits
- Updated Laravel 6-9 minor version
  - Laravel 6: https://github.com/laravel/framework/releases/tag/v6.20.44
  - Laravel 7: https://github.com/laravel/framework/releases/tag/v7.30.6
  - Laravel 8: https://github.com/laravel/framework/releases/tag/v8.83.27
  - Laravel 9: https://github.com/laravel/framework/releases/tag/v9.52.7
- Fixed "Docs::Entry::Invalid: missing type" on running `doc:generate` Laravel 6-8
- Fixed codes being squashed into one line (fixes #1852)
Left: [Production](https://devdocs.io/laravel~9/docs/9.x/facades) | Right: Dev
<img width="1192" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/57529236/d384c4b4-48ac-4665-9735-c90ce4d37102">

