### PR TITLE
Update Django REST Framework to 3.15.2

### DIFF
--- a/lib/docs/scrapers/mkdocs/django_rest_framework.rb
+++ b/lib/docs/scrapers/mkdocs/django_rest_framework.rb
@@ -1,7 +1,7 @@
 module Docs
   class DjangoRestFramework < Mkdocs
     self.name = 'Django REST Framework'
-    self.release = '3.14.0'
+    self.release = '3.15.2'
     self.slug = 'django_rest_framework'
     self.base_url = 'https://www.django-rest-framework.org/'
     self.root_path = 'index.html'


### PR DESCRIPTION
Released June 14th: https://www.django-rest-framework.org/community/release-notes/#315x-series

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Checked against previous update commit: 008749f6f1eb31cf7053162c48e162c3e714a0b2.