### PR TITLE
fixing yii scraper - the url scheme for the api docs changed (with everything else staying the same)

### DIFF
--- a/lib/docs/scrapers/yii.rb
+++ b/lib/docs/scrapers/yii.rb
@@ -8,9 +8,8 @@ module Docs
     HTML
 
     version '2.0' do
-      self.release = '2.0.12'
-      self.base_url = 'http://www.yiiframework.com/doc-2.0/'
-      self.root_path = 'index.html'
+      self.release = '2.0.50'
+      self.base_url = 'https://www.yiiframework.com/doc/api/2.0'
       self.links = {
         home: 'http://www.yiiframework.com/',
         code: 'https://github.com/yiisoft/yii2'

--- a/lib/docs/scrapers/yii.rb
+++ b/lib/docs/scrapers/yii.rb
@@ -3,7 +3,7 @@ module Docs
     self.type = 'yii'
 
     options[:attribution] = <<-HTML
-      &copy; 2008&ndash;2017 by Yii Software LLC<br>
+      &copy; 2008&ndash;2024 by Yii Software LLC<br>
       Licensed under the three clause BSD license.
     HTML
 


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
