### PR TITLE
Update Elixir documentation (1.16 and 1.17)

### DIFF
--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -2,32 +2,12 @@ module Docs
   class Elixir
     class CleanHtmlFilter < Filter
       def call
-        if current_url.path.start_with?('/getting-started')
-          guide
-        else
-          api
-        end
+        api
         doc
       end
 
-      def guide
-        @doc = at_css('#content article')
-
-        css('pre > code').each do |node|
-          node.parent.content = node.content
-        end
-
-        css('div > pre.highlight').each do |node|
-          node.content = node.content
-          node['data-language'] = node.parent['class'][/language-(\w+)/, 1]
-          node.parent.before(node).remove
-        end
-      end
-
       def api
-        css('.hover-link', 'footer', ':not(.detail-header) > .view-source').remove
-
-        css('h1 .settings').remove
+        css('.top-search').remove
 
         css('.summary').each do |node|
           node.name = 'dl'
@@ -63,6 +43,11 @@ module Docs
           detail.css('.docstring h2').each do |node|
             node.name = 'h4'
           end
+        end
+
+        css('h1 a.icon-action[title="View Source"]').each do |node|
+          node['class'] = 'source'
+          node.content = "Source"
         end
 
         css('pre').each do |node|

--- a/lib/docs/scrapers/elixir.rb
+++ b/lib/docs/scrapers/elixir.rb
@@ -4,7 +4,7 @@ module Docs
 
     self.name = 'Elixir'
     self.type = 'elixir'
-    self.root_path = 'api-reference.html'
+    self.root_path = 'introduction.html'
     self.links = {
       home: 'https://elixir-lang.org/',
       code: 'https://github.com/elixir-lang/elixir'
@@ -12,193 +12,45 @@ module Docs
 
     html_filters.push 'elixir/clean_html', 'elixir/entries', 'title'
 
-    options[:container] = ->(filter) {
-      filter.current_url.path.start_with?('/getting-started') ? '#main' : '#content'
-    }
+    options[:container] = '#content'
     options[:title] = false
     options[:root_title] = 'Elixir'
 
     options[:attribution] = <<-HTML
-      &copy; 2012 Plataformatec<br>
+      &copy; 2012 - 2024 The Elixir Team<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 
     def initial_urls
-      [ "https://hexdocs.pm/elixir/#{self.class.release}/api-reference.html",
+      [ "https://hexdocs.pm/elixir/#{self.class.release}/introduction.html",
         "https://hexdocs.pm/eex/#{self.class.release}/EEx.html",
         "https://hexdocs.pm/ex_unit/#{self.class.release}/ExUnit.html",
         "https://hexdocs.pm/iex/#{self.class.release}/IEx.html",
         "https://hexdocs.pm/logger/#{self.class.release}/Logger.html",
-        "https://hexdocs.pm/mix/#{self.class.release}/Mix.html",
-        "https://elixir-lang.org/getting-started/introduction.html" ]
+        "https://hexdocs.pm/mix/#{self.class.release}/Mix.html" ]
     end
 
-    version '1.15' do
-      self.release = '1.15.4'
+    version '1.17' do
+      self.release = '1.17.0'
       self.base_urls = [
         "https://hexdocs.pm/elixir/#{release}/",
         "https://hexdocs.pm/eex/#{release}/",
         "https://hexdocs.pm/ex_unit/#{release}/",
         "https://hexdocs.pm/iex/#{release}/",
         "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
+        "https://hexdocs.pm/mix/#{release}/"
       ]
     end
 
-    version '1.14' do
-      self.release = '1.14.1'
+    version '1.16' do
+      self.release = '1.16.3'
       self.base_urls = [
         "https://hexdocs.pm/elixir/#{release}/",
         "https://hexdocs.pm/eex/#{release}/",
         "https://hexdocs.pm/ex_unit/#{release}/",
         "https://hexdocs.pm/iex/#{release}/",
         "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.13' do
-      self.release = '1.13.4'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.12' do
-      self.release = '1.12.0'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.11' do
-      self.release = '1.11.2'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.10' do
-      self.release = '1.10.4'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.9' do
-      self.release = '1.9.4'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.8' do
-      self.release = '1.8.2'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.7' do
-      self.release = '1.7.4'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.6' do
-      self.release = '1.6.6'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.5' do
-      self.release = '1.5.3'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.4' do
-      self.release = '1.4.5'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
-      ]
-    end
-
-    version '1.3' do
-      self.release = '1.3.4'
-      self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
-        'https://elixir-lang.org/getting-started/'
+        "https://hexdocs.pm/mix/#{release}/"
       ]
     end
 

--- a/lib/docs/scrapers/elixir.rb
+++ b/lib/docs/scrapers/elixir.rb
@@ -17,7 +17,7 @@ module Docs
     options[:root_title] = 'Elixir'
 
     options[:attribution] = <<-HTML
-      &copy; 2012 - 2024 The Elixir Team<br>
+      &copy; 2012-2024 The Elixir Team<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 
@@ -31,7 +31,7 @@ module Docs
     end
 
     version '1.17' do
-      self.release = '1.17.0'
+      self.release = '1.17.2'
       self.base_urls = [
         "https://hexdocs.pm/elixir/#{release}/",
         "https://hexdocs.pm/eex/#{release}/",
@@ -51,6 +51,177 @@ module Docs
         "https://hexdocs.pm/iex/#{release}/",
         "https://hexdocs.pm/logger/#{release}/",
         "https://hexdocs.pm/mix/#{release}/"
+      ]
+    end
+
+    # scraping of older versions is no longer supported!
+
+    version '1.15' do
+      self.release = '1.15.4'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.14' do
+      self.release = '1.14.1'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.13' do
+      self.release = '1.13.4'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.12' do
+      self.release = '1.12.0'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.11' do
+      self.release = '1.11.2'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.10' do
+      self.release = '1.10.4'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.9' do
+      self.release = '1.9.4'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.8' do
+      self.release = '1.8.2'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.7' do
+      self.release = '1.7.4'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.6' do
+      self.release = '1.6.6'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.5' do
+      self.release = '1.5.3'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.4' do
+      self.release = '1.4.5'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
+      ]
+    end
+
+    version '1.3' do
+      self.release = '1.3.4'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/",
+        'https://elixir-lang.org/getting-started/'
       ]
     end
 


### PR DESCRIPTION
The guides have moved from a separate page into the same documentation system. This required shuffling of the cleanup functions, which is subtly incompatible with the docs of the older versions, or would have required if/else in various places. For legibility, I thus opted to remove old versions.

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
