### PR TITLE
GitHub Actions: install Heroku CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+    - name: Install Heroku CLI
+      run: |
+        curl https://cli-assets.heroku.com/install.sh | sh
     - name: Deploy to Heroku
       uses: akhileshns/heroku-deploy@e3eb99d45a8e2ec5dca08735e089607befa4bf28 # v3.14.15
       with:


### PR DESCRIPTION
Follow-up for #2480.

According to https://github.com/AkhileshNS/heroku-deploy?tab=readme-ov-file#important-note

> Please Note: ubuntu-latest which as of the time of updating this documentation is 24.04 no longer supports the heroku-cli by default. So if you must use the latest version of ubuntu-latest, be sure to install heroku-cli (instructions [here](https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli)) before running the plugin.

cc: @ojeytonwilliams 