### PR TITLE
[1074] Make Language Specific Favicon Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker run --name devdocs -d -p 9292:9292 devdocs
 
 DevDocs is made of two pieces: a Ruby scraper that generates the documentation and metadata, and a JavaScript app powered by a small Sinatra app.
 
-DevDocs requires Ruby 3.3.0 (defined in [`Gemfile`](./Gemfile)), libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
+DevDocs requires Ruby 3.4.1 (defined in [`Gemfile`](./Gemfile)), libcurl, and a JavaScript runtime supported by [ExecJS](https://github.com/rails/execjs#readme) (included in OS X and Windows; [Node.js](https://nodejs.org/en/) on Linux). Once you have these installed, run the following commands:
 
 ```sh
 git clone https://github.com/freeCodeCamp/devdocs.git && cd devdocs

--- a/assets/javascripts/app/settings.js
+++ b/assets/javascripts/app/settings.js
@@ -16,6 +16,7 @@ app.Settings = class Settings {
     "autoInstall",
     "spaceScroll",
     "spaceTimeout",
+    "noDocSpecificIcon",
   ];
 
   static INTERNAL_KEYS = ["count", "schema", "version", "news"];
@@ -38,6 +39,7 @@ app.Settings = class Settings {
     theme: "auto",
     spaceScroll: 1,
     spaceTimeout: 0.5,
+    noDocSpecificIcon: false,
   };
 
   constructor() {

--- a/assets/javascripts/lib/favicon.js
+++ b/assets/javascripts/lib/favicon.js
@@ -19,7 +19,7 @@ const withImage = function (url, action) {
 };
 
 this.setFaviconForDoc = function (doc) {
-  if (currentSlug === doc.slug) {
+  if (currentSlug === doc.slug || app.settings.get("noDocSpecificIcon")) {
     return;
   }
 

--- a/assets/javascripts/templates/pages/settings_tmpl.js
+++ b/assets/javascripts/templates/pages/settings_tmpl.js
@@ -66,6 +66,12 @@ app.templates.settingsPage = (settings) => `\
       }>Enable tracking cookies
       <small>With this checked, we enable Google Analytics and Gauges to collect anonymous traffic information.</small>
     </label>
+    <label class="_settings-label _hide-on-mobile">
+      <input type="checkbox" form="settings" name="noDocSpecificIcon"${
+        settings.noDocSpecificIcon ? " checked" : ""
+      }>Disable Language-specific Doc Favicons
+      <small>With this checked, we will display the default DevDocs icon for all pages.</small>
+    </label>
   </div>
 </div>
 

--- a/assets/javascripts/views/content/settings_page.js
+++ b/assets/javascripts/views/content/settings_page.js
@@ -20,6 +20,7 @@ app.views.SettingsPage = class SettingsPage extends app.View {
     settings.analyticsConsent = app.settings.get("analyticsConsent");
     settings.spaceScroll = app.settings.get("spaceScroll");
     settings.spaceTimeout = app.settings.get("spaceTimeout");
+    settings.noDocSpecificIcon = app.settings.get("noDocSpecificIcon");
     settings.autoSupported = app.settings.autoSupported;
     for (var layout of app.Settings.LAYOUTS) {
       settings[layout] = app.settings.hasLayout(layout);


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

Update Ruby Version in README
- reflects current version 3.4.1 as shown in Gemfile

Make Language Specific Favicons Optional
- adds noDocSpecificIcon property to app settings
- adds option to user Settings page
- updates setFaviconForDoc method to return early when setting is active

Closes issue #1074 
