### PR TITLE
fix rust 1.79.0 docs std crate indexing

### DIFF
--- a/assets/stylesheets/pages/_rust.scss
+++ b/assets/stylesheets/pages/_rust.scss
@@ -14,7 +14,7 @@
   em.stab, span.stab { @extend %label; }
   em.stab.unstable, span.stab.unstable { @extend %label-orange; }
   .out-of-band { float: right; }
-  .since, .srclink {
+  .since, .src, .rightside {
     float: right;
     margin-left: .5rem;
   }

--- a/lib/docs/filters/rust/clean_html.rb
+++ b/lib/docs/filters/rust/clean_html.rb
@@ -19,6 +19,7 @@ module Docs
           css('.anchor').remove
 
           css('.main-heading > h1').each do |node|
+            node.at('button')&.remove
             node.parent.name = 'h1'
             node.parent.content = node.content
           end

--- a/lib/docs/filters/rust/clean_html.rb
+++ b/lib/docs/filters/rust/clean_html.rb
@@ -30,6 +30,8 @@ module Docs
           end
         end
 
+        css('.doc-anchor').remove
+
         # Fix notable trait sections
         css('.method, .rust.trait').each do |node|
           traitSection = node.at_css('.notable-traits')

--- a/lib/docs/filters/rust/entries.rb
+++ b/lib/docs/filters/rust/entries.rb
@@ -9,6 +9,7 @@ module Docs
         elsif slug == 'error-index'
           'Compiler Errors'
         else
+          at_css('main h1').at_css('button')&.remove
           name = at_css('main h1').content.remove(/\A.+\s/).remove('⎘')
           mod = slug.split('/').first
           name.prepend("#{mod}::") unless name.start_with?(mod)

--- a/lib/docs/scrapers/rust.rb
+++ b/lib/docs/scrapers/rust.rb
@@ -3,7 +3,7 @@
 module Docs
   class Rust < UrlScraper
     self.type = 'rust'
-    self.release = '1.79.0'
+    self.release = '1.80.0'
     self.base_url = 'https://doc.rust-lang.org/'
     self.root_path = 'book/index.html'
     self.initial_paths = %w(


### PR DESCRIPTION
fixes #2290
<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
