### PR TITLE
Upgrade ActiveSupport from 7.0.8 to 7.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
+    base64 (0.2.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
+    bigdecimal (3.1.5)
     browser (5.3.1)
     byebug (11.1.3)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     daemons (1.4.1)
+    drb (2.2.0)
+      ruby2_keywords
     erubi (1.12.0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -28,7 +38,7 @@ GEM
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_optim (0.31.3)
       exifr (~> 1.2, >= 1.2.2)
@@ -47,6 +57,7 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.2.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.0.1)

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -56,7 +56,6 @@ class App < Sinatra::Application
 
     SpritesCLI.new.invoke(:generate, [], :disable_optimization => true)
 
-    require 'active_support/per_thread_registry'
     require 'active_support/cache'
     sprockets.cache = ActiveSupport::Cache.lookup_store :file_store, root.join('tmp', 'cache', 'assets', environment.to_s)
   end


### PR DESCRIPTION
Upgrades ActiveSupport from 7.0.8 to 7.1.2 and removes deprecated `per_thread_registry` usage.

- [7.1.2 Changelog](https://github.com/rails/rails/blob/6b93fff8af32ef5e91f4ec3cfffb081d0553faf0/activesupport/CHANGELOG.md)

This upgrade and fix was inspired by https://github.com/freeCodeCamp/devdocs/pull/2073#issuecomment-1879764828. Thus, this PR is an alternative PR to the following bump PR. Ideally one or the other is merged and the other closed.
- https://github.com/freeCodeCamp/devdocs/pull/2073

Tests work fine locally. CI looks good too.

![Screenshot from 2024-01-07 08-17-39](https://github.com/freeCodeCamp/devdocs/assets/1557529/0bf2bde3-2807-4838-959a-1d37f704e085)
