### PR TITLE
Fix Cordova indents with new clean html option

### DIFF
--- a/lib/docs/filters/cordova/clean_html_core.rb
+++ b/lib/docs/filters/cordova/clean_html_core.rb
@@ -1,0 +1,11 @@
+module Docs
+  class Cordova
+    class CleanHtmlCoreFilter < Filter
+      def call
+        css('script', 'style', 'link').remove
+        xpath('descendant::comment()').remove
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/core/clean_html.rb
+++ b/lib/docs/filters/core/clean_html.rb
@@ -8,6 +8,7 @@ module Docs
       xpath('./text()', './/text()[not(ancestor::pre) and not(ancestor::code) and not(ancestor::div[contains(concat(" ", normalize-space(@class), " "), " prism ")])]').each do |node|
         content = node.content
         next unless content.valid_encoding?
+        next if context[:clean_html_maintain_nbsp] && !content.index(" ").nil?
         content.gsub! %r{[[:space:]]+}, ' '
         node.content = content
       end

--- a/lib/docs/filters/core/clean_html.rb
+++ b/lib/docs/filters/core/clean_html.rb
@@ -8,7 +8,6 @@ module Docs
       xpath('./text()', './/text()[not(ancestor::pre) and not(ancestor::code) and not(ancestor::div[contains(concat(" ", normalize-space(@class), " "), " prism ")])]').each do |node|
         content = node.content
         next unless content.valid_encoding?
-        next if context[:clean_html_maintain_nbsp] && !content.index(" ").nil?
         content.gsub! %r{[[:space:]]+}, ' '
         node.content = content
       end

--- a/lib/docs/scrapers/cordova.rb
+++ b/lib/docs/scrapers/cordova.rb
@@ -11,6 +11,7 @@ module Docs
     html_filters.push 'cordova/entries', 'cordova/clean_html'
 
     options[:container] = '.docs'
+    options[:clean_html_maintain_nbsp] = true
     options[:skip] = %w(index.html)
 
     options[:fix_urls] = ->(url) do

--- a/lib/docs/scrapers/cordova.rb
+++ b/lib/docs/scrapers/cordova.rb
@@ -8,10 +8,10 @@ module Docs
       code: 'https://github.com/apache/cordova'
     }
 
+    html_filters.replace 'clean_html', 'cordova/clean_html_core'
     html_filters.push 'cordova/entries', 'cordova/clean_html'
 
     options[:container] = '.docs'
-    options[:clean_html_maintain_nbsp] = true
     options[:skip] = %w(index.html)
 
     options[:fix_urls] = ->(url) do


### PR DESCRIPTION
Fixes #1004 

- Did this by adding a new option in `CleanHtmlFilter` and setting it in the Cordova scraper 
- The indents are removed as they are a non breaking space character that gets removed by CleanHtmlFilter. The option allows bypassing the whitespace removal if it detects a non breaking space
- I'm open to other ways of doing this more cleanly

Existing unindented with new indented
<img width="1379" alt="image" src="https://github.com/user-attachments/assets/ea787c50-6011-43d3-9a27-f12e85d814ab">

Source indented with new indented
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/b74fc864-169d-4720-8ca2-79ec8487ec5d">
