### PR TITLE
Fix CPP - Add support for super/subscript

### DIFF
--- a/lib/docs/filters/cppref/clean_html.rb
+++ b/lib/docs/filters/cppref/clean_html.rb
@@ -109,6 +109,16 @@ module Docs
           node['src'] = node['src'].sub! %r{https://upload.cppreference.com/mwiki/(images/[^"']+?)}, 'http://upload.cppreference.com/mwiki/\1'
         end
 
+        css('.t-su.t-su-b').each do |node|
+          node.inner_html = node.inner_html.gsub('<br>', '')
+          node.name = 'sub'
+        end
+
+        css('.t-su:not(.t-su-b)').each do |node|
+          node.inner_html = node.inner_html.gsub('<br>', '')
+          node.name = 'sup'
+        end
+
         # temporary solution due lack of mathjax/mathml support
         css('.t-mfrac').each do |node|
           fraction = Nokogiri::XML::Node.new('span', doc.document)


### PR DESCRIPTION
Fixes #1142

- Add support for super/subscript by detecting CSS class

Superscript https://en.cppreference.com/w/cpp/numeric/random/seed_seq/seed_seq
<img width="1045" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/dba43421-e7aa-4736-ba1c-a36dcfc481aa">

Subscript https://en.cppreference.com/w/cpp/algorithm/lower_bound
<img width="924" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/bbf90e31-0c66-487e-8229-a56e9810f045">

Preview of pages
<img width="643" alt="image" src="https://github.com/freeCodeCamp/devdocs/assets/892961/34af6195-112f-4242-b2f7-ac76d0fe03f4">

