### PR TITLE
Fix browsing file names that contain percent-encoded @ symbol

### DIFF
--- a/assets/javascripts/models/doc.js
+++ b/assets/javascripts/models/doc.js
@@ -71,9 +71,14 @@ app.models.Doc = class Doc extends app.Model {
     return this.entry;
   }
 
+  encodePath(path) {
+    return path.replace(/@/g, "%40");
+  }
+
   findEntryByPathAndHash(path, hash) {
     let entry;
-    if (hash && (entry = this.entries.findBy("path", `${path}#${hash}`))) {
+    let encodedPath = this.encodePath(path);
+    if (hash && (entry = this.entries.findBy("path", `${encodedPath}#${hash}`))) {
       return entry;
     } else if (path === "index") {
       return this.toEntry();


### PR DESCRIPTION
This fixes browsing the Godot docs for @GlobalScope and @GDScript, by adding a short encode method to handle the `@` symbol.

The bug was mentioned in #1853 , where the author was unable to determine why they couldn't browse these files.

This PR adds the encoding on the frontend, rather than trying to override filename generation in scrapers. It's possible that this will impact other documentation sources, but I expect those would also need to have encoded the @ as %40 in their own doc filenames. This PR only impacts filename matching, not entries (which already use slugs).

 If reviewers knows of other languages that use `@` in a similar way, I'd be happy to test against them!

This doesn't use Javascript's [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) or [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) methods, because encodeURI doesn't include `@`, and encodeURIComponent includes `/` which we don't want. If there are other URL-reserved characters
that would be useful to encode, those should be easy enough to add to the short method I added here.

## QA

Testing done in local instance of devdocs.

- [x] tested against some selected packaged docs (making sure I didn't break anything):
  - [x] godot 2.1
  - [x] godot 3.5
  - [x] ansible 
  - [x] HTML 
  - [x] elixir 1.15
- [x] tested against locally generated godot docs:
  - [x] godot 3.5
  - [x] godot 4.2 (WIP, will be separate PR)  

