### PR TITLE
Add Django 5.1

### DIFF
--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,6 +34,11 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '5.1' do
+      self.release = '5.1'
+      self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"
+    end
+
     version '5.0' do
       self.release = '5.0'
       self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"


### PR DESCRIPTION
Released August 7: https://www.djangoproject.com/weblog/2024/aug/07/django-51-released/

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

(Adapting from my Django 5.0 PR: #2147.)