### PR TITLE
mdn: Fix iframe height (again)

### DIFF
--- a/assets/stylesheets/pages/_mdn.scss
+++ b/assets/stylesheets/pages/_mdn.scss
@@ -1,4 +1,6 @@
 ._mdn {
+  container-type: inline-size;
+
   .index { // HTML, CSS
     -webkit-columns: 16em;
        -moz-columns: 16em;
@@ -155,7 +157,7 @@
         height: 780px;
       }
     }
-  @media screen and (min-width: 993px) {
+  @container (min-width: 594px) {
     .interactive {
       height: 380px;
 


### PR DESCRIPTION
Follow up on the past pull request #1809.

Since container queries are [more widely supported](https://developer.mozilla.org/en-US/docs/Web/CSS/@container#browser_compatibility) and have [similar support](https://caniuse.com/?search=%40container) to `@media`, I went back and changed the [_MDN.scss](https://github.com/freeCodeCamp/devdocs/blob/main/assets/stylesheets/pages/_mdn.scss) file to use container queries. This makes resizing the sidebar work more as expected and fixes most edge case issues.

## Before

Edge case where the window width isn't enough. More common to see on different screen widths due to the sidebar's width.

![image](https://github.com/freeCodeCamp/devdocs/assets/109556932/b4771e2e-9841-4145-803b-129b38d68db0)

## After

Container queries mean that it does not care about the screen width.

![image](https://github.com/freeCodeCamp/devdocs/assets/109556932/15eb89a4-261f-4412-b699-fdf9330ecce8)

A video showing the sidebar interacting correctly:

https://github.com/freeCodeCamp/devdocs/assets/109556932/802549b6-0108-46ba-9ebb-4f4357482f68

