### PR TITLE
Update Svelte documentation (4.2.1)

### DIFF
--- a/lib/docs/filters/svelte/clean_html.rb
+++ b/lib/docs/filters/svelte/clean_html.rb
@@ -2,8 +2,12 @@ module Docs
   class Svelte
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('main > .content')
-        at_css('h1').content = 'Svelte'
+        @doc = at_css('main .page.content')
+        at_css('h1').content = 'Svelte' if root_page?
+        css('pre').each do |node|
+          node.content = node.css('.line').map(&:content).join("\n")
+          node['data-language'] = 'javascript'
+        end
         doc
       end
     end

--- a/lib/docs/filters/svelte/entries.rb
+++ b/lib/docs/filters/svelte/entries.rb
@@ -2,15 +2,18 @@ module Docs
   class Svelte
     class EntriesFilter < Docs::EntriesFilter
       def get_type
-        'Svelte'
+        at_css('ul.sidebar > li:has(.active) > span.section').content
       end
 
       def additional_entries
-        type = 'Svelte'
         subtype = nil
+        css('aside').remove
+        css('.category').remove
+        css('.controls').remove
+        css('.edit').remove
+        css('.permalink').remove
         css('h2, h3, h4').each_with_object [] do |node, entries|
           if node.name == 'h2'
-            type = node.content.strip
             subtype = nil
           elsif node.name == 'h3'
             subtype = node.content.strip
@@ -19,7 +22,8 @@ module Docs
           next if type == 'Before we begin'
           name = node.content.strip
           name.concat " (#{subtype})" if subtype && node.name == 'h4'
-          entries << [name, node['id'], subtype || type]
+          next if name.starts_with?('Example')
+          entries << [name, node['id'], get_type]
         end
       end
     end

--- a/lib/docs/scrapers/svelte.rb
+++ b/lib/docs/scrapers/svelte.rb
@@ -8,18 +8,27 @@ module Docs
       code: 'https://github.com/sveltejs/svelte'
     }
 
+    self.root_path = 'introduction'
     options[:root_title] = 'Svelte'
 
+    # https://github.com/sveltejs/svelte/blob/master/LICENSE.md
     options[:attribution] = <<-HTML
-      &copy; 2016–2022 Rich Harris and contributors<br>
+      &copy; 2016–2023 Rich Harris and contributors<br>
       Licensed under the MIT License.
     HTML
 
     options[:skip] = %w(team.html plugins/)
 
-    self.release = '3.55.0'
-    self.base_url = 'https://svelte.dev/docs'
+    self.base_url = 'https://svelte.dev/docs/'
     html_filters.push 'svelte/entries', 'svelte/clean_html'
+    
+    version do
+      self.release = '4.2.1'
+    end
+
+    version '3' do
+      self.release = '3.55.0'
+    end
 
     def get_latest_version(opts)
       get_npm_version('svelte', opts)


### PR DESCRIPTION

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
