### PR TITLE
updated eslint version (8.56.0 > 9.15.0)

### DIFF
--- a/lib/docs/filters/eslint/clean_html.rb
+++ b/lib/docs/filters/eslint/clean_html.rb
@@ -5,6 +5,7 @@ module Docs
         @doc = at_css('#main') if at_css('#main')
         @doc = at_css('.docs-main__content') if at_css('.docs-main__content')
 
+        css('.docs-toc').remove
         css('.eslint-ad').remove
         css('.glyphicon').remove
         css('hr', 'colgroup', 'td:empty').remove

--- a/lib/docs/filters/eslint/entries.rb
+++ b/lib/docs/filters/eslint/entries.rb
@@ -10,7 +10,12 @@ module Docs
         if subpath.start_with?('rules')
           return 'Rules'
         else
-          at_css('nav.docs-index [aria-current="true"]').ancestors('li')[-1].at_css('a').content
+          type = at_css('nav.docs-index [aria-current="true"]').ancestors('li')[-1].at_css('a').content
+          # This specific entry is mispelled with a lowercase 'i'
+          if type.start_with?('integrate')
+            type = type.sub('integrate', 'Integrate')
+          end
+          return type
         end
       end
     end

--- a/lib/docs/scrapers/eslint.rb
+++ b/lib/docs/scrapers/eslint.rb
@@ -2,9 +2,9 @@ module Docs
   class Eslint < UrlScraper
     self.name = 'ESLint'
     self.type = 'simple'
-    self.release = '8.56.0'
+    self.release = '9.15.0'
     self.base_url = 'https://eslint.org/docs/latest/'
-    self.root_path = 'user-guide/getting-started'
+    self.root_path = '/'
     self.links = {
       home: 'https://eslint.org/',
       code: 'https://github.com/eslint/eslint'
@@ -14,7 +14,22 @@ module Docs
 
     options[:skip_patterns] = [/maintain/, /migrating/, /migrate/, /\Aversions/, /rule-deprecation/]
     options[:skip] = %w(about about/ versions)
-    options[:replace_paths] = { 'user-guide' => 'user-guide/' }
+    # A number of paths have a trailing slash, causing them to be suffixed by "index" during the NormalizePathsFilter
+    options[:replace_paths] = {
+      'configure/' => 'configure',
+      'contribute/' => 'contribute',
+      'contribute/architecture/' => 'contribute/architecture',
+      'extend/' => 'extend',
+      'flags/' => 'flags',
+      'integrate/' => 'integrate',
+      'rules/' => 'rules',
+      'use/' => 'use',
+      'use/formatters/' => 'use/formatters',
+      'use/configure/' => 'use/configure',
+      'use/configure/rules/' => 'use/configure/rules',
+      'use/core-concepts/' => 'use/core-concepts',
+      'use/troubleshooting/' => 'use/troubleshooting',
+    }
 
     options[:attribution] = <<-HTML
       &copy; OpenJS Foundation and other contributors<br>


### PR DESCRIPTION
If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good