### PR TITLE
fix: download_doc should delete tempfile

### DIFF
--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -343,6 +343,7 @@ class DocsCLI < Thor
       file.close
       tar = UnixUtils.gunzip(file.path)
       dir = UnixUtils.untar(tar)
+      FileUtils.rm(tar)
       FileUtils.rm_rf(target_path)
       FileUtils.mv(dir, target_path)
       FileUtils.rm(file.path)


### PR DESCRIPTION
The download task in `docs.thor` did not delete the tarball after unpacking in `/tmp`.