### PR TITLE
CPP Fix - prevent source code parent replacement if parent is a list item

### DIFF
--- a/lib/docs/filters/cppref/clean_html.rb
+++ b/lib/docs/filters/cppref/clean_html.rb
@@ -57,7 +57,7 @@ module Docs
           node.content = ' ' if node.content.empty?
         end
 
-        css('tt', 'span > span.source-cpp', 'span.t-c', 'span.t-lc', 'span.t-dsc-see-tt').each do |node|
+        css('tt', 'span > span.source-cpp', 'span.t-c', 'span.t-lc', 'span.t-dsc-see-tt', 'div.t-li1 > span.source-cpp', 'div.t-li2 > span.source-cpp', 'div.t-li3 > span.source-cpp').each do |node|
           node.name = 'code'
           node.remove_attribute('class')
           node.content = node.content unless node.at_css('a')

--- a/lib/docs/filters/cppref/fix_code.rb
+++ b/lib/docs/filters/cppref/fix_code.rb
@@ -3,10 +3,12 @@ module Docs
     class FixCodeFilter < Filter
       def call
         css('div > span.source-c', 'div > span.source-cpp').each do |node|
-          node.inner_html = node.inner_html.gsub(/<br>\n?/, "\n").gsub("\n</p>\n", "</p>\n")
-          node.parent.name = 'pre'
-          node.parent['class'] = node['class']
-          node.parent.content = node.content
+          if (node.parent.classes||[]).none?{|className| ['t-li1','t-li2','t-li3'].include?(className) }
+            node.inner_html = node.inner_html.gsub(/<br>\n?/, "\n").gsub("\n</p>\n", "</p>\n")
+            node.parent.name = 'pre'
+            node.parent['class'] = node['class']
+            node.parent.content = node.content
+          end
         end
 
         nbsp = Nokogiri::HTML('&nbsp;').text


### PR DESCRIPTION
Fixes #2060

- Pages that have multiple source code syntax in a shared parent will fail this code section https://github.com/freeCodeCamp/devdocs/blob/0c1719eb030d8f8e89df8153a7b5d235de3376c8/lib/docs/filters/cppref/fix_code.rb#L5-L10 due to the `node.parent.content = node.content` of the first element

- Example pages
  - https://en.cppreference.com/w/cpp/io/basic_istream/get
  - https://en.cppreference.com/w/cpp/utility/to_chars
  - https://en.cppreference.com/w/cpp/language/dynamic_cast

<img width="930" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/7cef2e3c-1d31-462e-a355-a199ae97df56">

### Error in parsing
```
$ thor docs:page cpp /io/basic_istream/get  --verbose --debug
Request: en.cppreference.com/w/cpp/io/basic_istream/get                                                                                                               [200] [2623ms]
Filter: ApplyBaseUrl                                                                                                                                                           [0ms]
Filter: Container                                                                                                                                                              [2ms]
Filter: Cppref::FixCode                                                                                                                                                        [3ms]
~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call': undefined method `name=' for nil:NilClass (NoMethodError)

          node.parent.name = 'pre'
                     ^^^^^^^
```

## Explanation of PR

- On looking at some of the pages it seems that the common parent is a list item (classes `t-li1`,`t-li2`,`t-li3`) and the usage is inline code so
  - by pass current `fix_code.rb` processing if we can detect this
  - and for `clean_html.rb` formatting use `code` instead of a `pre` block


## Other pages affected

```
$ grep -i fix_code.rb:7 generate_cpp_source_no_changes.txt  -B3              
  https://en.cppreference.com/w/cpp/io/ios_base
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/utility/functional/not_fn
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/integer_literal
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/explicit_cast
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/io/basic_ostream/operator_ltlt
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/utility/to_chars
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/utility/variant/visit
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/memory/new/operator_delete
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/dynamic_cast
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/array/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/storage_duration
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/function
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/static_cast
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/reinterpret_cast
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/operator_member_access
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/language/overload_resolution
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/utility/tuple/get
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/ranges/drop_view
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/algorithm/sort_heap
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/numeric/math/fma
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/deque/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/forward_list/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/set/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/list/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/vector/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/multimap/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/multiset/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/container/map/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/utility/tuple/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/io/basic_ostream/operator_ltlt2
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/io/basic_istream/get
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
--
  https://en.cppreference.com/w/cpp/ranges/cartesian_product_view/iterator/operator_cmp
  NoMethodError: undefined method `name=' for nil:NilClass

  ~/devdocs/lib/docs/filters/cppref/fix_code.rb:7:in `block in call'
```