### PR TITLE
Add Django 5.2

### DIFF
--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,6 +34,11 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '5.2' do
+      self.release = '5.2'
+      self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"
+    end
+
     version '5.1' do
       self.release = '5.1'
       self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

Currently in beta: https://www.djangoproject.com/weblog/2025/feb/19/django-52-beta-1-released/

The versioned documentation has been available since the alpha release: https://docs.djangoproject.com/en/5.1/

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [[ ]] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

(Adapted from my previous Django 5.1 PR: #2300.)