### PR TITLE
Update QUnit documentation (2.21.0)

### DIFF
--- a/lib/docs/filters/qunit/clean_html.rb
+++ b/lib/docs/filters/qunit/clean_html.rb
@@ -4,7 +4,7 @@ module Docs
   class Qunit
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.content[role="main"]')
+        @doc = at_css('.content[role="main"] > article')
         css('.sidebar').remove
         css('pre').each do |node|
           node['data-language'] = 'javascript'

--- a/lib/docs/scrapers/qunit.rb
+++ b/lib/docs/scrapers/qunit.rb
@@ -4,8 +4,8 @@ module Docs
   class Qunit < UrlScraper
     self.name = 'QUnit'
     self.type = 'qunit'
-    self.release = '2.19.3'
-    self.base_url = 'https://api.qunitjs.com/'
+    self.release = '2.21.0'
+    self.base_url = 'https://qunitjs.com/api/'
     self.root_path = '/'
     self.links = {
       home: 'https://qunitjs.com/',
@@ -18,13 +18,14 @@ module Docs
 
     options[:container] = '.main'
     options[:skip_patterns] = [
-      /deprecated/,
       /^QUnit$/,
       /^assert$/,
       /^callbacks$/,
       /^async$/,
       /^config$/,
       /^extension$/,
+      /^deprecated$/,
+      /^removed$/,
     ]
 
     options[:attribution] = <<-HTML


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

```
$ bundle exec thor docs:download qunit
…
$ bundle exec thor docs:generate qunit
```
```
Proceed? (y/n) y
Entries: (7 KB, +1 KB)
  Updated: 64
  Created: 6
    + assert.closeTo()
    + QUnit.config.modules
    + QUnit.dump.setParser()
    + QUnit.load()
    + QUnit.test.if()
    + QUnit.urlParams
  Deleted: 1
    - QUnit.push()
Types:
  Updated: 5
  Created: 0
  Deleted: 0
Files: (0.3 MB, +0.1 MB)
  Updated: 65
  Created: 6
    + qunit/test.if
    + qunit/load
    + config/modules
    + assert/closeto
    + extension/qunit.dump.setparser
    + extension/qunit.urlparams
  Deleted: 1
    - extension/qunit.push
Done
```