### PR TITLE
feat: add the GitHub action to create a Docker image and push to Docker Registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,10 +15,21 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        variant:
+          - name: regular
+            file: Dockerfile
+            suffix: ''
+          - name: alpine
+            file: Dockerfile-alpine
+            suffix: '-alpine'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -33,25 +44,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
-            type=raw,value={{date 'YYYYMMDD'}}
+            type=raw,value=latest${{ matrix.variant.suffix }}
+            type=raw,value={{date 'YYYYMMDD'}}${{ matrix.variant.suffix }}
 
-      - name: Build and push regular image
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
+          file: ./${{ matrix.variant.file }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push Alpine image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile-alpine
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-{{date 'YYYYMMDD'}}
-          labels: ${{ steps.meta.outputs.labels }} 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Images
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'  # Run monthly on the 1st
+  workflow_dispatch:  # Allow manual triggers
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      - name: Build and push regular image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Alpine image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile-alpine
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-{{date 'YYYYMMDD'}}
+          labels: ${{ steps.meta.outputs.labels }} 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ Keep track of development news:
 
 Unless you wish to contribute to the project, we recommend using the hosted version at [devdocs.io](https://devdocs.io). It's up-to-date and works offline out-of-the-box.
 
+### Using Docker (Recommended)
+
+The easiest way to run DevDocs locally is using Docker:
+
+```sh
+docker run --name devdocs -d -p 9292:9292 ghcr.io/freecodcamp/devdocs:latest
+```
+
+This will start DevDocs at [localhost:9292](http://localhost:9292). We provide both regular and Alpine-based images:
+- `ghcr.io/freecodcamp/devdocs:latest` - Standard image
+- `ghcr.io/freecodcamp/devdocs:latest-alpine` - Alpine-based (smaller size)
+
+Images are automatically built and updated monthly with the latest documentation.
+
+Alternatively, you can build the image yourself:
+
+```sh
+git clone https://github.com/freeCodeCamp/devdocs.git && cd devdocs
+docker build -t devdocs .
+docker run --name devdocs -d -p 9292:9292 devdocs
+```
+
+### Manual Installation
+
 DevDocs is made of two pieces: a Ruby scraper that generates the documentation and metadata, and a JavaScript app powered by a small Sinatra app.
 
 DevDocs requires Ruby 3.3.0 (defined in [`Gemfile`](./Gemfile)), libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
@@ -37,17 +61,6 @@ Finally, point your browser at [localhost:9292](http://localhost:9292) (the firs
 The `thor docs:download` command is used to download pre-generated documentations from DevDocs's servers (e.g. `thor docs:download html css`). You can see the list of available documentations and versions by running `thor docs:list`. To update all downloaded documentations, run `thor docs:download --installed`. To download and install all documentation this project has available, run `thor docs:download --all`.
 
 **Note:** there is currently no update mechanism other than `git pull origin main` to update the code and `thor docs:download --installed` to download the latest version of the docs. To stay informed about new releases, be sure to [watch](https://github.com/freeCodeCamp/devdocs/subscription) this repository.
-
-Alternatively, DevDocs may be started as a Docker container:
-
-```sh
-# First, build the image
-git clone https://github.com/freeCodeCamp/devdocs.git && cd devdocs
-docker build -t thibaut/devdocs .
-
-# Finally, start a DevDocs container (access http://localhost:9292)
-docker run --name devdocs -d -p 9292:9292 thibaut/devdocs
-```
 
 ## Vision
 


### PR DESCRIPTION
This PR addresses #2330 

### Add automated Docker image builds

This PR adds a GitHub Actions workflow that automatically builds and publishes DevDocs Docker images to GitHub Container Registry (GHCR). The workflow addresses the concern of outdated official Docker images by providing fresh builds on a regular schedule.

### What this adds:
- New workflow .github/workflows/docker-build.yml that:
- Runs monthly on the 1st of each month
- Can be manually triggered via GitHub Actions UI
- Builds both regular and Alpine-based images
- Publishes to GHCR with the following tags:
  - ghcr.io/[org]/devdocs:latest
  - ghcr.io/[org]/devdocs:[YYYYMMDD]
  - ghcr.io/[org]/devdocs:alpine
  - ghcr.io/[org]/devdocs:alpine-[YYYYMMDD]
  
  The administrators for the repo would need to do the following - 
  
1. Enable GitHub Container Registry:
  - Go to repository "Settings" → "Actions" → "General"
  - Under "Workflow permissions", ensure "Read and write permissions" is selected
  - Save the changes
  - Enable Package Write Permissions:
2. Go to repository "Settings" → "Packages"
  - Ensure "Inherit access from source repository" is enabled
  - If not using inheritance, explicitly grant write access to GitHub Actions
3. Optional but recommended - Branch Protection
  - Go to repository "Settings" → "Branches"
  - Add branch protection rule for your main branch
  - Enable "Require status checks to pass before merging"
  - This ensures the Docker build workflow succeeds before merging
  
  
  I believe no other changes are needed here. 