### PR TITLE
Upgrade minitest dependency from 5.18.1 to 5.20.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     in_threads (1.6.0)
     method_source (1.0.0)
     mini_portile2 (2.8.4)
-    minitest (5.18.1)
+    minitest (5.20.0)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'rack/test'
 require 'app'
 
-class AppTest < MiniTest::Spec
+class AppTest < Minitest::Spec
   include Rack::Test::Methods
 
   MODERN_BROWSER = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:39.0) Gecko/20100101 Firefox/39.0'

--- a/test/lib/docs/core/doc_test.rb
+++ b/test/lib/docs/core/doc_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsDocTest < MiniTest::Spec
+class DocsDocTest < Minitest::Spec
   let :doc do
     Class.new Docs::Doc do
       self.name = 'name'

--- a/test/lib/docs/core/entry_index_test.rb
+++ b/test/lib/docs/core/entry_index_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsEntryIndexTest < MiniTest::Spec
+class DocsEntryIndexTest < Minitest::Spec
   let :entry do
     Docs::Entry.new 'name', 'path', 'type'
   end

--- a/test/lib/docs/core/filter_test.rb
+++ b/test/lib/docs/core/filter_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsFilterTest < MiniTest::Spec
+class DocsFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::Filter
 

--- a/test/lib/docs/core/instrumentable_test.rb
+++ b/test/lib/docs/core/instrumentable_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsInstrumentableTest < MiniTest::Spec
+class DocsInstrumentableTest < Minitest::Spec
   let :extended_class do
     Class.new.tap { |klass| klass.send :extend, Docs::Instrumentable }
   end

--- a/test/lib/docs/core/manifest_test.rb
+++ b/test/lib/docs/core/manifest_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class ManifestTest < MiniTest::Spec
+class ManifestTest < Minitest::Spec
   let :doc do
     doc = Class.new Docs::Scraper
     doc.name = 'TestDoc'

--- a/test/lib/docs/core/models/entry_test.rb
+++ b/test/lib/docs/core/models/entry_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class DocsEntryTest < MiniTest::Spec
+class DocsEntryTest < Minitest::Spec
   Entry = Docs::Entry
 
   let :entry do

--- a/test/lib/docs/core/models/type_test.rb
+++ b/test/lib/docs/core/models/type_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class DocsTypeTest < MiniTest::Spec
+class DocsTypeTest < Minitest::Spec
   Type = Docs::Type
 
   describe ".new" do

--- a/test/lib/docs/core/parser_test.rb
+++ b/test/lib/docs/core/parser_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsParserTest < MiniTest::Spec
+class DocsParserTest < Minitest::Spec
   def parser(content)
     Docs::Parser.new(content)
   end

--- a/test/lib/docs/core/request_test.rb
+++ b/test/lib/docs/core/request_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsRequestTest < MiniTest::Spec
+class DocsRequestTest < Minitest::Spec
   let :url do
     'http://example.com'
   end

--- a/test/lib/docs/core/requester_test.rb
+++ b/test/lib/docs/core/requester_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsRequesterTest < MiniTest::Spec
+class DocsRequesterTest < Minitest::Spec
   def stub_request(url)
     Typhoeus.stub(url).and_return(Typhoeus::Response.new)
   end

--- a/test/lib/docs/core/response_test.rb
+++ b/test/lib/docs/core/response_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsResponseTest < MiniTest::Spec
+class DocsResponseTest < Minitest::Spec
   let :response do
     Typhoeus::Response.new(options).tap do |response|
       response.extend Docs::Response

--- a/test/lib/docs/core/scraper_test.rb
+++ b/test/lib/docs/core/scraper_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsScraperTest < MiniTest::Spec
+class DocsScraperTest < Minitest::Spec
   class Scraper < Docs::Scraper
     self.type = 'scraper'
     self.base_url = 'http://example.com/'

--- a/test/lib/docs/core/scrapers/file_scraper_test.rb
+++ b/test/lib/docs/core/scrapers/file_scraper_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class FileScraperTest < MiniTest::Spec
+class FileScraperTest < Minitest::Spec
   ROOT_PATH = File.expand_path('../../../../../../', __FILE__)
 
   class Scraper < Docs::FileScraper

--- a/test/lib/docs/core/scrapers/url_scraper_test.rb
+++ b/test/lib/docs/core/scrapers/url_scraper_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class DocsUrlScraperTest < MiniTest::Spec
+class DocsUrlScraperTest < Minitest::Spec
   class Scraper < Docs::UrlScraper
     self.base_url = 'http://example.com'
     self.html_filters = Docs::FilterStack.new

