### PR TITLE
Update Ruby, Rails, and Minitest docs

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -242,11 +242,12 @@ done
 ### Ruby / Minitest
 ### Ruby on Rails
 * Download a release at https://github.com/rails/rails/releases or clone https://github.com/rails/rails.git (checkout to the branch of the rails' version that is going to be scraped)
-* Open "railties/lib/rails/api/task.rb" and comment out any code related to sdoc ("configure_sdoc")
-* Run "bundle install --without db && bundle exec rake rdoc" (in the Rails directory)
-* Run "cd guides && bundle exec rake guides:generate:html"
-* Copy the "guides/output" directory to "html/guides"
-* Copy the "html" directory to "docs/rails~[version]"
+* Open `railties/lib/rails/api/task.rb` and comment out any code related to sdoc (`configure_sdoc`)
+* Run `bundle config set --local without 'db job'` (in the Rails directory)
+* Run `bundle install && bundle exec rake rdoc` (in the Rails directory)
+* Run `cd guides && bundle exec rake guides:generate:html`
+* Copy the `guides/output` directory to `html/guides`
+* Copy the `html` directory to `docs/rails~[version]`
 
 ### Ruby
 Download the tarball of Ruby from https://www.ruby-lang.org/en/downloads/, extract it, run

--- a/lib/docs/filters/rails/entries.rb
+++ b/lib/docs/filters/rails/entries.rb
@@ -40,7 +40,7 @@ module Docs
 
       def get_name
         if slug.start_with?('guides')
-          name = at_css('#feature h2').content.strip
+          name = at_css('#mainCol h2').content.strip
           name.remove! %r{\s\(.+\)\z}
           return name
         end

--- a/lib/docs/scrapers/rdoc/minitest.rb
+++ b/lib/docs/scrapers/rdoc/minitest.rb
@@ -8,7 +8,7 @@ module Docs
 
     self.name = 'Ruby / Minitest'
     self.slug = 'minitest'
-    self.release = '5.17.0'
+    self.release = '5.20.0'
     self.links = {
       code: 'https://github.com/minitest/minitest'
     }

--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -75,8 +75,12 @@ module Docs
       end
     end
 
+    version '7.1' do
+      self.release = '7.1.2'
+    end
+
     version '7.0' do
-      self.release = '7.0.4'
+      self.release = '7.0.8'
     end
 
     version '6.1' do

--- a/lib/docs/scrapers/rdoc/ruby.rb
+++ b/lib/docs/scrapers/rdoc/ruby.rb
@@ -69,16 +69,20 @@ module Docs
       Licensed under their own licenses.
     HTML
 
-    version '3.2' do
-      self.release = '3.2.0'
+    version '3.3' do
+      self.release = '3.3.0'
     end
-    
+
+    version '3.2' do
+      self.release = '3.2.2'
+    end
+
     version '3.1' do
-      self.release = '3.1.3'
+      self.release = '3.1.4'
     end
 
     version '3' do
-      self.release = '3.0.0'
+      self.release = '3.0.6'
     end
 
     version '2.7' do


### PR DESCRIPTION
Heavily based on the following.
- https://github.com/freeCodeCamp/devdocs/pull/1902

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Sources
- https://www.ruby-lang.org/en/downloads/releases/
- https://rubyonrails.org/category/releases
- https://github.com/minitest/minitest/tags