### PR TITLE
Fix almost everything being missing in erlang modules' docs

### DIFF
--- a/lib/docs/filters/erlang/clean_html.rb
+++ b/lib/docs/filters/erlang/clean_html.rb
@@ -2,7 +2,7 @@ module Docs
   class Erlang
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('#content .innertube:only-child', '#content')
+        @doc = at_css('#content')
 
         # frontpage
 

--- a/lib/docs/scrapers/erlang.rb
+++ b/lib/docs/scrapers/erlang.rb
@@ -40,8 +40,12 @@ module Docs
       Licensed under the Apache License, Version 2.0.
     HTML
 
+    version '26' do
+      self.release = '26.0.1'
+    end
+
     version '25' do
-      self.release = '25.2.2'
+      self.release = '25.3.2.2'
     end
 
     version '24' do


### PR DESCRIPTION
In current version (both on site and in `main`), erlang modules has almost all documentation text missing, including functions. Example:
- https://devdocs.io/erlang~25/lib/stdlib-4.2/doc/html/binary
- Original: https://www.erlang.org/doc/man/binary.html (version from [downloadable docs](https://www.erlang.org/downloads) looks the same)

The reason is that `#content .innertube:only-child` selector in `Erlang::CleanHtmlFilter#call` selects only the first `.innertube` section, and there are multiple such sections in the current version of documentation.

https://github.com/freeCodeCamp/devdocs/blob/04d7fd9b6365e68e1e31030376d246d0033c20ea/lib/docs/filters/erlang/clean_html.rb#L4-L5

There was alternative selector, `#content` that seems to work correctly, so I left only it in this changeset. After this change, functions appear back in modules' documentation.

I see an error (more like warning, as generation still finishes successfully) when running `thor docs:generate erlang --force` locally, but it also occurs in `main` without this change, so it's subject to a separate pull request:
<details>

```
ERROR:
  http://localhost/erts-13.2.2/doc/html/figures/perf-beamasm.svg
  NoMethodError: undefined method `content' for nil:NilClass

  /Users/kolen/src/devdocs/lib/docs/filters/erlang/entries.rb:5:in `get_name'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:31:in `name'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:22:in `default_entry'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:12:in `entries'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:6:in `call'
  /Users/kolen/src/devdocs/lib/docs/core/instrumentable.rb:15:in `instrument'
  /Users/kolen/src/devdocs/lib/docs/core/instrumentable.rb:15:in `instrument'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:179:in `process_response'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:160:in `block in handle_response'
  /Users/kolen/src/devdocs/lib/docs/core/instrumentable.rb:15:in `instrument'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:159:in `handle_response'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:77:in `block in build_pages'
  /Users/kolen/src/devdocs/lib/docs/core/scrapers/file_scraper.rb:39:in `request_all'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:76:in `build_pages'
  /Users/kolen/src/devdocs/lib/docs/core/doc.rb:115:in `block in store_pages'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:87:in `block (2 levels) in replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:182:in `track_touched'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:87:in `block in replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:170:in `lock'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:87:in `replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:85:in `block in replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:144:in `open_yield_close'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:30:in `open'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:85:in `replace'
  /Users/kolen/src/devdocs/lib/docs/core/doc.rb:114:in `store_pages'
  /Users/kolen/src/devdocs/lib/docs.rb:100:in `generate'
  /Users/kolen/src/devdocs/lib/tasks/docs.thor:303:in `generate_doc'
  /Users/kolen/src/devdocs/lib/tasks/docs.thor:105:in `generate'

ERROR:
  http://localhost/erts-13.2.2/doc/html/figures/perf-beamasm-merged.svg
  NoMethodError: undefined method `content' for nil:NilClass

  /Users/kolen/src/devdocs/lib/docs/filters/erlang/entries.rb:5:in `get_name'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:31:in `name'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:22:in `default_entry'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:12:in `entries'
  /Users/kolen/src/devdocs/lib/docs/filters/core/entries.rb:6:in `call'
  /Users/kolen/src/devdocs/lib/docs/core/instrumentable.rb:15:in `instrument'
  /Users/kolen/src/devdocs/lib/docs/core/instrumentable.rb:15:in `instrument'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:179:in `process_response'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:160:in `block in handle_response'
  /Users/kolen/src/devdocs/lib/docs/core/instrumentable.rb:15:in `instrument'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:159:in `handle_response'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:77:in `block in build_pages'
  /Users/kolen/src/devdocs/lib/docs/core/scrapers/file_scraper.rb:39:in `request_all'
  /Users/kolen/src/devdocs/lib/docs/core/scraper.rb:76:in `build_pages'
  /Users/kolen/src/devdocs/lib/docs/core/doc.rb:115:in `block in store_pages'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:87:in `block (2 levels) in replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:182:in `track_touched'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:87:in `block in replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:170:in `lock'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:87:in `replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:85:in `block in replace'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:144:in `open_yield_close'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:30:in `open'
  /Users/kolen/src/devdocs/lib/docs/storage/abstract_store.rb:85:in `replace'
  /Users/kolen/src/devdocs/lib/docs/core/doc.rb:114:in `store_pages'
  /Users/kolen/src/devdocs/lib/docs.rb:100:in `generate'
  /Users/kolen/src/devdocs/lib/tasks/docs.thor:303:in `generate_doc'
  /Users/kolen/src/devdocs/lib/tasks/docs.thor:105:in `generate'
```

</details>