### PR TITLE
Remove parent divs only once for each `ul` element

### DIFF
--- a/lib/docs/filters/cppref/clean_html.rb
+++ b/lib/docs/filters/cppref/clean_html.rb
@@ -19,8 +19,9 @@ module Docs
           node.before(node.children).remove
         end
 
-        css('div > ul').each do |node|
-          node.parent.before(node.parent.children).remove
+        parents = css('div > ul').map(&:parent).uniq
+        parents.each do |parent|
+          parent.before(parent.children).remove
         end
 
         css('dl > dd:first-child:last-child > ul:first-child:last-child').each do |node|


### PR DESCRIPTION
Fixes #2039 

The issue was that, in `Docs::Cpref::CleanHtmlFilter`, we had the following:

```ruby
        css('div > ul').each do |node|
          node.parent.before(node.parent.children).remove
        end
```

This was fine for almost all cases, however, the page for [`std::vector::vector`](https://en.cppreference.com/w/cpp/container/vector/vector) had more than one `ul` element inside the same `div` (in the Complexity section).

This meant that, as we iterated over each `ul` element, because 2 or more had the same parent `div`, for the first `ul` with a sibling, we'd correctly pop all it's siblings out of the parent div, but when we came around to the second sibling `ul`, it's parent `div` was now some outer `div` on the page, and that would get removed. This would repeat itself how many sibling `ul` elements there might be on the page.

I modified the code to simply grab the parent divs, remove the duplicates and then execute the logic to pop out it's children and remove itself.

All tests passed locally, but when I went ahead to add tests to prevent this bug from reappearing, I noticed that there doesn't seem to be any tests for specific scrapers or filters, is that by choice?