--- a/test/lib/docs/core/url_test.rb
+++ b/test/lib/docs/core/url_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsUrlTest < MiniTest::Spec
+class DocsUrlTest < Minitest::Spec
   URL = Docs::URL
 
   describe ".new" do

--- a/test/lib/docs/filters/core/apply_base_url_test.rb
+++ b/test/lib/docs/filters/core/apply_base_url_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class ApplyBaseUrlFilterTest < MiniTest::Spec
+class ApplyBaseUrlFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::ApplyBaseUrlFilter
   self.filter_type = 'html'

--- a/test/lib/docs/filters/core/clean_html_test.rb
+++ b/test/lib/docs/filters/core/clean_html_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class CleanHtmlFilterTest < MiniTest::Spec
+class CleanHtmlFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::CleanHtmlFilter
 

--- a/test/lib/docs/filters/core/clean_text_test.rb
+++ b/test/lib/docs/filters/core/clean_text_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class CleanTextFilterTest < MiniTest::Spec
+class CleanTextFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::CleanTextFilter
 

--- a/test/lib/docs/filters/core/container_test.rb
+++ b/test/lib/docs/filters/core/container_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class ContainerFilterTest < MiniTest::Spec
+class ContainerFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::ContainerFilter
   self.filter_type = 'html'

--- a/test/lib/docs/filters/core/entries_test.rb
+++ b/test/lib/docs/filters/core/entries_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class EntriesFilterTest < MiniTest::Spec
+class EntriesFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::EntriesFilter
 

--- a/test/lib/docs/filters/core/inner_html_test.rb
+++ b/test/lib/docs/filters/core/inner_html_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class InnerHtmlFilterTest < MiniTest::Spec
+class InnerHtmlFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::InnerHtmlFilter
 

--- a/test/lib/docs/filters/core/internal_urls_test.rb
+++ b/test/lib/docs/filters/core/internal_urls_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class InternalUrlsFilterTest < MiniTest::Spec
+class InternalUrlsFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::InternalUrlsFilter
 

--- a/test/lib/docs/filters/core/normalize_paths_test.rb
+++ b/test/lib/docs/filters/core/normalize_paths_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class NormalizePathsFilterTest < MiniTest::Spec
+class NormalizePathsFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::NormalizePathsFilter
 

--- a/test/lib/docs/filters/core/normalize_urls_test.rb
+++ b/test/lib/docs/filters/core/normalize_urls_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class NormalizeUrlsFilterTest < MiniTest::Spec
+class NormalizeUrlsFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::NormalizeUrlsFilter
 

--- a/test/lib/docs/filters/core/parse_cf_email_test.rb
+++ b/test/lib/docs/filters/core/parse_cf_email_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class ParseCfEmailFilterTest < MiniTest::Spec
+class ParseCfEmailFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::ParseCfEmailFilter
 

--- a/test/lib/docs/filters/core/title_test.rb
+++ b/test/lib/docs/filters/core/title_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../test_helper'
 require_relative '../../../../../lib/docs'
 
-class TitleFilterTest < MiniTest::Spec
+class TitleFilterTest < Minitest::Spec
   include FilterTestHelper
   self.filter_class = Docs::TitleFilter
 

--- a/test/lib/docs/storage/abstract_store_test.rb
+++ b/test/lib/docs/storage/abstract_store_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsAbstractStoreTest < MiniTest::Spec
+class DocsAbstractStoreTest < Minitest::Spec
   InvalidPathError = Docs::AbstractStore::InvalidPathError
   LockError = Docs::AbstractStore::LockError
 

--- a/test/lib/docs/storage/file_store_test.rb
+++ b/test/lib/docs/storage/file_store_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../test_helper'
 require_relative '../../../../lib/docs'
 
-class DocsFileStoreTest < MiniTest::Spec
+class DocsFileStoreTest < Minitest::Spec
   let :store do
     Docs::FileStore.new(tmp_path)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ end
 
 ActiveSupport::TestCase.test_order = :random
 
-class MiniTest::Spec
+class Minitest::Spec
   include ActiveSupport::Testing::Assertions
 
   module DSL


### PR DESCRIPTION
Upgrades `devdocs` from `5.18.1` to `5.20.0`.

- https://github.com/minitest/minitest/releases/tag/v5.19.0
- https://github.com/minitest/minitest/releases/tag/v5.20.0

Note, requires `MiniTest` ➡ `minitest` migration.

Supersedes the following automated bump.
- https://github.com/freeCodeCamp/devdocs/pull/2023