### PR TITLE
Update Astro documentation (3.2.0)

### DIFF
--- a/lib/docs/filters/astro/entries.rb
+++ b/lib/docs/filters/astro/entries.rb
@@ -8,14 +8,16 @@ module Docs
       end
 
       def get_type
+        return 'Guides' if slug.start_with?('contribute/')
+        return 'Guides' if slug.start_with?('guides/')
         aside = at_css('aside')
         a = aside.at_css('a[aria-current="page"]', 'a[data-current-parent="true"]')
         a.ancestors('details').at_css('summary').content
       end
 
       def additional_entries
-        return if slug.start_with?('guides/deploy')
-        return if slug.start_with?('guides/integrations-guide')
+        return [] if slug.start_with?('guides/deploy')
+        return [] if slug.start_with?('guides/integrations-guide')
         at_css('article').css('h2[id], h3[id]').each_with_object [] do |node, entries|
           type = node.content.strip
           type.sub! %r{\s*#\s*}, ''

--- a/lib/docs/scrapers/astro.rb
+++ b/lib/docs/scrapers/astro.rb
@@ -16,7 +16,7 @@ module Docs
 
     options[:skip_patterns] = [/tutorial/]
 
-    self.release = '2.9.7'
+    self.release = '3.2.0'
     self.base_url = 'https://docs.astro.build/en/'
     self.initial_paths = %w(getting-started/)
 


### PR DESCRIPTION

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
