### PR TITLE
Fix: Add YAML syntax highlighting for Ansible docs

### DIFF
--- a/lib/docs/filters/ansible/clean_html.rb
+++ b/lib/docs/filters/ansible/clean_html.rb
@@ -13,7 +13,10 @@ module Docs
             subnode.remove_attribute('style')
           end
         end
-
+        css('pre > code').each do |node|
+        existing_class = node['class']
+        node['class'] = [existing_class, 'language-yaml'].compact.join(' ')
+        end
         doc
 
       end


### PR DESCRIPTION
This PR adds syntax highlighting support for YAML code blocks in Ansible documentation.

It ensures existing classes are preserved while appending the appropriate language-yaml class for PrismJS highlighting.
