### PR TITLE
Allow Python scraper to keep empty spans with ids

### DIFF
--- a/lib/docs/filters/sphinx/clean_html.rb
+++ b/lib/docs/filters/sphinx/clean_html.rb
@@ -36,9 +36,11 @@ module Docs
           node.replace(pre)
         end
 
-        css('span[id]:empty').each do |node|
-          (node.next_element || node.previous_element)['id'] ||= node['id'] if node.next_element || node.previous_element
-          node.remove
+        unless context[:sphinx_keep_empty_ids]
+          css('span[id]:empty').each do |node|
+            (node.next_element || node.previous_element)['id'] ||= node['id'] if node.next_element || node.previous_element
+            node.remove
+          end
         end
 
         css('.section').each do |node|

--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -28,14 +28,14 @@ module Docs
     HTML
 
     version '3.12' do
-      self.release = '3.12.0'
+      self.release = '3.12.1'
       self.base_url = "https://docs.python.org/#{self.version}/"
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'
     end
 
     version '3.11' do
-      self.release = '3.11.5'
+      self.release = '3.11.7'
       self.base_url = "https://docs.python.org/#{self.version}/"
 
       html_filters.push 'python/entries_v3', 'sphinx/clean_html', 'python/clean_html'

--- a/lib/docs/scrapers/python.rb
+++ b/lib/docs/scrapers/python.rb
@@ -7,6 +7,12 @@ module Docs
       code: 'https://github.com/python/cpython'
     }
 
+    # bypass the clean_text filter as it removes empty span with ids
+    options[:clean_text] = false
+
+    # bypass sphinx modifying empty ids
+    options[:sphinx_keep_empty_ids] = true
+
     options[:skip_patterns] = [/whatsnew/]
     options[:skip] = %w(
       library/2to3.html


### PR DESCRIPTION
Fixes #1081 

Source has 3 IDs
<img width="869" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/111efa50-1df4-4923-966a-63c22f6f8536">

Scraped page has 2
<img width="779" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/9cd6b9f5-6df4-4e45-b09b-705f812d8c6f">


Turns out that
- Empty spans with IDs are removed in `core/clean_text` https://github.com/freeCodeCamp/devdocs/blob/887c879e0f5b5d4b77ee6cbc660e268b8d318b3f/lib/docs/filters/core/clean_text.rb#L10
- `sphinx/clean_html` does some ID manipulation and removal of some empty spans https://github.com/freeCodeCamp/devdocs/blob/887c879e0f5b5d4b77ee6cbc660e268b8d318b3f/lib/docs/filters/sphinx/clean_html.rb#L39-L42

## Code changes done

- Created new `sphinx_keep_empty_ids` parameter to bypass `sphinx/clean_html` processing and set python scraper to `options[:sphinx_keep_empty_ids] = true`
- `options[:clean_text] = false` to bypass `core/clean_text`

### Other notes

In testing this solve the issue mentioned and likely other scenarios (could be up to 54 scenarios in total)

```
➜  python~3.10 git:(allow-python-empty-spans) ✗ pwd
/Users/thewheat/src/devdocs/docs/python~3.10
➜  python~3.10 git:(allow-python-empty-spans) ✗ grep -irn  "<span id=.*</span><span id="  | grep datetime
./library/datetime.html:2660:<span id="strftime-strptime-behavior"></span><span id="index-0"></span><h2><code class="xref py py-meth docutils literal notranslate"><span class="pre">strftime()</span></code> and <code class="xref py py-meth docutils literal notranslate"><span class="pre">strptime()</span></code> Behavior<a class="headerlink" href="#strftime-and-strptime-behavior" title="Permalink to this headline">¶</a></h2>
➜  python~3.10 git:(allow-python-empty-spans) ✗ grep -irn  "<span id=.*</span><span id="  | wc -l        
      54
```

Some others affected that are fixed in my local setup
- Search `option flags` https://devdocs.io/python~3.7/library/doctest#doctest-options
- Search `doctest directives` https://devdocs.io/python~3.7/library/doctest#doctest-directives