### PR TITLE
Fix the broken "Show source" toggle for Ruby 3.4 docs

### DIFF
--- a/lib/docs/filters/rdoc/clean_html.rb
+++ b/lib/docs/filters/rdoc/clean_html.rb
@@ -30,11 +30,23 @@ module Docs
           node.remove_attribute 'id'
         end
 
-        # Convert "click to toggle source" into a link
+        # (RDoc prior to Ruby 3.4) Convert "click to toggle source" into a link
         css('.method-click-advice').each do |node|
           node.name = 'a'
           node.content = 'Show source'
         end
+
+        # (RDoc for Ruby 3.4+) Add a "Show source" link
+        css('.method-source-toggle').each do |node|
+          link_node = Nokogiri::XML::Node.new('a', doc.document)
+          link_node.content = 'Show source'
+          link_node['class'] = 'method-click-advice'
+
+          node.parent.parent.at_css('.method-heading').add_child(link_node)
+        end
+
+        # (RDoc for Ruby 3.4+) Remove the additional "Source" toggle from the page
+        css('.method-controls').remove
 
         # Add class to differentiate Ruby code from C code
         css('.method-source-code').each do |node|


### PR DESCRIPTION
Should fix https://github.com/freeCodeCamp/devdocs/issues/2417.

With Ruby 3.4 the documentation is generated using a different theme, which impacted the layout of the page and the classes for HTML elements. Without the change the "Source" toggle from the original doc is copied over into the the final document without doing anything, whereas the expected header "Show source" link is missing and as the result the source code cannot be viewed.

This PR updates `Docs::Rdoc::CleanHtmlFilter` to add a link for methods with the source and remove the superfluous "Source" toggle from the original documentation.

Manually tested on documentation from Ruby 3.3 and 3.4.

<details>
<summary>Before</summary>
<img width="613" alt="Screenshot 2025-03-26 at 22 21 04" src="https://github.com/user-attachments/assets/f45dd3ba-2cbc-43a1-a9f7-84e91651b685" />
</details>

<details>
<summary>After</summary>
<img width="623" alt="Screenshot 2025-03-26 at 22 22 57" src="https://github.com/user-attachments/assets/4461f21f-ea37-49b7-931d-4bc85cfbdaf3" />
</details>