### PR TITLE
Minimize CPU-hungry sidebar drag operations

### DIFF
--- a/assets/javascripts/views/layout/resizer.js
+++ b/assets/javascripts/views/layout/resizer.js
@@ -44,14 +44,20 @@ app.views.Resizer = class Resizer extends app.View {
       return;
     }
     this.lastDragValue = value;
-    if (this.lastDrag && this.lastDrag > Date.now() - 50) {
+    if (this.rafPending) {
       return;
     }
-    this.lastDrag = Date.now();
-    this.resize(value, false);
+    this.rafPending = requestAnimationFrame(() => {
+      this.rafPending = null;
+      this.resize(this.lastDragValue, false);
+    });
   }
 
   onDragEnd(event) {
+    if (this.rafPending) {
+      cancelAnimationFrame(this.rafPending);
+      this.rafPending = null;
+    }
     $.off(window, "dragover", this.onDrag);
     let value = event.pageX || event.screenX - window.screenX;
     if (


### PR DESCRIPTION
This makes an effort to fix slowdowns caused by dragging the sidebar. Fix suggested and implemented by Claude Code. Closes #1542 .

The following CPU profiles are from Firefox for Windows, dragging the sidebar left/right with lodash docs open.

## Before (13 sec)
<img width="1599" height="67" alt="image" src="https://github.com/user-attachments/assets/e0dffba3-43f1-43d5-ac23-6b0ab2da634e" />

## After (23 sec)
<img width="1586" height="53" alt="image" src="https://github.com/user-attachments/assets/5c13b87d-dbe5-4368-8076-d22647f82cdd" />

The 98% CPU usage points are still there, but visibly less frequently.