### PR TITLE
fix: use aliases from config

### DIFF
--- a/assets/javascripts/templates/pages/help_tmpl.js
+++ b/assets/javascripts/templates/pages/help_tmpl.js
@@ -3,7 +3,7 @@ app.templates.helpPage = function () {
   const navKey = $.isMac() ? "cmd" : "alt";
   const arrowScroll = app.settings.get("arrowScroll");
 
-  const aliases = Object.entries(app.models.Entry.ALIASES);
+  const aliases = Object.entries(app.config.docs_aliases);
   const middle = Math.ceil(aliases.length / 2);
   const aliases_one = aliases.slice(0, middle);
   const aliases_two = aliases.slice(middle);


### PR DESCRIPTION
https://github.com/freeCodeCamp/devdocs/pull/2344 updated the aliases, but not everywhere. The help page still tried to access the old property and crashed.

Closes https://github.com/freeCodeCamp/devdocs/issues/2364