### PR TITLE
Add Django 5.0

### DIFF
--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,6 +34,11 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '5.0' do
+      self.release = '5.0'
+      self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"
+    end
+
     version '4.2' do
       self.release = '4.2'
       self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"


### PR DESCRIPTION
Released 4 December: https://www.djangoproject.com/weblog/2023/dec/04/django-50-released/

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
