### PR TITLE
Add PyTorch 2.8 and 2.9 documentation support

### DIFF
--- a/lib/docs/filters/pytorch/clean_html.rb
+++ b/lib/docs/filters/pytorch/clean_html.rb
@@ -2,9 +2,11 @@ module Docs
   class Pytorch
     class CleanHtmlFilter < Filter
       def call
-        @doc = at_css('.pytorch-article')
-        # Show katex-mathml nodes and remove katex-html nodes
-        css('.katex-html').remove
+        if root = at_css('#pytorch-article')
+          @doc = root
+          # Show katex-mathml nodes and remove katex-html nodes
+          css('.katex-html').remove
+        end
         doc
       end
     end

--- a/lib/docs/scrapers/pytorch.rb
+++ b/lib/docs/scrapers/pytorch.rb
@@ -19,6 +19,16 @@ module Docs
     PyTorch has a BSD-style license, as found in the <a href="https://github.com/pytorch/pytorch/blob/main/LICENSE">LICENSE</a> file.
     HTML
 
+    version '2.9' do
+      self.release = '2.9'
+      self.base_url = "https://docs.pytorch.org/docs/#{release}/"
+    end
+
+    version '2.8' do
+      self.release = '2.8'
+      self.base_url = "https://docs.pytorch.org/docs/#{release}/"
+    end
+
     version '2.7' do
       self.release = '2.7'
       self.base_url = "https://docs.pytorch.org/docs/#{release}/"


### PR DESCRIPTION
The PR updates the PyTorch scraper for documentation versions 2.8 and 2.9, addressing changes in the theme and HTML structure.

The PyTorch 2.8 and 2.9 uses a new sphinx theme, which is somewhat unfriendly to scrapers at the moment. The commit mainly addresses truncations in the breadcrumb navigation section (e.g. https://docs.pytorch.org/docs/2.9/name_inference.html, https://docs.pytorch.org/docs/2.9/config_mod.html) by extracting the text inside the heading instead.

The extracted doc structure is slightly different from those of older PyTorch docs because sometimes truncations happen in the middle of the navigation paths (e.g. https://docs.pytorch.org/docs/2.9/torch.compiler_aot_inductor_debugging_guide.html).

Key changes:
- Identifies the main content area correctly in newer version docs.
- Supports the new breadcrumb navigation structure.
- Restore truncated entry names in newer docs using the full page header, maintaining consistent naming conventions.

<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
