### PR TITLE
feat: add /llms.txt endpoints for LLM-friendly documentation

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -301,6 +301,70 @@ class App < Sinatra::Application
     200
   end
 
+  # llms.txt - LLM-friendly documentation index
+  # See https://llmstxt.org/ for the specification
+  get '/llms.txt' do
+    content_type 'text/plain'
+
+    lines = []
+    lines << '# DevDocs'
+    lines << ''
+    lines << '> DevDocs combines multiple API documentations in a fast, organized, and searchable interface.'
+    lines << ''
+    lines << '## Documentation'
+    lines << ''
+
+    settings.docs.each do |slug, doc|
+      lines << "- [#{doc['full_name']}](https://devdocs.io/#{slug}/)"
+    end
+
+    lines.join("\n")
+  end
+
+  get %r{/([\w~\.%]+)/llms\.txt} do |doc|
+    doc.sub! '%7E', '~'
+    return 404 unless @doc = find_doc(doc)
+
+    content_type 'text/plain'
+
+    index_path = File.join(settings.docs_path, @doc['slug'], 'index.json')
+    return 404 unless File.exist?(index_path)
+
+    index = JSON.parse(File.read(index_path))
+
+    lines = []
+    lines << "# #{@doc['full_name']}"
+    lines << ''
+    lines << "> #{@doc['full_name']} documentation on DevDocs."
+    lines << ''
+
+    if index['types'] && !index['types'].empty?
+      grouped = {}
+      (index['entries'] || []).each do |entry|
+        type_name = entry['type'] || 'General'
+        grouped[type_name] ||= []
+        grouped[type_name] << entry
+      end
+
+      grouped.sort_by { |type, _| type }.each do |type, entries|
+        lines << "## #{type}"
+        lines << ''
+        entries.each do |entry|
+          path = entry['path'].to_s.split('#').first
+          lines << "- [#{entry['name']}](https://devdocs.io/#{@doc['slug']}/#{path})"
+        end
+        lines << ''
+      end
+    else
+      (index['entries'] || []).each do |entry|
+        path = entry['path'].to_s.split('#').first
+        lines << "- [#{entry['name']}](https://devdocs.io/#{@doc['slug']}/#{path})"
+      end
+    end
+
+    lines.join("\n")
+  end
+
   %w(docs.json application.js application.css).each do |asset|
     class_eval <<-CODE, __FILE__, __LINE__ + 1
       get '/#{asset}' do


### PR DESCRIPTION
## Summary

Adds two new routes that serve LLM-friendly plain text documentation following the [llms.txt specification](https://llmstxt.org/):

- **`GET /llms.txt`** — Returns a top-level index of all available documentation with links to each doc section.
- **`GET /:doc/llms.txt`** — Returns a per-documentation index with all entries grouped by type, linking to individual pages.

### Format

The output follows the llms.txt standard:

```
# DevDocs

> DevDocs combines multiple API documentations in a fast, organized, and searchable interface.

## Documentation

- [CSS](https://devdocs.io/css/)
- [JavaScript](https://devdocs.io/javascript/)
...
```

Per-doc endpoints group entries by type:

```
# JavaScript

> JavaScript documentation on DevDocs.

## Array

- [Array.from()](https://devdocs.io/javascript/global_objects/array/from)
- [Array.isArray()](https://devdocs.io/javascript/global_objects/array/isarray)
...

## Promise

- [Promise.all()](https://devdocs.io/javascript/global_objects/promise/all)
...
```

### Why

LLM tools and AI-powered development environments need efficient, structured access to documentation. The llms.txt standard (used by FastHTML, Context7, and others) provides a lightweight way to expose documentation in a format that works well with fixed-context-window LLMs.

### Implementation

- Routes are defined before the catch-all doc route to avoid conflicts
- Uses existing `settings.docs` manifest and per-doc `index.json` files
- No new dependencies required
- Served as `text/plain` with Markdown formatting

Closes #2520