### PR TITLE
Update Readme to Ruby 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Unless you wish to contribute to the project, we recommend using the hosted vers
 
 DevDocs is made of two pieces: a Ruby scraper that generates the documentation and metadata, and a JavaScript app powered by a small Sinatra app.
 
-DevDocs requires Ruby 3.2.1, libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
+
+DevDocs requires Ruby 3.2.2 (defined in [`Gemfile`](./Gemfile)), libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
 
 ```sh
 git clone https://github.com/freeCodeCamp/devdocs.git && cd devdocs


### PR DESCRIPTION
- While trying to [install based on the Readme](https://github.com/freeCodeCamp/devdocs/tree/main#quick-start), the Ruby version mention (3.2.1) conflicts with [`.ruby-version`](https://github.com/freeCodeCamp/devdocs/blob/main/.ruby-version) / [`Gemfile`](https://github.com/freeCodeCamp/devdocs/blob/main/Gemfile) / [`Gemfile.lock`](https://github.com/freeCodeCamp/devdocs/blob/main/Gemfile.lock) (3.2.2)

```
$ ruby -v
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-darwin23]
$ bundle install                              
Your Ruby version is 3.2.1, but your Gemfile specified 3.2.2
```

- So updating the Readme to mention current Ruby version and link to `Gemfile` as a reference (as mentioned in `bundle install` output) if it changes in the future

- Alternatively to prevent the need to keep updating the Ruby version, maybe just link to the appropriate file where it is it defined?