### PR TITLE
Remove the "::" separator from the SEPARATORS_REGEXP in searcher.js 

### DIFF
--- a/assets/javascripts/app/searcher.js
+++ b/assets/javascripts/app/searcher.js
@@ -154,7 +154,7 @@ app.Searcher = class Searcher extends Events {
   };
 
   static SEPARATORS_REGEXP =
-    /#|::|:-|->|\$(?=\w)|\-(?=\w)|\:(?=\w)|\ [\/\-&]\ |:\ |\ /g;
+    /#|:-|->|\$(?=\w)|\-(?=\w)|\:(?=\w)|\ [\/\-&]\ |:\ |\ /g;
   static EOS_SEPARATORS_REGEXP = /(\w)[\-:]$/;
   static INFO_PARANTHESES_REGEXP = /\ \(\w+?\)$/;
   static EMPTY_PARANTHESES_REGEXP = /\(\)/;


### PR DESCRIPTION
Should fix #2463 

Tried searching for `std::min` and was able to get good C++ documentation results.