### PR TITLE
Update Elixir documentation (1.18)

### DIFF
--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -34,7 +34,9 @@ module Docs
             node.name = 'h3'
             node['id'] = id
 
-            source_href = node.at_css('a.icon-action[title="View Source"]').attr('href')
+            a = node.at_css('a.icon-action[title="View Source"]')
+            a ||= node.at_css('a.icon-action[aria-label="View Source"]')
+            source_href = a.attr('href')
 
             node.content = node.at_css('.signature').inner_text
             node << %(<a href="#{source_href}" class="source">Source</a>)

--- a/lib/docs/scrapers/elixir.rb
+++ b/lib/docs/scrapers/elixir.rb
@@ -30,6 +30,18 @@ module Docs
         "https://hexdocs.pm/mix/#{self.class.release}/Mix.html" ]
     end
 
+    version '1.18' do
+      self.release = '1.18.1'
+      self.base_urls = [
+        "https://hexdocs.pm/elixir/#{release}/",
+        "https://hexdocs.pm/eex/#{release}/",
+        "https://hexdocs.pm/ex_unit/#{release}/",
+        "https://hexdocs.pm/iex/#{release}/",
+        "https://hexdocs.pm/logger/#{release}/",
+        "https://hexdocs.pm/mix/#{release}/"
+      ]
+    end
+
     version '1.17' do
       self.release = '1.17.2'
       self.base_urls = [


### PR DESCRIPTION
- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

