### PR TITLE
Fixing the issue

### DIFF
--- a/lib/docs/scrapers/cppref/c.rb
+++ b/lib/docs/scrapers/cppref/c.rb
@@ -2,7 +2,7 @@ module Docs
   class C < Cppref
     self.name = 'C'
     self.slug = 'c'
-    self.base_url = 'https://en.cppreference.com/w/c/'
+    self.base_url = 'https://en.cppreference.com/w/c'
     # release = '2023-03-24'
 
     html_filters.insert_before 'cppref/clean_html', 'c/entries'

--- a/lib/docs/scrapers/cppref/cpp.rb
+++ b/lib/docs/scrapers/cppref/cpp.rb
@@ -2,7 +2,7 @@ module Docs
   class Cpp < Cppref
     self.name = 'C++'
     self.slug = 'cpp'
-    self.base_url = 'https://en.cppreference.com/w/cpp/'
+    self.base_url = 'https://en.cppreference.com/w/'
     # release = '2023-03-24'
 
     html_filters.insert_before 'cppref/clean_html', 'cpp/entries'


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION A - Adding a new scraper -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#contributing-new-documentations -->

If you’re adding a new scraper, please ensure that you have:

- [ ] Tested the scraper on a local copy of DevDocs
- [ ] Ensured that the docs are styled similarly to other docs on DevDocs
<!-- If the docs don’t have an icon, delete the next four items: -->
- [ ] Added these files to the <code>public/icons/*your_scraper_name*/</code> directory:
  - [ ] `16.png`: a 16×16 pixel icon for the doc
  - [ ] `16@2x.png`: a 32×32 pixel icon for the doc
  - [ ] `SOURCE`: A text file containing the URL to the page the image can be found on or the URL of the original image itself

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [ ] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ ] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
