### PR TITLE
Fixed Reactjs Documentation bug 

### DIFF
--- a/lib/docs/scrapers/cppref/c.rb
+++ b/lib/docs/scrapers/cppref/c.rb
@@ -2,7 +2,7 @@ module Docs
   class C < Cppref
     self.name = 'C'
     self.slug = 'c'
-    self.base_url = 'https://en.cppreference.com/w/c/'
+    self.base_url = 'https://en.cppreference.com/w/c'
     # release = '2023-03-24'
 
     html_filters.insert_before 'cppref/clean_html', 'c/entries'

--- a/lib/docs/scrapers/cppref/cpp.rb
+++ b/lib/docs/scrapers/cppref/cpp.rb
@@ -2,7 +2,7 @@ module Docs
   class Cpp < Cppref
     self.name = 'C++'
     self.slug = 'cpp'
-    self.base_url = 'https://en.cppreference.com/w/cpp/'
+    self.base_url = 'https://en.cppreference.com/w/'
     # release = '2023-03-24'
 
     html_filters.insert_before 'cppref/clean_html', 'cpp/entries'

--- a/lib/docs/scrapers/react.rb
+++ b/lib/docs/scrapers/react.rb
@@ -3,7 +3,7 @@ module Docs
     self.name = 'React'
     self.type = 'simple'
     self.release = '18.2.0'
-    self.base_url = 'https://react.dev/'
+    self.base_url = 'https://react.dev/reference/react/'
     self.root_path = 'hello-world.html'
     self.links = {
       home: 'https://reactjs.org/',

--- a/lib/docs/scrapers/react.rb
+++ b/lib/docs/scrapers/react.rb
@@ -3,7 +3,7 @@ module Docs
     self.name = 'React'
     self.type = 'simple'
     self.release = '18.2.0'
-    self.base_url = 'https://reactjs.org/docs/'
+    self.base_url = 'https://react.dev/'
     self.root_path = 'hello-world.html'
     self.links = {
       home: 'https://reactjs.org/',


### PR DESCRIPTION
#1997
Fixed the Documentation bug - 

The React documentation links to the old React documentation at reactjs.org. The new website is react.dev.
