### PR TITLE
Update Git to 2.46.0

### DIFF
--- a/lib/docs/scrapers/git.rb
+++ b/lib/docs/scrapers/git.rb
@@ -15,9 +15,10 @@ module Docs
     options[:only_patterns] = [/\A\/[^\/]+\z/]
     options[:skip] = %w(/howto-index.html)
 
+    # https://github.com/git/git-scm.com/blob/main/MIT-LICENSE.txt
     options[:attribution] = <<-HTML
-      &copy; 2005&ndash;2024 Linus Torvalds and others<br>
-      Licensed under the GNU General Public License version 2.
+      &copy; 2012&ndash;2024 Scott Chacon and others<br>
+      Licensed under the MIT License.
     HTML
 
     def get_latest_version(opts)

--- a/lib/docs/scrapers/git.rb
+++ b/lib/docs/scrapers/git.rb
@@ -1,7 +1,7 @@
 module Docs
   class Git < UrlScraper
     self.type = 'git'
-    self.release = '2.43.1'
+    self.release = '2.46.0'
     self.base_url = 'https://git-scm.com/docs'
     self.initial_paths = %w(/git.html)
     self.links = {
@@ -16,8 +16,8 @@ module Docs
     options[:skip] = %w(/howto-index.html)
 
     options[:attribution] = <<-HTML
-      &copy; 2012&ndash;2024 Scott Chacon and others<br>
-      Licensed under the MIT License.
+      &copy; 2005&ndash;2024 Linus Torvalds and others<br>
+      Licensed under the GNU General Public License version 2.
     HTML
 
     def get_latest_version(opts)


### PR DESCRIPTION
Release announcement: https://public-inbox.org/git/xmqqzfq0i0qa.fsf@gitster.g/

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date - changed back to GPL. #1068 changed to the license of the git-scm.com website, but the documentation is not hosted in that repository, instead in the `Documentation/` directory of the `git/git` repository: https://github.com/git/git/tree/master/Documentation . So this PR changes the license back to the GPL v2 per https://github.com/git/git/blob/master/COPYING .
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
