### PR TITLE
Update multiple "current version" checks

### DIFF
--- a/lib/docs/core/scraper.rb
+++ b/lib/docs/core/scraper.rb
@@ -150,7 +150,7 @@ module Docs
       if path.empty? || path == '/'
         root_url.to_s
       else
-        File.join(base_url.to_s, path)
+        File.join(base_url.to_s, path.to_s)
       end
     end
 

--- a/lib/docs/scrapers/cppref/cppref.rb
+++ b/lib/docs/scrapers/cppref/cppref.rb
@@ -23,7 +23,7 @@ module Docs
 
     # Check if the 'headers' page has changed
     def get_latest_version(opts)
-      doc = fetch_doc(self.base_url + self.root_path, opts)
+      doc = fetch_doc((self.base_url + self.root_path).to_s, opts)
       date = doc.at_css('#footer-info-lastmod').content
       date = date.match(/[[:digit:]]{1,2} .* [[:digit:]]{4}/).to_s
       date = DateTime.strptime(date, '%e %B %Y').to_time.to_i

--- a/lib/docs/scrapers/docker.rb
+++ b/lib/docs/scrapers/docker.rb
@@ -96,7 +96,7 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://docs.docker.com/engine/release-notes/', opts)
-      latest_version = doc.at_css('.content > section > h1[id^="version-"]').content.strip
+      latest_version = doc.at_css('.content > section > h2').content.strip
       latest_version.rpartition(' ')[-1]
     end
   end

--- a/lib/docs/scrapers/electron.rb
+++ b/lib/docs/scrapers/electron.rb
@@ -27,7 +27,7 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://www.electronjs.org/releases/stable', opts)
-      doc.at_css(".tag").content.gsub!(/[a-zA-Z]/, '')
+      doc.at_css('.release-card__metadata>a')['href'].gsub!(/[a-zA-Z\/:]/, '')[1..-1]
     end
   end
 end

--- a/lib/docs/scrapers/gnu/gcc.rb
+++ b/lib/docs/scrapers/gnu/gcc.rb
@@ -156,8 +156,8 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://gcc.gnu.org/onlinedocs/', opts)
-      label = doc.at_css('ul > li > ul > li > a').content.strip
-      label.scan(/([0-9.]+)/)[0][0]
+      label = doc.at_css('details > ul > li > a')['href'].strip
+      label.scan(/([0-9.]+)/)[2..-1][0][0]
     end
   end
 end

--- a/lib/docs/scrapers/gnu/gnu_fortran.rb
+++ b/lib/docs/scrapers/gnu/gnu_fortran.rb
@@ -53,8 +53,8 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://gcc.gnu.org/onlinedocs/', opts)
-      label = doc.at_css('ul > li > ul > li > a').content.strip
-      label.scan(/([0-9.]+)/)[0][0]
+      label = doc.at_css('details > ul > li > a')['href'].strip
+      label.scan(/([0-9.]+)/)[2..-1][0][0]
     end
   end
 end

--- a/lib/docs/scrapers/react_bootstrap.rb
+++ b/lib/docs/scrapers/react_bootstrap.rb
@@ -29,7 +29,7 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://react-bootstrap.github.io/', opts)
-      doc.at_css('#t-version>a').content.split()[0].strip[1..-1]
+      doc.at_css('.my-2').content.split()[-1].strip[0..-1]
     end
   end
 end


### PR DESCRIPTION
- Single scrapers (just effecting one (max. two) scrapers):  GCC, GNU Fortran, React Bootstrap, Docker, Electron, C/C++
- Adjustment in Base Scraper (potential affect in all (though practically didn't))