### PR TITLE
Grid-like Layout for TailwindCSS Color Documentation

### DIFF
--- a/assets/stylesheets/pages/_tailwindcss.scss
+++ b/assets/stylesheets/pages/_tailwindcss.scss
@@ -2,7 +2,6 @@
   // Styling for customizing-colors page - color swatches (based on original tailwind display design)
   .colors {
     display: flex;
-    flex-direction: column;
     gap: 1.2rem;
 
     // Text offset


### PR DESCRIPTION
This PR updates the TailwindCSS colors documentation to use a better, grid-like layout. It closes #2172.

**Old**
![Old TailwindCSS Colors Docs](https://github.com/freeCodeCamp/devdocs/assets/144612896/03126458-a3fc-4cae-8af0-8381353cfd92)

**New**
![New TailwindCSS Colors Docs](https://github.com/freeCodeCamp/devdocs/assets/144612896/b34dee26-a291-4aa1-b56d-942863b7926e)
