### PR TITLE
Add get_latest_version for opengl

### DIFF
--- a/lib/docs/scrapers/opengl.rb
+++ b/lib/docs/scrapers/opengl.rb
@@ -27,5 +27,9 @@ module Docs
       self.release = '2.1'
       self.base_url = "https://registry.khronos.org/OpenGL-Refpages/gl#{self.version}/"
     end
+
+    def get_latest_version(opts)
+      get_latest_github_commit_date('KhronosGroup', 'OpenGL-Refpages', opts)
+    end
   end
 end

--- a/lib/docs/scrapers/opengl.rb
+++ b/lib/docs/scrapers/opengl.rb
@@ -19,13 +19,13 @@ module Docs
     version '4' do
       self.root_path = 'index.php'
       self.release = '4'
-      self.base_url = "https://registry.khronos.org/OpenGL-Refpages/gl#{self.version}/"
+      self.base_url = "https://registry.khronos.org/OpenGL-Refpages/gl#{self.version}/html/"
     end
 
     version '2.1' do
       self.root_path = 'index.html'
       self.release = '2.1'
-      self.base_url = "https://registry.khronos.org/OpenGL-Refpages/gl#{self.version}/"
+      self.base_url = "https://registry.khronos.org/OpenGL-Refpages/gl#{self.version}/xhtml/"
     end
 
     def get_latest_version(opts)


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Also updated base_url's, previous ones didn't exist. 
