### PR TITLE
Crystal docs: Use fully qualified name for entries

### DIFF
--- a/lib/docs/filters/crystal/entries.rb
+++ b/lib/docs/filters/crystal/entries.rb
@@ -16,8 +16,12 @@ module Docs
           name
         else
           return at_css('h1').content.strip unless at_css('.type-name')
-          name = at_css('.type-name').children.last.content.strip
+          name = at_css('.type-name').children.reject { |n| n.matches?('.kind') }
+          name.map! { |n| n.text.strip }
+          name.reject! &:empty?
+          name = name.join
           name.remove! %r{\(.*\)}
+          name.strip!
           name
         end
       end


### PR DESCRIPTION
Currently entities name for Crystal is just the short version making it impossible to distinguish search hits:
![image](https://github.com/user-attachments/assets/b3ee7da6-62b4-4866-8d55-eda74cee77c8)

This PR will change entry name to be the fully qualified name:
![image](https://github.com/user-attachments/assets/10b2eecd-dd84-493c-a0b2-f99b8ea0f4d9)

It also enables searches like "json builder", which isn't possible today.

--

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
