### PR TITLE
Upgrade love to 11.3; remove diacritic.

### DIFF
--- a/lib/docs.rb
+++ b/lib/docs.rb
@@ -124,7 +124,7 @@ module Docs
       'kubernetes' => 'k8s',
       'less' => 'ls',
       'lodash' => '_',
-      'love' => 'löve',
+      'love' => 'love',
       'marionette' => 'mn',
       'markdown' => 'md',
       'matplotlib' => 'mpl',

--- a/lib/docs/scrapers/love.rb
+++ b/lib/docs/scrapers/love.rb
@@ -3,7 +3,7 @@ module Docs
     self.name = 'LÖVE'
     self.slug = 'love'
     self.type = 'love'
-    self.release = '11.3'
+    self.release = '11.5'
     self.base_url = 'https://love2d.org/wiki/'
     self.root_path = 'Main_Page'
     self.initial_paths = %w(love love.audio love.data love.event love.filesystem love.font


### PR DESCRIPTION
If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

Follow up to https://github.com/freeCodeCamp/devdocs/issues/2584, updates the documentation and removes the diacritic from the alias.
