### PR TITLE
Scroll to top of view upon route entry

### DIFF
--- a/assets/javascripts/lib/page.js
+++ b/assets/javascripts/lib/page.js
@@ -98,26 +98,35 @@ page.canGoForward = () => !Context.isLastState(currentState);
 const currentPath = () => location.pathname + location.search + location.hash;
 
 class Context {
+  /**
+   * A counter tracking the largest state ID used.
+   */
+  static stateId = 0;
+
+  /**
+   * The session ID to apply across all contexts.
+   */
+  static sessionId = Date.now();
+
   static isIntialState(state) {
     return state.id === 0;
   }
 
   static isLastState(state) {
-    return state.id === this.stateId - 1;
+    return state.id === Context.stateId - 1;
   }
 
   static isInitialPopState(state) {
-    return state.path === this.initialPath && this.stateId === 1;
+    return state.path === this.initialPath && Context.stateId === 1;
   }
 
   static isSameSession(state) {
-    return state.sessionId === this.sessionId;
+    return state.sessionId === Context.sessionId;
   }
 
   constructor(path, state) {
     this.initialPath = currentPath();
-    this.sessionId = Date.now();
-    this.stateId = 0;
+
     if (path == null) {
       path = "/";
     }
@@ -136,10 +145,11 @@ class Context {
     );
 
     if (this.state.id == null) {
-      this.state.id = this.constructor.stateId++;
+      Context.stateId++;
+      this.state.id = Context.stateId;
     }
     if (this.state.sessionId == null) {
-      this.state.sessionId = this.constructor.sessionId;
+      this.state.sessionId = Context.sessionId;
     }
     this.state.path = this.path;
   }

--- a/assets/javascripts/views/content/content.js
+++ b/assets/javascripts/views/content/content.js
@@ -149,6 +149,12 @@ app.views.Content = class Content extends app.View {
 
   beforeRoute(context) {
     this.cacheScrollPosition();
+
+    // If scroll position wasn't cached from an earlier visit, scroll to top.
+    if (!this.scrollMap[context.state.id]) {
+      this.scrollToTop();
+    }
+
     this.routeCtx = context;
     this.scrollToTargetTimeout = this.delay(this.scrollToTarget);
   }


### PR DESCRIPTION
This has two changes:
* Fixes a bug wherein state IDs were not assigned correctly, and scroll states were not cached.
* Scrolls the page to the top for new states.

Fixes #2130 .