### PR TITLE
Fix multiple version checks of scrapers.

### DIFF
--- a/lib/docs/scrapers/docker.rb
+++ b/lib/docs/scrapers/docker.rb
@@ -96,7 +96,7 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://docs.docker.com/engine/release-notes/', opts)
-      latest_version = doc.at_css('.DocSearch-content > h2 > a').content.strip
+      latest_version = doc.at_css('h2.scroll-mt-20 > a').content.strip
       latest_version.rpartition(' ')[-1]
     end
   end

--- a/lib/docs/scrapers/meteor.rb
+++ b/lib/docs/scrapers/meteor.rb
@@ -47,8 +47,7 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://docs.meteor.com/#/full/', opts)
-      doc.at_css('select.version-select > option').content
+      get_npm_version('meteor', opts)
     end
   end
 end

--- a/lib/docs/scrapers/nix.rb
+++ b/lib/docs/scrapers/nix.rb
@@ -23,9 +23,7 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://nixos.org/manual/nix/stable/', opts)
-      json = JSON.parse(doc.at_css('body')['data-nix-channels'])
-      channel = json.find { |c| c['channel'] == 'stable' }
-      channel['version']
+      doc.at_css('a.active')['href'].scan(/([0-9.]+)/)[0][0]
     end
   end
 end

--- a/lib/docs/scrapers/phpunit.rb
+++ b/lib/docs/scrapers/phpunit.rb
@@ -77,8 +77,8 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://phpunit.readthedocs.io/', opts)
-      label = doc.at_css('.rst-current-version').content.strip
-      label.scan(/v: ([0-9.]+)/)[0][0]
+      label = doc.at_css('meta[name="readthedocs-version-slug"]')["content"]
+      label
     end
 
   end

--- a/lib/docs/scrapers/redis.rb
+++ b/lib/docs/scrapers/redis.rb
@@ -22,8 +22,7 @@ module Docs
 
     def get_latest_version(opts)
       body = fetch('http://download.redis.io/redis-stable/00-RELEASENOTES', opts)
-      body = body.lines[1..-1].join
-      body.scan(/Redis ([0-9.]+)/)[0][0]
+      body.scan(/Redis Community Edition ([0-9.]+)/)[0][0]
     end
 
     private

--- a/lib/docs/scrapers/sass.rb
+++ b/lib/docs/scrapers/sass.rb
@@ -20,12 +20,12 @@ module Docs
       &copy; 2006&ndash;2024 the Sass team, and numerous contributors<br>
       Licensed under the MIT License.
     HTML
-  
-    private
 
     def get_latest_version(opts)
       get_npm_version('sass', opts)
     end
+
+    private
 
     def parse(response)
       response.body.gsub! '<span class="widont">&nbsp;</span>', '&nbsp;'

--- a/lib/docs/scrapers/trio.rb
+++ b/lib/docs/scrapers/trio.rb
@@ -25,7 +25,7 @@ module Docs
 
     def get_latest_version(opts)
       doc = fetch_doc('https://trio.readthedocs.io/en/stable/', opts)
-      doc.at_css('.rst-other-versions a[href^="/en/v"]').content[1..-1]
+      doc.at_css('div.trio-version').content[0..-1]
     end
   end
 end


### PR DESCRIPTION
This PR fixes the following version checks:
- Docker
- Meteor
- Nix
- PHPUnit
- Redis
- Sass
- Trio