### PR TITLE
fix: prevent compression with Accept-Encoding

### DIFF
--- a/lib/tasks/docs.thor
+++ b/lib/tasks/docs.thor
@@ -239,7 +239,7 @@ class DocsCLI < Thor
           ['index.json', 'meta.json'].each do |filename|
             json = "https://documents.devdocs.io/#{doc.path}/#{filename}?#{time}"
             begin
-              URI.open(json) do |file|
+              URI.open(json, "Accept-Encoding" => "identity") do |file|
                 mutex.synchronize do
                   path = File.join(dir, filename)
                   File.write(path, file.read)


### PR DESCRIPTION
It seems that (apparently randomly) the index.json files are getting compressed and causing URI.open to fail. Possibly, it's a little unclear.

Nonetheless, sending the "Accept-Encoding" of "identity" seems to do the trick.
