### PR TITLE
Update Ruby docs versions

### DIFF
--- a/lib/docs/scrapers/rdoc/ruby.rb
+++ b/lib/docs/scrapers/rdoc/ruby.rb
@@ -70,19 +70,19 @@ module Docs
     HTML
 
     version '3.3' do
-      self.release = '3.3.0'
+      self.release = '3.3.2'
     end
 
     version '3.2' do
-      self.release = '3.2.2'
+      self.release = '3.2.3'
     end
 
     version '3.1' do
-      self.release = '3.1.4'
+      self.release = '3.1.6'
     end
 
     version '3' do
-      self.release = '3.0.6'
+      self.release = '3.0.7'
     end
 
     version '2.7' do


### PR DESCRIPTION
Adding updated Ruby versions for docs.

- https://www.ruby-lang.org/en/news/2024/05/30/ruby-3-3-2-released/
- https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
- https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
- https://www.ruby-lang.org/en/news/2024/05/29/ruby-3-1-6-released/
- https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
- https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/

Tangentially related
- https://github.com/freeCodeCamp/devdocs/pull/2155

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ x Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
