### PR TITLE
Add pandas 2.2.2 documentation

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -183,9 +183,12 @@ mv ./usr/share/doc/openjdk-16-jre-headless/api/ docs/openjdk~$VERSION
 
 ## Pandas
 
+From the home directory; `devdocs`, execute below:
+
 ```sh
-curl https://pandas.pydata.org/docs/pandas.zip | bsdtar --extract --file - --directory=docs/pandas~1
+curl https://pandas.pydata.org/docs/pandas.zip -o tmp.zip && unzip tmp.zip -d docs/pandas~2 && rm tmp.zip
 ```
+
 
 ## PHP
 Click the link under the "Many HTML files" column on https://www.php.net/download-docs.php, extract the tarball, change its name to `php` and put it in `docs/`.

--- a/lib/docs/scrapers/pandas.rb
+++ b/lib/docs/scrapers/pandas.rb
@@ -16,6 +16,29 @@ module Docs
       Licensed under the 3-clause BSD License.
     HTML
 
+    version '2' do
+      self.release = '2.2.2'
+      self.base_url = "https://pandas.pydata.org/pandas-docs/version/#{self.release}/"
+
+      html_filters.push 'pandas/clean_html', 'pandas/entries'
+
+      options[:container] = 'main section'
+
+      options[:skip_patterns] = [
+        /development/,
+        /getting_started/,
+        /whatsnew/
+      ]
+
+      options[:skip] = [
+        'panel.html',
+        'pandas.pdf',
+        'pandas.zip',
+        'ecosystem.html'
+      ]
+
+    end
+
     version '1' do
       self.release = '1.5.0'
       self.base_url = "https://pandas.pydata.org/pandas-docs/version/#{self.release}/"


### PR DESCRIPTION
Released 10 April 2024 https://pandas.pydata.org/docs/whatsnew/v2.2.2.html

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
