### PR TITLE
Update Crystal docs to 1.15.0

### DIFF
--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -21,6 +21,7 @@ module Docs
 
     options[:skip_patterns] = [
       %r{\ACrystal/System/},
+      %r{\ACrystal/PointerPairingHeap/},
       %r{\AIO/Evented.html\z},
       %r{\ARegex/PCRE2.html\z}
     ]

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -34,7 +34,7 @@ module Docs
         HTML
       else
         <<-HTML
-          &copy; 2012&ndash;2024 Manas Technology Solutions.<br>
+          &copy; 2012&ndash;2025 Manas Technology Solutions.<br>
           Licensed under the Apache License, Version 2.0.
         HTML
       end

--- a/lib/docs/scrapers/crystal.rb
+++ b/lib/docs/scrapers/crystal.rb
@@ -2,7 +2,7 @@ module Docs
   class Crystal < UrlScraper
     include MultipleBaseUrls
     self.type = 'crystal'
-    self.release = '1.14.0'
+    self.release = '1.15.0'
     self.base_urls = [
       "https://crystal-lang.org/api/#{release}/",
       "https://crystal-lang.org/reference/#{release[0..2]}/",


### PR DESCRIPTION
If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
