### PR TITLE
Update kubernetes.rb to add versions available

### DIFF
--- a/lib/docs/scrapers/kubernetes.rb
+++ b/lib/docs/scrapers/kubernetes.rb
@@ -34,11 +34,6 @@ module Docs
       self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
     end
 
-   version '1.27' do
-      self.release = "#{version}"
-      self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
-    end
-
    version '1.26' do
       self.release = "#{version}"
       self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"

--- a/lib/docs/scrapers/kubernetes.rb
+++ b/lib/docs/scrapers/kubernetes.rb
@@ -20,14 +20,39 @@ module Docs
 
     # latest version has a special URL that does not include the version identifier 
     version do
-      self.release = "1.26"
+      self.release = "1.29"
       self.base_url = "https://kubernetes.io/docs/reference/kubernetes-api/"
     end
 
-    version '1.20' do
+    version '1.28' do
       self.release = "#{version}"
       self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
     end
+
+    version '1.27' do
+      self.release = "#{version}"
+      self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
+    end
+
+   version '1.27' do
+      self.release = "#{version}"
+      self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
+    end
+
+   version '1.26' do
+      self.release = "#{version}"
+      self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
+   end
+
+   version '1.25' do
+      self.release = "#{version}"
+      self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
+   end
+
+   version '1.24' do
+      self.release = "#{version}"
+      self.base_url = "https://v#{version.sub('.', '-')}.docs.kubernetes.io/docs/reference/kubernetes-api/"
+   end
 
     def get_latest_version(opts)
       get_latest_github_release('kubernetes', 'kubernetes', opts)


### PR DESCRIPTION
Previously only the latest and v1.20 was available, this change adds the latest version 1.29 and the previous five versions through 1.24 which are common K8S releases in circulation.



<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

TBD on these:
- [ ] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ ] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
