### PR TITLE
fix: convert hash to keyword args

### DIFF
--- a/lib/tasks/updates.thor
+++ b/lib/tasks/updates.thor
@@ -174,7 +174,7 @@ class UpdatesCLI < Thor
       order: 'desc'
     }
 
-    matching_issues = github_get('/search/issues', search_params)
+    matching_issues = github_get('/search/issues', **search_params)
     previous_issue = matching_issues['items'].find {|item| item['number'] != created_issue['number']}
 
     if previous_issue.nil?


### PR DESCRIPTION
This should fix the errors when generating the document reports: https://github.com/freeCodeCamp/devdocs/actions/runs/6368002480/job/17287040076

From digging through the history, it looks like it was a side-effect of the move to ruby v3 in https://github.com/freeCodeCamp/devdocs/pull/1867