### PR TITLE
Update GitHub Action based CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@v4.1.1
     - name: Set up Ruby
       uses: ruby/setup-ruby@a05e47355e80e57b9a67566a813648fa67d92011 # v1.157.0
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
     - name: Set up Ruby
-      uses: ruby/setup-ruby@a05e47355e80e57b9a67566a813648fa67d92011 # v1.157.0
+      uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests


### PR DESCRIPTION
Update GitHub Action based CI workflow, primarily to support Ruby 3.3.0 (https://github.com/freeCodeCamp/devdocs/pull/2110) but also for the general long term health of the project/repo. This PR does the following.
- Updates runner from `ubuntu-20.04` to `ubuntu-latest` which is 22.04 LTS ([runs-on docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on))
- Updates actions/checkout action from `2.7.0` to `4.1.1` ([4.1.1 release notes](https://github.com/actions/checkout/releases/tag/v4.1.1))
- Updates ruby/setup-ruby action from `1.157.0` to `1.165.1` ([1.165.1 release notes](https://github.com/ruby/setup-ruby/releases/tag/v1.165.1))

The last one should fix CI for Ruby 3.3.0 which is currently failing due to only having access to up to `3.3.0-preview2`, likely due to the version of ruby/setup-ruby.

Note, usually I don't lock versions so we very well could use `actions/checkout@4` and `ruby/setup-ruby` just like so but such could unexpectedly break at some point so I went with a more conservative approach akin to what was already in place.