### PR TITLE
Bump homebrew to 4.6.15

### DIFF
--- a/lib/docs/filters/homebrew/entries.rb
+++ b/lib/docs/filters/homebrew/entries.rb
@@ -11,16 +11,25 @@ module Docs
       CONTRIBUTOR_SLUGS = %w(
         How-To-Open-a-Homebrew-Pull-Request
         Formula-Cookbook
+        Cask-Cookbook
         Acceptable-Formulae
+        Acceptable-Casks
+        License-Guidelines
         Versions
+        Deprecating-Disabling-and-Removing-Formulae
         Node-for-Formula-Authors
         Python-for-Formula-Authors
+        Brew-Livecheck
+        Autobump
         Migrating-A-Formula-To-A-Tap
         Rename-A-Formula
         Building-Against-Non-Homebrew-Dependencies
         How-to-Create-and-Maintain-a-Tap
         Brew-Test-Bot
-        Prose-Style-Guidelines)
+        Prose-Style-Guidelines
+        Typechecking
+        Reproducible-Builds
+      )
 
       def get_type
         if CONTRIBUTOR_SLUGS.include?(slug)

--- a/lib/docs/scrapers/homebrew.rb
+++ b/lib/docs/scrapers/homebrew.rb
@@ -2,7 +2,7 @@ module Docs
   class Homebrew < UrlScraper
     self.name = 'Homebrew'
     self.type = 'simple'
-    self.release = '3.5.10'
+    self.release = '4.6.15'
     self.base_url = 'https://docs.brew.sh/'
     self.links = {
       home: 'https://brew.sh',


### PR DESCRIPTION
Bump homebrew version to 4.6.15. Update entries list with newer articles.

---

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
