### PR TITLE
Add Django 6.0

### DIFF
--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,6 +34,11 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '6.0' do
+      self.release = '6.0'
+      self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"
+    end
+
     version '5.2' do
       self.release = '5.2'
       self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"


### PR DESCRIPTION
<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

Currently in alpha: https://www.djangoproject.com/weblog/2025/sep/17/django-60-alpha-released/

That means its docs pages are now up: https://docs.djangoproject.com/en/6.0/

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

(Adapted from my previous Django 5.2 PR: #2442.)