### PR TITLE
Update Vulkan version

### DIFF
--- a/lib/docs/scrapers/vulkan.rb
+++ b/lib/docs/scrapers/vulkan.rb
@@ -2,11 +2,11 @@ module Docs
   class Vulkan < UrlScraper
     self.name = 'Vulkan'
     self.type = 'simple'
-    self.release = '1.0.59'
-    self.base_url = 'https://www.khronos.org/registry/vulkan/specs/1.0/'
-    self.root_path = 'apispec.html'
+    self.release = '1.3.289'
+    self.base_url = 'https://registry.khronos.org/vulkan/specs/1.3/html/'
+    self.root_path = 'vkspec.html'
     self.links = {
-      home: 'https://www.khronos.org/vulkan/'
+      home: 'https://registry.khronos.org/vulkan'
     }
 
     html_filters.push 'vulkan/entries', 'vulkan/clean_html', 'title'
@@ -16,7 +16,7 @@ module Docs
     options[:root_title] = 'Vulkan API Reference'
 
     options[:attribution] = <<-HTML
-      &copy; 2014&ndash;2017 Khronos Group Inc.<br>
+      &copy; 2024 Khronos Group Inc.<br>
       Licensed under the Creative Commons Attribution 4.0 International License.<br>
       Vulkan and the Vulkan logo are registered trademarks of the Khronos Group Inc.
     HTML


### PR DESCRIPTION
Hello, so I recently discovered this tool with much excitement as Khronos Docs can sometimes be cumbersome to navigate. I was disappointed to learn the Vulkan version was only 1.0. I attempted to quickly update the Vulkan scraper to the new domain and version, but upon running `bundle exec thor docs:page vulkan` or any other command to pull/build/generate docs I get ssl cert error: 

`bundle exec thor docs:page vulkan`

I have verified the cert on the remote host. I also noticed an [old PR](https://github.com/freeCodeCamp/devdocs/pull/2117) suffered the same error due to changes in attribution methods. Since it has been 2 years I was wondering if something similar has changed causing these issues with the Vulkan scraper.

I attempted the same thor command above, with an unmodified version of the Vulkan scraper on the main branch, and it failed with the same error. Any suggestions?

<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [X] Updated the versions and releases in the scraper file
- [X] Ensured the license is up-to-date
- [X] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ ] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
