### PR TITLE
Bump `bundler` from `2.4.6` to `2.5.4`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,4 +180,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.6
+   2.5.4


### PR DESCRIPTION
Bump `bundler` from `2.4.6` to `2.5.4`. There have been 23 released between `2.4.6` and `2.5.4`, thus this upgrade brings with it substantial fixes from a performance, usability, and security aspects. ([changelog](https://github.com/rubygems/rubygems/blob/8ffa73df3a250623b13c5bf7ab48ed8b8e84e46f/bundler/CHANGELOG.md))

Should be independent of the Ruby 3.3.0 upgrade but a nice thing to ship along with it, for sure.
- https://github.com/freeCodeCamp/devdocs/pull/2110

