### PR TITLE
Add Rails 7.2 docs

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -244,9 +244,9 @@ done
 * Open `railties/lib/rails/api/task.rb` and comment out any code related to sdoc (`configure_sdoc`)
 * Run `bundle config set --local without 'db job'` (in the Rails directory)
 * Run `bundle install && bundle exec rake rdoc` (in the Rails directory)
-* Run `cd guides && bundle exec rake guides:generate:html`
-* Copy the `guides/output` directory to `html/guides`
-* Copy the `html` directory to `docs/rails~[version]`
+* Run `cd guides && bundle exec rake guides:generate:html && cd ..`
+* Run `cp -r guides/output html/guides`
+* Run `cp -r html $DEVDOCS/docs/rails~[version]`
 
 ### Ruby
 Download the tarball of Ruby from https://www.ruby-lang.org/en/downloads/, extract it, run

--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -76,7 +76,7 @@ module Docs
     end
 
     version '7.2' do
-      self.release = '7.2.0'
+      self.release = '7.2.1'
     end
 
     version '7.1' do

--- a/lib/docs/scrapers/rdoc/rails.rb
+++ b/lib/docs/scrapers/rdoc/rails.rb
@@ -75,6 +75,10 @@ module Docs
       end
     end
 
+    version '7.2' do
+      self.release = '7.2.0'
+    end
+
     version '7.1' do
       self.release = '7.1.2'
     end


### PR DESCRIPTION
Simply adding Rails 7.2 as it was released almost 2 weeks ago.

- https://github.com/rails/rails/releases/tag/v7.2.0
- https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released