### PR TITLE
CPP scrape entries ending with <typename>

### DIFF
--- a/lib/docs/filters/cpp/entries.rb
+++ b/lib/docs/filters/cpp/entries.rb
@@ -52,7 +52,7 @@ module Docs
         name.remove! %r{\s\(.+\)}
 
         name.sub! %r{\AStandard library header <(.+)>\z}, '\1'
-        name.sub! %r{(<[^>]+>)}, ''
+        name.sub! %r{(<[^>]+>::)}, '::'
 
         if name.include?('operator') && name.include?(',')
           name.sub!(%r{operator.+([\( ])}, 'operators (') || name.sub!(%r{operator.+}, 'operators')


### PR DESCRIPTION
Fixes #2049

- Certain pages will currently result in a name that already exists and thus get missed
- Example pages
   - https://en.cppreference.com/w/cpp/chrono/system_clock/formatter
   - https://en.cppreference.com/w/cpp/chrono/duration/formatter
- The removal of text between `<` and `>` results in both pages having a name of `std::formatter` https://github.com/freeCodeCamp/devdocs/blob/887c879e0f5b5d4b77ee6cbc660e268b8d318b3f/lib/docs/filters/cpp/entries.rb#L55 
- There is duplicate name detection that prevents a page from being scraped https://github.com/freeCodeCamp/devdocs/blob/887c879e0f5b5d4b77ee6cbc660e268b8d318b3f/lib/docs/filters/cpp/entries.rb#L74
- `std::formatter` exists as https://devdocs.io/cpp/utility/format/formatter 

<img width="1026" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/8b7bfeea-20e5-45b2-abc0-883c202e94b7">

## Explanation of PR

- This PR just removes the text if there is `::` after it
- The reason being there are pages that should still have the text removed e.g. https://en.cppreference.com/w/cpp/container/queue/queue is shortned to `std::queue::queue` https://devdocs.io/cpp/container/queue/queue
- Am not too familiar with CPP syntax and docs in general so if there is a better naming convention, I'll be open to it

**Preview of some of the new entries**
<img width="982" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/76d45df7-1df4-46d1-8d01-9ab3b120c69f">
