### PR TITLE
update github scraper

### DIFF
--- a/lib/docs/scrapers/github.rb
+++ b/lib/docs/scrapers/github.rb
@@ -4,5 +4,20 @@ module Docs
     self.type = 'github'
 
     html_filters.push 'github/clean_html'
+
+    def process_response?(response)
+      if super(response)
+        return true
+      end
+      JSON.parse(response.body)
+      true
+    rescue JSON::ParserError, TypeError => e
+      false
+    end
+
+    def parse(response)
+      parsed = JSON.parse(response.response_body)
+      [parsed['payload']['blob']['richText'], parsed['title']]
+    end
   end
 end


### PR DESCRIPTION
tweak github scraper to work again after GitHub UI update which gives back JSON data
fixes #2014 

Needed to:
- update the scraper to check if response is valid json after the usual fails
- updat the `parse` method to extract the data correctly before processing