### PR TITLE
Add Laravel 11 documentation

### DIFF
--- a/lib/docs/scrapers/laravel.rb
+++ b/lib/docs/scrapers/laravel.rb
@@ -29,6 +29,20 @@ module Docs
       Laravel is a trademark of Taylor Otwell.
     HTML
 
+    version '11' do
+      self.release = '11.11.1'
+      self.root_path = '/api/11.x/index.html'
+      self.initial_paths = %w(/docs/11.x/installation /api/11.x/classes.html)
+
+      options[:only_patterns] = [%r{\A/api/11\.x/}, %r{\A/docs/11\.x/}]
+
+      options[:fix_urls] = ->(url) do
+        url.sub! %r{11.x/+}, "11.x/"
+        url.sub! %r{#{Regexp.escape(Laravel.base_url)}/docs\/(?![1-9]?\d)}, "#{Laravel.base_url}/docs/11.x/"
+        url
+      end
+    end
+
     version '10' do
       self.release = '10.13.0'
       self.root_path = '/api/10.x/index.html'


### PR DESCRIPTION
If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
