### PR TITLE
Disable programmatic scrolling for anchored entries

### DIFF
--- a/assets/javascripts/views/content/content.js
+++ b/assets/javascripts/views/content/content.js
@@ -150,8 +150,12 @@ app.views.Content = class Content extends app.View {
   beforeRoute(context) {
     this.cacheScrollPosition();
 
-    // If scroll position wasn't cached from an earlier visit, scroll to top.
-    if (!this.scrollMap[context.state.id]) {
+    /*
+     * If scroll position wasn't cached from an earlier visit:
+     * - let the anchor (if there is one) set position, or
+     * - scroll to top.
+     */
+    if (!this.scrollMap[context.state.id] && !context.hash) {
       this.scrollToTop();
     }
 

--- a/lib/docs/filters/nim/clean_html.rb
+++ b/lib/docs/filters/nim/clean_html.rb
@@ -58,6 +58,11 @@ module Docs
         css('a', 'dl', 'table', 'code').remove_attr('class')
         css('table').remove_attr('border')
 
+        # Remove Source/Edit links.
+        css('dd > a').each do |node|
+          node.remove if node.inner_html == 'Source' || node.inner_html == 'Edit'
+        end
+
         doc
       end
     end


### PR DESCRIPTION
This fixes a breakage caused by PR #2667 in which all route visits with no cached scroll position reset to the top. Anchored entries rely on the href's anchor to set scroll position and don't use cache; thus, all anchored entries scroll to the top.

nim's HTML cleaner was also updated to remove 'Source'/'Edit' links.

Fixes #2671 .