### PR TITLE
Fix the regexp for Golang generic functions

### DIFF
--- a/lib/docs/filters/go/entries.rb
+++ b/lib/docs/filters/go/entries.rb
@@ -28,7 +28,7 @@ module Docs
           case node.content
           when /type\ (\w+)/
             name = "#{package}.#{$1}"
-          when /func\ (?:\(.+\)\ )?(\w+)\(/
+          when /func\ (?:\(.+\)\ )?(\w+)[\(\[]/
             name = "#{$1}()"
             name.prepend "#{$1}." if node['href'] =~ /#(\w+)\.#{$1}/
             name.prepend "#{package}."

--- a/lib/docs/scrapers/go.rb
+++ b/lib/docs/scrapers/go.rb
@@ -1,7 +1,7 @@
 module Docs
   class Go < UrlScraper
     self.type = 'go'
-    self.release = '1.21.0'
+    self.release = '1.21.5'
     self.base_url = 'https://golang.org/pkg/'
     self.links = {
       home: 'https://golang.org/',
@@ -10,10 +10,10 @@ module Docs
 
     # Run godoc locally, since https://golang.org/pkg/ redirects to https://pkg.go.dev/std with rate limiting / scraping protection.
 
-    # docker run --expose=6060 --rm -it docker.io/golang:1.18.0
-    #docker# go install golang.org/x/tools/cmd/godoc@latest
-    #docker# rm -r /usr/local/go/test/
-    #docker# godoc -http 0.0.0.0:6060 -v
+    # podman run --net host --rm -it docker.io/golang:1.21.5
+    #podman# go install golang.org/x/tools/cmd/godoc@latest
+    #podman# rm -r /usr/local/go/test/
+    #podman# godoc -http 0.0.0.0:6060 -v
     self.base_url = 'http://localhost:6060/pkg/'
 
     html_filters.push 'clean_local_urls'


### PR DESCRIPTION
Fix the regular expression of additional entries for Golang funciton signatures that are generic.

Before:
![before](https://github.com/freeCodeCamp/devdocs/assets/7692030/b6b5d57f-b591-40f2-8131-1c7d291e9986)

After:
![after](https://github.com/freeCodeCamp/devdocs/assets/7692030/e15dd02a-146c-4643-88d6-b177dd5456b0)
