### PR TITLE
fix: open external links in default browser from macOS PWA

### DIFF
--- a/assets/javascripts/lib/util.js
+++ b/assets/javascripts/lib/util.js
@@ -457,13 +457,13 @@ $.noop = function () {};
 
 $.popup = function (value) {
   try {
+    window.open(value.href || value, "_blank", "noopener");
+  } catch (error) {
     const win = window.open();
     if (win.opener) {
       win.opener = null;
     }
     win.location = value.href || value;
-  } catch (error) {
-    window.open(value.href || value, "_blank");
   }
 };
 


### PR DESCRIPTION
By using `window.open(url, "_blank", "noopener")` directly instead of a very old workaround, Safari can detect before opening the new window that it's going to an external URL, and send the link to the default browser. I tested this locally, and although MDN claims that, on iOS, ["this method will not function if the `target` parameter is unspecified or set to `_blank`"](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#browser_compatibility), in my testing it seemed to work fine.

Fixes freeCodeCamp/devdocs#2438