### PR TITLE
Add support for Rails 7.1.3 docs

### DIFF
--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -76,7 +76,7 @@ module Docs
     end
 
     version '7.1' do
-      self.release = '7.1.2'
+      self.release = '7.1.3'
     end
 
     version '7.0' do


### PR DESCRIPTION
Adds support for Rails 7.1.3.

https://rubyonrails.org/2024/1/16/Rails-7-1-3-has-been-released

Follow up to
- https://github.com/freeCodeCamp/devdocs/pull/2104

Tangentially related
- https://github.com/freeCodeCamp/devdocs/pull/2212

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
