### PR TITLE
Fix CPP clean_html to remove adding an extra dot

### DIFF
--- a/lib/docs/filters/cppref/clean_html.rb
+++ b/lib/docs/filters/cppref/clean_html.rb
@@ -82,7 +82,6 @@ module Docs
             node << node.next
           end
           node.inner_html = node.inner_html.strip
-          node << '.' if node.content =~ /[a-zA-Z0-9\)]\z/
           node.remove if node.content.blank? && !node.at_css('img')
         end
 


### PR DESCRIPTION
Fixes: #1608

- Remove a line that specifically adds a dot
- Am unsure why this line exists it seems to have been added in this migration https://github.com/freeCodeCamp/devdocs/commit/e17bc84ea4c2a675fb16282339610dcab1506ce0 

- Generating page does show desired output
```
$ thor docs:page cpp /utility/launder 
Done
```
<img width="439" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/ec16ac26-4aa3-4d7f-9145-fcf902fd1b53">

- I tried to output other contents where a dot was added by temporarily adding this and reviewing the output it doesn't seem to add much value but I could be missing some fuller context.

```
          if node.content =~ /[a-zA-Z0-9\)]\z/
            puts "Add dot: #{node.content}"
          end
```
- Excerpt of output showing other contents that would have the dot added
```
$ thor docs:generate cpp
...
Add dot: 13.1.6* (partial)
Add dot: 12.0.0* (partial)
Add dot: 13.1.6* (partial)
...
Add dot: 10.0.0* (partial)
Add dot: 10.0.0* (partial)
Add dot: std::bit_ceil(), std::bit_floor(), std::bit_width(), std::has_single_bit()
Add dot: 11.0.3* (P0556R3) 13.0.0* (P1956R1)
Add dot: 10.0.1* (partial)
Add dot: 10.0.1* (P1209R0) 12.0.5* (P1115R3)
Add dot: rotl(), rotr(), countl_zero(), countl_one(), countr_zero(), countr_one(), popcount()
Add dot: 13.1.6* (partial)
Add dot: The kind of the implementation is implementation-defined. The macro __STDC_HOSTED__ is predefined to 1 for hosted implementations and 0 for freestanding implementations. (since C++11)
Add dot: Basic concepts
Add dot: Comments ASCII chart Punctuation Names and identifiers Types – Fundamental types Object – Scope – Lifetime Definitions and ODR Name lookup qualified – unqualified (ADL) As-if rule Undefined behavior (UB) Memory model and data races Character sets and encodings Phases of translation The main function Modules (C++20)
Add dot: Keywords
Add dot: Preprocessor
Add dot: #if - #ifdef - #ifndef - #elif #elifdef - #elifndef (C++23) #define - # - ## #include - #pragma #line - #error - #warning (C++23)
Add dot: Expressions
Add dot: Value categories Evaluation order and sequencing Constant expressions Operators assignment – arithmetic increment and decrement logical – comparison member access and indirection call, comma, ternary sizeof – alignof (C++11) new – delete – typeid alternative representation Operator overloading Default comparisons (C++20) Operator precedence Conversions implicit – explicit – user-defined Usual arithmetic conversions static_cast – dynamic_cast const_cast – reinterpret_cast Literals (Escape sequences) boolean – integer – floating character – string nullptr (C++11) user-defined (UDL) (C++11)
Add dot: Declarations
Add dot: Namespace declaration Namespace alias References – Pointers – Arrays Structured bindings (C++17) Enumerations and enumerators Storage duration and linkage Translation-unit-local (C++20) Language linkage inline specifier Inline assembly const/volatile constexpr (C++11) consteval (C++20) constinit (C++20) decltype (C++11) – auto (C++11) typedef – Type alias (C++11) Elaborated type specifiers Attributes (C++11) alignas (C++11) static_assert (C++11)
Add dot: Initialization
...
Add dot: Smart pointers (e.g. std::shared_ptr), allocators (e.g. std::allocator or std::pmr::memory_resource), C-style memory management (e.g. std::malloc)
Add dot: Exceptions (e.g. std::exception, std::terminate), assertions (e.g. assert)
Add dot: Support for functions that take an arbitrary number of parameters (via e.g. va_start, va_arg, va_end)
Add dot: Time tracking (e.g. std::chrono::time_point, std::chrono::duration), C-style date and time (e.g. std::time, std::clock)
Add dot: The library creates and manipulates range views, lightweight objects that indirectly represent iterable sequences (ranges). Ranges are an abstraction on top of
Add dot: _Exit() (since C++11)
Add dot: abs() (int) abs() (float) abs<>() (std::complex) abs<>() (std::valarray) acos() acos<>() (std::complex) (since C++11) acos<>() (std::valarray) acosf() (since C++11) acosh() (since C++11) acosh<>() (std::complex) (since C++11) acoshf() (since C++11) acoshl() (since C++11) acosl() (since C++11) accumulate<>() add_const<> (since C++11) add_const_t<> (since C++14) add_cv<> (since C++11) add_cv_t<> (since C++14) add_pointer<> (since C++11) add_pointer_t<> (since C++14) add_lvalue_reference<> (since C++11) add_lvalue_reference_t<> (since C++14) add_rvalue_reference<> (since C++11) add_rvalue_reference_t<> (since C++14) add_volatile<> (since C++11) add_volatile_t<> (since C++14) addressof<> (since C++11) adjacent_difference<> adjacent_find<> adopt_lock (since C++11) adopt_lock_t (since C++11) advance<>() align() (since C++11) align_val_t (since C++17) aligned_alloc() (since C++17) aligned_storage<> (since C++11) aligned_storage_t<> (since C++14) aligned_union<> (since C++11) aligned_union_t<> (since C++14) alignment_of<> (since C++11) alignment_of_v<> (since C++17) all_of<>() (since C++11) allocate_shared<>() (since C++11) allocate_shared_for_overwrite<>() (since C++20) allocation_result<> (since C++23) allocator<> allocator_arg (since C++11) allocator_arg_t (since C++11) allocator_traits<> (since C++11) any (since C++17) any_cast<>() (since C++17) any_of<>() (since C++11) apply<>() (since C++17) arg<>() array<> (since C++11) as_bytes<>() (since C++20) as_const<>() (since C++17) as_writable_bytes<>() (since C++20) asctime() asin() asin<>() (std::complex) (since C++11) asin<>() (std::valarray) asinf() (since C++11) asinh() (since C++11) asinh<>() (std::complex) (since C++11) asinhf() (since C++11) asinhl() (since C++11) asinl() (since C++11) assignable_from<> (since C++20) assoc_laguerre() (since C++17) assoc_laguerref() (since C++17) assoc_laguerrel() (since C++17) assoc_legendre() (since C++17) assoc_legendref() (since C++17) assoc_legendrel() (since C++17) assume_aligned<>() (since C++20) async<>() (since C++11) at_quick_exit() (since C++11) atan() atan<>() (std::complex) (since C++11) atan<>() (std::valarray) atan2() atan2<>() (std::valarray) atan2f() (since C++11) atan2l() (since C++11) atanf() (since C++11) atanh() (since C++11) atanh<>() (std::complex) (since C++11) atanhf() (since C++11) atanhl() (since C++11) atanl() (since C++11) atexit() atof() atoi() atol() atoll() (since C++11)
Add dot: atomic<> (since C++11)
Add dot: atomic<> full specializations and typedefs: atomic_bool (since C++11) atomic_char (since C++11) atomic_char16_t (since C++11) atomic_char32_t (since C++11) atomic_char8_t (since C++20) atomic_int (since C++11) atomic_int8_t (since C++11) atomic_int16_t (since C++11) atomic_int32_t (since C++11) atomic_int64_t (since C++11) atomic_int_fast8_t (since C++11) atomic_int_fast16_t (since C++11) atomic_int_fast32_t (since C++11) atomic_int_fast64_t (since C++11) atomic_int_least8_t (since C++11) atomic_int_least16_t (since C++11) atomic_int_least32_t (since C++11) atomic_int_least64_t (since C++11) atomic_intmax_t (since C++11) atomic_intptr_t (since C++11) atomic_llong (since C++11) atomic_long (since C++11) atomic_ptrdiff_t (since C++11) atomic_schar (since C++11) atomic_short (since C++11) atomic_signed_lock_free (since C++20) atomic_size_t (since C++11) atomic_uchar (since C++11) atomic_uint (since C++11) atomic_uint8_t (since C++11) atomic_uint16_t (since C++11) atomic_uint32_t (since C++11) atomic_uint64_t (since C++11) atomic_uint_fast8_t (since C++11) atomic_uint_fast16_t (since C++11) atomic_uint_fast32_t (since C++11) atomic_uint_fast64_t (since C++11) atomic_uint_least8_t (since C++11) atomic_uint_least16_t (since C++11) atomic_uint_least32_t (since C++11) atomic_uint_least64_t (since C++11) atomic_uintmax_t (since C++11) atomic_uintptr_t (since C++11) atomic_ullong (since C++11) atomic_ulong (since C++11) atomic_unsigned_lock_free (since C++20) atomic_ushort (since C++11) atomic_wchar_t (since C++11)
Add dot: atomic_compare_exchange_strong<>() (since C++11) atomic_compare_exchange_strong<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_compare_exchange_strong_explicit<>() (since C++11) atomic_compare_exchange_strong_explicit<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_compare_exchange_weak<>() (since C++11) atomic_compare_exchange_weak<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_compare_exchange_weak_explicit<>() (since C++11) atomic_compare_exchange_weak_explicit<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_exchange<>() (since C++11) atomic_exchange<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_exchange_explicit<>() (since C++11) atomic_exchange_explicit<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_fetch_add<>() (since C++11) atomic_fetch_add_explicit<>() (since C++11) atomic_fetch_and<>() (since C++11) atomic_fetch_and_explicit<>() (since C++11) atomic_fetch_or<>() (since C++11) atomic_fetch_or_explicit<>() (since C++11) atomic_fetch_sub<>() (since C++11) atomic_fetch_sub_explicit<>() (since C++11) atomic_fetch_xor<>() (since C++11) atomic_fetch_xor_explicit<>() (since C++11) atomic_flag (since C++11) atomic_flag_clear() (since C++11) atomic_flag_clear_explicit() (since C++11) atomic_flag_notify_all() (since C++20) atomic_flag_notify_one() (since C++20) atomic_flag_test() (since C++20) atomic_flag_test_explicit() (since C++20) atomic_flag_test_and_set() (since C++11) atomic_flag_test_and_set_explicit() (since C++11) atomic_flag_wait() (since C++20) atomic_flag_wait_explicit() (since C++20) atomic_init<>() (since C++11)(deprecated in C++20) atomic_is_lock_free<>() (since C++11) atomic_is_lock_free<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_load<>() (since C++11) atomic_load<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_load_explicit<>() (since C++11) atomic_load_explicit<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_notify_all<>() (since C++20) atomic_notify_one<>() (since C++20) atomic_ref<> (since C++20) atomic_signal_fence() (since C++11) atomic_store<>() (since C++11) atomic_store<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_store_explicit<>() (since C++11) atomic_store_explicit<>() (std::shared_ptr) (since C++11)(deprecated in C++20) atomic_thread_fence() (since C++11) atomic_wait<>() (since C++20) atomic_wait_explicit<>() (since C++20) atto (since C++11)
Add dot: back_insert_iterator<> back_inserter<> bad_alloc bad_any_cast (since C++17) bad_array_new_length (since C++11) bad_cast bad_exception bad_expected_access<> (since C++23) bad_function_call (since C++11) bad_optional_access (since C++17) bad_typeid bad_variant_access (since C++17) bad_weak_ptr (since C++11) barrier<> (since C++20) basic_common_reference<> (since C++20) basic_const_iterator<> (since C++23) basic_filebuf<> basic_format_arg<> (since C++20) basic_format_args<> (since C++20) basic_format_context<> (since C++20) basic_format_parse_context<> (since C++20) basic_format_string<> (since C++20) basic_fstream<> basic_ifstream<> basic_istream<> basic_ios<> basic_iostream<> basic_ispanstream<> (since C++23) basic_istringstream<> basic_ofstream<> basic_ostream<> basic_ospanstream<> (since C++23) basic_ostringstream<> basic_osyncstream<> (since C++20) basic_regex<> (since C++11) basic_spanbuf<> (since C++23) basic_spanstream<> (since C++23) basic_stacktrace<> (since C++23) basic_streambuf<> basic_string<> basic_string_view<> (since C++17) basic_stringbuf<> basic_stringstream<> basic_syncbuf<> (since C++20) begin<>() (since C++11) bernoulli_distribution<> (since C++11) beta() (since C++17) betaf() (since C++17) betal() (since C++17) bfloat16_t (since C++23) bidirectional_iterator<> (since C++20) bidirectional_iterator_tag binary_search<>() binary_semaphore (since C++20) bind<>() (since C++11) bind_back<>() (since C++23) bind_front<>() (since C++20) binomial_distribution<> (since C++11) bit_and<> bit_cast<>() (since C++20) bit_ceil<>() (since C++20) bit_floor<>() (since C++20) bit_not<> (since C++14) bit_or<> bit_width<>() (since C++20) bit_xor<> bitset<> bool_constant<> (since C++17) boolalpha() boyer_moore_horspool_searcher<> (since C++17) boyer_moore_searcher<> (since C++17) bsearch() btowc() byte (since C++17) byteswap<>() (since C++23)
Add dot: c16rtomb() (since C++11) c32rtomb() (since C++11) c8rtomb() (since C++20) call_once<>() (since C++11) calloc() cauchy_distribution<> (since C++11) cbegin<>() (since C++14) cbrt() (since C++11) cbrtf() (since C++11) cbrtl() (since C++11) ceil() ceilf() (since C++11) ceill() (since C++11) cend<>() (since C++14) centi (since C++11) cerr char_traits<> chars_format (since C++17) chi_squared_distribution<> (since C++11) ▶ chrono (since C++11) ▶ chrono_literals (since C++14) cin clamp<>() (since C++17) clearerr() clock() clock_t clog cmatch (since C++11) cmp_equal<>() (since C++20) cmp_greater<>() (since C++20) cmp_greater_equal<>() (since C++20) cmp_less<>() (since C++20) cmp_less_equal<>() (since C++20) cmp_not_equal<>() (since C++20) codecvt<> codecvt_base codecvt_byname<> codecvt_mode (since C++11)(deprecated in C++17) codecvt_utf16<> (since C++11)(deprecated in C++17) codecvt_utf8<> (since C++11)(deprecated in C++17) codecvt_utf8_utf16<> (since C++11)(deprecated in C++17) collate<> collate_byname<> common_comparison_category<> (since C++20) common_comparison_category_t<> (since C++20) common_iterator<> (since C++20) common_reference<> (since C++20) common_reference_t<> (since C++20) common_reference_with<> (since C++20) common_type<> (since C++11) common_type_t<> (since C++14) common_with (since C++20) comp_ellint_1() (since C++17) comp_ellint_1f() (since C++17) comp_ellint_1l() (since C++17) comp_ellint_2() (since C++17) comp_ellint_2f() (since C++17) comp_ellint_2l() (since C++17) comp_ellint_3() (since C++17) comp_ellint_3f() (since C++17) comp_ellint_3l() (since C++17) compare_partial_order_fallback (since C++20) compare_strong_order_fallback (since C++20) compare_three_way (since C++20) compare_three_way_result<> (since C++20) compare_three_way_result_t<> (since C++20) compare_weak_order_fallback (since C++20) complex<> ▶ complex_literals (since C++14) conditional<> (since C++11) conditional_t<> (since C++14) condition_variable (since C++11) condition_variable_any (since C++11) conjunction<> (since C++17) conjunction_v<> (since C++17) conj<>() const_iterator<> (since C++23) const_pointer_cast<>() (since C++11) const_sentinel<> (since C++23) construct_at<>() (since C++20) constructible_from<> (since C++20) consume_header (since C++11)(deprecated in C++17) contiguous_iterator<> (since C++20) contiguous_iterator_tag (since C++20) convertible_to (since C++20) copy<>() copy_backward<>() copy_constructible (since C++20) copy_if<>() (since C++11) copy_n<>() (since C++11) copyable<> (since C++20) copysign() (since C++11) copysignf() (since C++11) copysignl() (since C++11) coroutine_handle<> (since C++20) coroutine_traits<> (since C++20) cos() cos<>() (std::complex) cos<>() (std::valarray) cosf() (since C++11) cosh() cosh<>() (std::complex) cosh<>() (std::valarray) coshf() (since C++11) coshl() (since C++11) cosl() (since C++11) count<>() count_if<>() counted_iterator<> (since C++20) counting_semaphore<> (since C++20) countl_one<>() (since C++20) countl_zero<>() (since C++20) countr_one<>() (since C++20) countr_zero<>() (since C++20) cout crbegin<>() (since C++14) cref<>() (since C++11) cregex_iterator (since C++11) cregex_token_iterator (since C++11) crend<>() (since C++14) csub_match (since C++11) ctime() ctype<> ctype_base ctype_byname<> current_exception() (since C++11) cv_status (since C++11) cyl_bessel_i() (since C++17) cyl_bessel_if() (since C++17) cyl_bessel_il() (since C++17) cyl_bessel_j() (since C++17) cyl_bessel_jf() (since C++17) cyl_bessel_jl() (since C++17) cyl_bessel_k() (since C++17) cyl_bessel_kf() (since C++17) cyl_bessel_kl() (since C++17) cyl_neumann() (since C++17) cyl_neumannf() (since C++17) cyl_neumannl() (since C++17)
Add dot: data<>() (since C++17) dec() deca (since C++11) decay<> (since C++11) decay_t<> (since C++14) deci (since C++11) declval<>() (since C++11) default_accessor<> (since C++23) default_delete (since C++11) default_initializable<> (since C++20) default_random_engine (since C++11) default_searcher<> (since C++17) default_sentinel (since C++20) default_sentinel_t (since C++20) defaultfloat() (since C++11) defer_lock (since C++11) defer_lock_t (since C++11) denorm_absent denorm_indeterminate denorm_present deque<> derived_from<> (since C++20) destroy<>() (since C++17) destroy_at<>() (since C++17) destroy_n<>() (since C++17) destroying_delete (since C++20) destroying_delete_t (since C++20) destructible (since C++20) dextents<> (since C++23) difftime() disable_sized_sentinel_for<> (since C++20) discrete_distribution<> (since C++11) discard_block_engine<> (since C++11) disjunction<> (since C++17) disjunction_v<> (since C++17) distance<>() div() div_t divides<> domain_error double_t (since C++11) dynamic_extent (since C++20) dynamic_pointer_cast<>() (since C++11)
Add dot: ellint_1() (since C++17) ellint_1f() (since C++17) ellint_1l() (since C++17) ellint_2() (since C++17) ellint_2f() (since C++17) ellint_2l() (since C++17) ellint_3() (since C++17) ellint_3f() (since C++17) ellint_3l() (since C++17) emit_on_flush<>() (since C++20) empty<>() (since C++17) enable_if<> (since C++11) enable_if_t<> (since C++14) enable_shared_from_this<> (since C++11) end<>() (since C++11) endian (since C++20) endl<>() ends<>() equal<>() equal_range<>() equal_to<> equality_comparable<> (since C++20) equality_comparable_with<> (since C++20) equivalence_relation<> (since C++20) erase<>() (std::basic_string) (since C++20) erase<>() (std::deque) (since C++20) erase<>() (std::forward_list) (since C++20) erase<>() (std::list) (since C++20) erase<>() (std::vector) (since C++20) erase_if<>() (std::basic_string) (since C++20) erase_if<>() (std::deque) (since C++20) erase_if<>() (std::flat_map) (since C++23) erase_if<>() (std::flat_multimap) (since C++23) erase_if<>() (std::flat_multiset) (since C++23) erase_if<>() (std::flat_set) (since C++23) erase_if<>() (std::forward_list) (since C++20) erase_if<>() (std::list) (since C++20) erase_if<>() (std::map) (since C++20) erase_if<>() (std::multimap) (since C++20) erase_if<>() (std::multiset) (since C++20) erase_if<>() (std::set) (since C++20) erase_if<>() (std::unordered_map) (since C++20) erase_if<>() (std::unordered_multimap) (since C++20) erase_if<>() (std::unordered_multiset) (since C++20) erase_if<>() (std::unordered_set) (since C++20) erase_if<>() (std::vector) (since C++20) erf() (since C++11) erfc() (since C++11) erfcf() (since C++11) erfcl() (since C++11) erff() (since C++11) erfl() (since C++11) errc (since C++11) error_category (since C++11) error_code (since C++11) error_condition (since C++11) exa (since C++11) exception exception_ptr (since C++11) exchange<>() (since C++14) exclusive_scan<>() (since C++17) ▶ execution (since C++17) exit() exp() exp<>() (std::complex) exp<>() (std::valarray) exp2() (since C++11) exp2f() (since C++11) exp2l() (since C++11) expf() (since C++11) expected<> (since C++23) expint() (since C++17) expintf() (since C++17) expintl() (since C++17) expl() (since C++11) expm1() (since C++11) expm1f() (since C++11) expm1l() (since C++11) exponential_distribution<> (since C++11) extent<> (since C++11) extent_v<> (since C++17) extents<> (since C++23) extreme_value_distribution<> (since C++11)
Add dot: fabs() fabsf() (since C++11) fabsl() (since C++11) false_type (since C++11) fclose() fdim() (since C++11) fdimf() (since C++11) fdiml() (since C++11) feclearexcept() (since C++11) fegetenv() (since C++11) fegetexceptflag() (since C++11) fegetround() (since C++11) feholdexcept() (since C++11) femto (since C++11) fenv_t (since C++11) feof() feraiseexcept() (since C++11) ferror() fesetenv() (since C++11) fesetexceptflag() (since C++11) fesetround() (since C++11) fetestexcept() (since C++11) feupdateenv() (since C++11) fexcept_t (since C++11) fflush() fgetc() fgetpos() fgets() fgetwc() fgetws() FILE filebuf ▶ filesystem (since C++17) fill<>() fill_n<>() find<>() find_end<>() find_first_of<>() find_if<>() find_if_not<>() (since C++11) fisher_f_distribution<> (since C++11) fixed() flat_map<> (since C++23) flat_multimap<> (since C++23) flat_multiset<> (since C++23) flat_set<> (since C++23) float_denorm_style float_round_style float_t (since C++11) float16_t (since C++23) float32_t (since C++23) float64_t (since C++23) float128_t (since C++23) floating_point<> (since C++20) floor() floorf() (since C++11) floorl() (since C++11) flush<>() flush_emit<>() (since C++20) fma() (since C++11) fmaf() (since C++11) fmal() (since C++11) fmax() (since C++11) fmaxf() (since C++11) fmaxl() (since C++11) fmin() (since C++11) fminf() (since C++11) fminl() (since C++11) fmod() fmodf() (since C++11) fmodl() (since C++11) fopen() for_each<>() for_each_n<>() (since C++17) format<>() (since C++20) format_args (since C++20) format_context (since C++20) format_error() (since C++20) format_parse_context (since C++20) format_string<> (since C++20) format_to<>() (since C++20) format_to_n<>() (since C++20) format_to_n_result<> (since C++20) formatted_size<>() (since C++20) formatter<> (since C++20) forward<>() (since C++11) forward_as_tuple<>() (since C++11) forward_iterator<> (since C++20) forward_iterator_tag forward_like<>() (since C++23) forward_list<> (since C++11) fpclassify() (since C++11) fpos<> fpos_t fprintf() fputc() fputs() fputwc() fputws() fread() free() freopen() frexp() frexpf() (since C++11) frexpl() (since C++11) from_chars() (since C++17) from_chars_result (since C++17) from_range (since C++23) from_range_t (since C++23) front_insert_iterator<> front_inserter<>() fscanf() fseek() fsetpos() fstream ftell() function<> (since C++11) future<> (since C++11) future_category() (since C++11) future_errc (since C++11) future_error (since C++11) future_status (since C++11) fwide() fwprintf() fwrite() fwscanf()
...
Add dot: same_as<> (since C++20) sample<>() (since C++17) scalbln() (since C++11) scalblnf() (since C++11) scalblnl() (since C++11) scalbn() (since C++11) scalbnf() (since C++11) scalbnl() (since C++11) scanf() scientific() scoped_allocator_adaptor<> (since C++11) scoped_lock (since C++17) search<>() search_n<>() seed_seq (since C++11) semiregular<> (since C++20) sentinel_for<> (since C++20) set<> set_difference<>() set_intersection<>() set_new_handler() set_symmetric_difference<>() set_terminate() set_union<>() setbase() setbuf() setfill<>() setiosflags() setlocale() setprecision() setvbuf() setw() shared_future<> (since C++11) shared_lock<> (since C++14) shared_mutex (since C++17) shared_ptr<> (since C++11) shared_timed_mutex (since C++14) shift_left<>() (since C++20) shift_right<>() (since C++20) showbase() showpoint() showpos() shuffle<>() (since C++11) shuffle_order_engine<> (since C++11) sig_atomic_t signal() signbit() (since C++11) signed_integral<> (since C++20) sin() sin<>() (std::complex) sin<>() (std::valarray) sinf() (since C++11) sinh() sinh<>() (std::complex) sinh<>() (std::valarray) sinhf() (since C++11) sinhl() (since C++11) sinl() (since C++11) size<>() (since C++17) size_t sized_sentinel_for<> (since C++20) skipws() slice slice_array<> smatch (since C++11) snprintf() (since C++11) sort<>() sort_heap<>() sortable<> (since C++20) sorted_equivalent (since C++23) sorted_equivalent_t (since C++23) sorted_unique (since C++23) sorted_unique_t (since C++23) source_location (since C++20) span<> (since C++20) spanbuf (since C++23) spanstream (since C++23) sph_bessel() (since C++17) sph_besself() (since C++17) sph_bessell() (since C++17) sph_legendre() (since C++17) sph_legendref() (since C++17) sph_legendrel() (since C++17) sph_neumann() (since C++17) sph_neumannf() (since C++17) sph_neumannl() (since C++17) sprintf() sqrt() sqrt<>() (std::complex) sqrt<>() (std::valarray) sqrtf() (since C++11) sqrtl() (since C++11) srand() sregex_iterator (since C++11) sregex_token_iterator (since C++11) sscanf() ssize<>() (since C++20) ssub_match (since C++11) stable_partition<>() stable_sort<>() stack<> stacktrace (since C++23) stacktrace_entry (since C++23) start_lifetime_as<>() (since C++23) static_pointer_cast<>() (since C++11) stod() (since C++11) stof() (since C++11) stoi() (since C++11) stol() (since C++11) stold() (since C++11) stoll() (since C++11) stoul() (since C++11) stoull() (since C++11) stop_callback<> (since C++20) stop_source (since C++20) stop_token (since C++20) strcat() strchr() strcmp() strcoll() strcpy() strcspn() streambuf streamoff streampos streamsize strerror() strftime() strict_weak_order<> (since C++20) string ▶ string_literals (since C++14) string_view (since C++17) ▶ string_view_literals (since C++17) stringbuf stringstream strlen() strncat() strncmp() strncpy() strong_order (since C++20) strong_ordering (since C++20) strpbrk() strrchr() strspn() strstr() strstream (deprecated in C++98) strstreambuf (deprecated in C++98) strtod() strtof() (since C++11) strtoimax() (since C++11) strtok() strtol() strtold() strtoll() (since C++11) strtoul() strtoull() (since C++11) strtoumax() (since C++11) strxfrm() syncbuf (since C++20) student_t_distribution<> (since C++11) sub_match<> (since C++11) subtract_with_carry_engine<> (since C++11) suspend_always (since C++20) suspend_never (since C++20) swap<>() swap_ranges<>() swappable<> (since C++20) swappable_with<> (since C++20) swprintf() swscanf() system() system_category (since C++11) system_error (since C++11)
Add dot: tan() tan<>() (std::complex) tan<>() (std::valarray) tan() tanf() (since C++11) tanh() tanh<>() (std::complex) tanh<>() (std::valarray) tanhf() (since C++11) tanhl() (since C++11) tanl() (since C++11) tera (since C++11) terminate() terminate_handler tgamma() (since C++11) tgammaf() (since C++11) tgammal() (since C++11) ▶ this_thread thread (since C++11) three_way_comparable<> (since C++20) three_way_comparable_with<> (since C++20) throw_with_nested<>() (since C++11) tie<>() (since C++11) time() time_base time_get<> time_get_byname<> time_put<> time_put_byname<> time_t timed_mutex (since C++11) timespec (since C++17) timespec_get() (since C++17) tm tmpfile() tmpnam() to_address<>() (since C++20) to_array<>() (since C++20) to_chars() (since C++17) to_chars_result (since C++17) to_integer<>() (since C++17) to_string() (since C++11) to_wstring() (since C++11) tolower() tolower<>() (locale) totally_ordered<> (since C++20) totally_ordered_with<> (since C++20) toupper() toupper<>() (locale) to_underlying<>() (since C++23) towctrans() towlower() towupper() transform<>() transform_exclusive_scan<>() (since C++17) transform_inclusive_scan<>() (since C++17) transform_reduce<>() (since C++17) true_type (since C++11) trunc() (since C++11) truncf() (since C++11) truncl() (since C++11) try_lock<>() (since C++11) try_to_lock (since C++11) try_to_lock_t (since C++11) tuple<> (since C++11) tuple_cat<>() (since C++11) tuple_element<> (since C++11) tuple_element_t<> (since C++14) tuple_size<> (since C++11) tuple_size_v<> (since C++17) type_identity<> (since C++20) type_identity_t<> (since C++20) type_index (since C++11) type_info
Add dot: u16streampos (since C++11) u16string (since C++11) u16string_view (since C++17) u32streampos (since C++11) u32string (since C++11) u32string_view (since C++17) u8streampos (since C++20) u8string (since C++20) u8string_view (since C++20) uint_fast16_t (since C++11) uint_fast32_t (since C++11) uint_fast64_t (since C++11) uint_fast8_t (since C++11) uint_least16_t (since C++11) uint_least32_t (since C++11) uint_least64_t (since C++11) uint_least8_t (since C++11) uint16_t (since C++11) uint32_t (since C++11) uint64_t (since C++11) uint8_t (since C++11) uintmax_t (since C++11) uintptr_t (since C++11) uncaught_exceptions (since C++17) underflow_error underlying_type<> (since C++11) underlying_type_t<> (since C++14) unexpect (since C++23) unexpect_t (since C++23) unexpected<> (since C++23) ungetc() ungetwc() uniform_int_distribution<> (since C++11) uniform_random_bit_generator<> (since C++20) uniform_real_distribution<> (since C++11) uninitialized_construct_using_allocator<>() (since C++20) uninitialized_copy<>() uninitialized_copy_n<>() (since C++11) uninitialized_default_construct<>() (since C++17) uninitialized_default_construct_n<>() (since C++17) uninitialized_fill<>() uninitialized_fill_n<>() uninitialized_move<>() (since C++17) uninitialized_move_n<>() (since C++17) uninitialized_value_construct<>() (since C++17) uninitialized_value_construct_n<>() (since C++17) unique<>() unique_copy<>() unique_lock<> (since C++11) unique_ptr<> (since C++11) unitbuf() unordered_map<> (since C++11) unordered_multimap<> (since C++11) unordered_multiset<> (since C++11) unordered_set<> (since C++11) unreachable() (since C++23) unreachable_sentinel (since C++20) unreachable_sentinel_t (since C++20) unsigned_integral<> (since C++20) unwrap_ref_decay<> (since C++20) unwrap_ref_decay_t<> (since C++20) unwrap_reference<> (since C++20) unwrap_reference_t<> (since C++20) upper_bound<>() uppercase() use_facet<>() uses_allocator<> (since C++11) uses_allocator_v<> (since C++17) uses_allocator_construction_args<>() (since C++20)
Add dot: va_list valarray<> variant<> (since C++17) variant_alternative<> (since C++17) variant_alternative_t<> (since C++17) variant_npos (since C++17) variant_size<> (since C++17) variant_size_v<> (since C++17) vector<> vformat() (since C++20) vformat_to<>() (since C++20) vfprintf() vfscanf() (since C++11) vfwprintf() vfwscanf() (since C++11) ▶ views (since C++20) visit<>() (since C++17) visit_format_arg<>() (since C++20) void_t (since C++17) vprint_nonunicode() (since C++23) vprint_unicode() (since C++23) vprintf() vscanf() (since C++11) vsnprintf() (since C++11) vsprintf() vsscanf() (since C++11) vswprintf() vswscanf() (since C++11) vwprintf() vwscanf() (since C++11)
Add dot: wbuffer_convert<> (since C++11)(deprecated in C++17) wcerr wcin wclog wcmatch (since C++11) wcout wcregex_iterator (since C++11) wcregex_token_iterator (since C++11) wcrtomb() wcscat() wcschr() wcscmp() wcscoll() wcscpy() wcscspn() wcsftime() wcslen() wcsncat() wcsncmp() wcsncpy() wcspbrk() wcsrchr() wcsrtombs() wcsspn() wcsstr() wcstod() wcstof() (since C++11) wcstoimax() (since C++11) wcstok() wcstol() wcstold() (since C++11) wcstoll() (since C++11) wcstombs() wcstoul() wcstoull() (since C++11) wcstoumax() (since C++11) wcsub_match (since C++11) wcsxfrm() wctob() wctomb() wctrans() wctrans_t wctype() wctype_t weak_order (since C++20) weak_ordering (since C++20) weak_ptr<> (since C++11) weakly_incrementable<> (since C++20) weibull_distribution<> (since C++11) wfilebuf wformat_args (since C++20) wformat_context (since C++20) wformat_parse_context (since C++20) wformat_string<> (since C++20) wfstream wifstream wint_t wios wiostream wispanstream (since C++23) wistream wistringstream wmemchr() wmemcmp() wmemcpy() wmemmove() wmemset() wofstream wospanstream (since C++23) wostream wosyncstream (since C++20) ws<>() wspanbuf (since C++23) wspanstream (since C++23) wstreambuf wstreampos wostringstream wprintf() wregex (since C++11) wscanf() wsmatch (since C++11) wsregex_iterator (since C++11) wsregex_token_iterator (since C++11) wssub_match (since C++11) wstring wstring_convert<> (since C++11)(deprecated in C++17) wstring_view<> (since C++17) wstringbuf wstringstream wsyncbuf (since C++20)
Add dot: yocto (since C++11) yotta (since C++11)
Add dot: zepto (since C++11) zetta (since C++11)
Add dot: The header <numbers> provides several mathematical constants, such as std::numbers::pi or std::numbers::sqrt2
Add dot: Discovered in 1969 by Lewis, Goodman and Miller, adopted as "Minimal standard" in 1988 by Park and Miller
Add dot: Newer "Minimum standard", recommended by Park, Miller, and Stockmeyer in 1993
...
perator expressions have the form
Add dot: The expression returns an object such that
Add dot: If both operands have arithmetic types, or if one operand has unscoped enumeration type and the other has integral type, the usual arithmetic conversions are applied to the operands, and then
Add dot: a = b a += b a -= b a *= b a /= b a %= b a &= b a |= b a ^= b a <<= b a >>= b
Add dot: +a -a a + b a - b a * b a / b a % b ~a a & b a | b a ^ b a << b a >> b
Add dot: !a a && b a || b
Add dot: a == b a != b a < b a > b a <= b a >= b a <=> b
Add dot: a[...] *a &a a->b a.b a->*b a.*b
Add dot: static_cast converts one type to another related type  dynamic_cast converts within inheritance hierarchies  const_cast adds or removes cv-qualifiers reinterpret_cast converts type to unrelated type C-style cast converts one type to another by a mix of static_cast, const_cast, and reinterpret_cast  new creates objects with dynamic storage duration delete destructs objects previously created by the new expression and releases obtained memory area sizeof queries the size of a type sizeof... queries the size of a parameter pack (since C++11) typeid queries the type information of a type noexcept checks if an expression can throw an exception (since C++11) alignof queries alignment requirements of a type (since C++11)
Add dot: Memory resources implement memory allocation strategies that can be used by std::pmr::polymorphic_allocator
Add dot: Includes e.g. operator new, operator delete, std::set_new_handler
Add dot: Includes e.g. std::malloc, std::free
Add dot: The expression assert(E) is guaranteed to be a constant subexpression, if either
Add dot: (none)
Add dot: iscntrl iswcntrl
Add dot: isprint iswprint
Add dot: isspace iswspace
Add dot: isblank iswblank
Add dot: isgraph iswgraph
Add dot: ispunct  iswpunct
...
Add dot: Inheritance diagram
Add dot: The manipulators that are invoked without arguments (e.g. std::cout << std::boolalpha; or std::cin >> std::hex;) are implemented as functions that take a reference to a stream as their only argument. The special overloads of basic_ostream::operator<< and basic_istream::operator>> accept pointers to these functions. These functions (or instantiations of function templates) are the only addressable functions in the standard library. (since C++20)
...
...
```