### PR TITLE
Add Raycast dev docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Made something cool? Feel free to open a PR to add a new row to this table! You 
 | [waiting-for-dev/vim-www](https://github.com/waiting-for-dev/vim-www)                       | Vim plugin                           | ![Latest GitHub commit](https://img.shields.io/github/last-commit/waiting-for-dev/vim-www?logo=github&label)         | ![GitHub stars](https://img.shields.io/github/stars/waiting-for-dev/vim-www?logo=github&label)         |
 | [luckasRanarison/nvim-devdocs](https://github.com/luckasRanarison/nvim-devdocs)             | Neovim plugin                        | ![Latest GitHub commit](https://img.shields.io/github/last-commit/luckasRanarison/nvim-devdocs?logo=github&label)    | ![GitHub stars](https://img.shields.io/github/stars/luckasRanarison/nvim-devdocs?logo=github&label)    |
 | [toiletbril/dedoc](https://github.com/toiletbril/dedoc)                                     | Terminal based viewer                | ![Latest GitHub commit](https://img.shields.io/github/last-commit/toiletbril/dedoc?logo=github&label)                | ![GitHub stars](https://img.shields.io/github/stars/toiletbril/dedoc?logo=github&label)                |
+| [Raycast Devdocs](https://www.raycast.com/pomdtr/devdocs)                                     | Raycast extension                | Unavailable                | Unavailable                |
 
 ## Copyright / License
 


### PR DESCRIPTION
Added a link to Raycast dev docs integration. Unfortunately the commit date and stars are not available because the extension lives in a monorepo: https://github.com/raycast/extensions/tree/93031d2d2e6a8b072fc7d9806ecb1eaee4f250aa/extensions/devdocs/