### PR TITLE
remove C/C++ from file-scraper list

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -4,16 +4,6 @@ This lists the docs that use `FileScraper` and instructions for building some of
 
 If you open a PR to update one of these docs, please add/fix the instructions.
 
-## C
-
-Download the HTML book from https://en.cppreference.com/w/Cppreference:Archives
-and copy `reference/en/c` from the ZIP file into `/path/to/devdocs/docs/c`.
-
-## C++
-
-Download the HTML book from https://en.cppreference.com/w/Cppreference:Archives
-and copy `reference/en/cpp` from the ZIP file into `/path/to/devdocs/docs/cpp`.
-
 ## Dart
 
 Click the “API docs” link under the “Stable channel” header on


### PR DESCRIPTION
moved to URLScraper by e17bc84ea4c2a675fb16282339610dcab1506ce0