### PR TITLE
Update documentation for Elixir 1.20.1 and Phoenix 1.8.8

### DIFF
--- a/lib/docs/filters/elixir/clean_html.rb
+++ b/lib/docs/filters/elixir/clean_html.rb
@@ -47,7 +47,7 @@ module Docs
           end
         end
 
-        css('h1 a.icon-action[title="View Source"]').each do |node|
+        css('.top-heading a.icon-action[title="View Source"]').each do |node|
           node['class'] = 'source'
           node.content = "Source"
         end

--- a/lib/docs/filters/elixir/entries.rb
+++ b/lib/docs/filters/elixir/entries.rb
@@ -7,19 +7,23 @@ module Docs
       end
 
       def get_type
-        section = at_css('h1 a.source').attr('href').match('elixir/pages/([^/]+)/')&.captures&.first
+        section = at_css('.top-heading a.source')&.attr('href')&.match('elixir/pages/([^/]+)/')&.captures&.first
         if section == "mix-and-otp"
           return "Mix & OTP"
         elsif section
           return section.gsub("-", " ").capitalize
         end
 
-        name = at_css('h1 span').text
+        # Sometimes the heading includes additional text in a <small> tag,
+        # in which case the main text is wrapped in a <span>
+        # e.g. https://elixir.hexdocs.pm/Exception.html
+        heading = at_css('.top-heading h1 span') || at_css('.top-heading h1')
+        name = heading.text
         case name.split(' ').first
         when 'mix' then 'Mix Tasks'
         when 'Changelog' then 'References'
         else
-          case at_css('h1 small').try(:content)
+          case at_css('.top-heading h1 small').try(:content)
           when 'exception'
             'Exceptions'
           when 'protocol'

--- a/lib/docs/filters/elixir/entries.rb
+++ b/lib/docs/filters/elixir/entries.rb
@@ -7,11 +7,19 @@ module Docs
       end
 
       def get_type
+        # Use section titles for Elixir docs
         section = at_css('.top-heading a.source')&.attr('href')&.match('elixir/pages/([^/]+)/')&.captures&.first
         if section == "mix-and-otp"
           return "Mix & OTP"
         elsif section
-          return section.gsub("-", " ").capitalize
+        return section.gsub(/[-_]/, " ").capitalize
+        end
+
+        # Use section titles for guides
+        guide = at_css('.top-heading a.source')&.attr('href')&.match('guides/(?:([^/]+)/)?')
+        if guide
+          section = guide.captures.first || "Guides"
+          return section.gsub(/[-_]/, " ").capitalize
         end
 
         # Sometimes the heading includes additional text in a <small> tag,

--- a/lib/docs/scrapers/elixir.rb
+++ b/lib/docs/scrapers/elixir.rb
@@ -17,52 +17,64 @@ module Docs
     options[:root_title] = 'Elixir'
 
     options[:attribution] = <<-HTML
-      &copy; 2012-2024 The Elixir Team<br>
+      &copy; 2012-2026 The Elixir Team<br>
       Licensed under the Apache License, Version 2.0.
     HTML
 
     def initial_urls
-      [ "https://hexdocs.pm/elixir/#{self.class.release}/introduction.html",
-        "https://hexdocs.pm/eex/#{self.class.release}/EEx.html",
-        "https://hexdocs.pm/ex_unit/#{self.class.release}/ExUnit.html",
-        "https://hexdocs.pm/iex/#{self.class.release}/IEx.html",
-        "https://hexdocs.pm/logger/#{self.class.release}/Logger.html",
-        "https://hexdocs.pm/mix/#{self.class.release}/Mix.html" ]
+      [ "https://elixir.hexdocs.pm/#{self.class.release}/introduction.html",
+        "https://eex.hexdocs.pm/#{self.class.release}/EEx.html",
+        "https://ex-unit.hexdocs.pm/#{self.class.release}/ExUnit.html",
+        "https://iex.hexdocs.pm/#{self.class.release}/IEx.html",
+        "https://logger.hexdocs.pm/#{self.class.release}/Logger.html",
+        "https://mix.hexdocs.pm/#{self.class.release}/Mix.html" ]
+    end
+
+    version '1.20' do
+      self.release = '1.20.1'
+      self.base_urls = [
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/"
+      ]
     end
 
     version '1.18' do
       self.release = '1.18.1'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/"
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/"
       ]
     end
 
     version '1.17' do
       self.release = '1.17.2'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/"
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/"
       ]
     end
 
     version '1.16' do
       self.release = '1.16.3'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/"
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/"
       ]
     end
 
@@ -71,12 +83,12 @@ module Docs
     version '1.15' do
       self.release = '1.15.4'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -84,12 +96,12 @@ module Docs
     version '1.14' do
       self.release = '1.14.1'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -97,12 +109,12 @@ module Docs
     version '1.13' do
       self.release = '1.13.4'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -110,12 +122,12 @@ module Docs
     version '1.12' do
       self.release = '1.12.0'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -123,12 +135,12 @@ module Docs
     version '1.11' do
       self.release = '1.11.2'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -136,12 +148,12 @@ module Docs
     version '1.10' do
       self.release = '1.10.4'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -149,12 +161,12 @@ module Docs
     version '1.9' do
       self.release = '1.9.4'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -162,12 +174,12 @@ module Docs
     version '1.8' do
       self.release = '1.8.2'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -175,12 +187,12 @@ module Docs
     version '1.7' do
       self.release = '1.7.4'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -188,12 +200,12 @@ module Docs
     version '1.6' do
       self.release = '1.6.6'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -201,12 +213,12 @@ module Docs
     version '1.5' do
       self.release = '1.5.3'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -214,12 +226,12 @@ module Docs
     version '1.4' do
       self.release = '1.4.5'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
@@ -227,18 +239,18 @@ module Docs
     version '1.3' do
       self.release = '1.3.4'
       self.base_urls = [
-        "https://hexdocs.pm/elixir/#{release}/",
-        "https://hexdocs.pm/eex/#{release}/",
-        "https://hexdocs.pm/ex_unit/#{release}/",
-        "https://hexdocs.pm/iex/#{release}/",
-        "https://hexdocs.pm/logger/#{release}/",
-        "https://hexdocs.pm/mix/#{release}/",
+        "https://elixir.hexdocs.pm/#{release}/",
+        "https://eex.hexdocs.pm/#{release}/",
+        "https://ex-unit.hexdocs.pm/#{release}/",
+        "https://iex.hexdocs.pm/#{release}/",
+        "https://logger.hexdocs.pm/#{release}/",
+        "https://mix.hexdocs.pm/#{release}/",
         'https://elixir-lang.org/getting-started/'
       ]
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://hexdocs.pm/elixir/api-reference.html', opts)
+      doc = fetch_doc('https://elixir.hexdocs.pm/api-reference.html', opts)
       doc.at_css('.sidebar-projectVersion').content.strip[1..-1]
     end
   end

--- a/lib/docs/scrapers/phoenix.rb
+++ b/lib/docs/scrapers/phoenix.rb
@@ -1,34 +1,44 @@
 module Docs
   class Phoenix < UrlScraper
+    include MultipleBaseUrls
+
     self.type = 'elixir'
-    self.release = '1.6.11'
-    self.base_url = 'https://hexdocs.pm/'
-    self.root_path = 'phoenix/Phoenix.html'
-    self.initial_paths = %w(
-      phoenix/api-reference.html
-      ecto/api-reference.html
-      phoenix_html/api-reference.html
-      phoenix_live_view/api-reference.html
-      phoenix_pubsub/api-reference.html
-      plug/api-reference.html)
+    self.release = '1.8.8'
+    self.root_path = 'overview.html'
     self.links = {
       home: 'http://www.phoenixframework.org',
       code: 'https://github.com/phoenixframework/phoenix'
     }
 
+    self.base_urls = %w(
+      https://phoenix.hexdocs.pm/
+      https://ecto.hexdocs.pm/
+      https://phoenix-html.hexdocs.pm/
+      https://phoenix-live-view.hexdocs.pm/
+      https://phoenix-pubsub.hexdocs.pm/
+      https://plug.hexdocs.pm/
+    )
+
+    def initial_urls
+      %w(
+        https://phoenix.hexdocs.pm/overview.html
+        https://ecto.hexdocs.pm/Ecto.html
+        https://phoenix-html.hexdocs.pm/Phoenix.HTML.html
+        https://phoenix-live-view.hexdocs.pm/welcome.html
+        https://phoenix-pubsub.hexdocs.pm/Phoenix.PubSub.html
+        https://plug.hexdocs.pm/readme.html
+      )
+    end
+
     html_filters.push 'elixir/clean_html', 'elixir/entries'
 
     options[:container] = '#content'
 
-    options[:skip_patterns] = [/extra-api-reference/, /js/, /\d+\.\d+\.\d+/]
-    options[:only_patterns] = [
-      /\Aphoenix\//,
-      /\Aecto\//,
-      /\Aphoenix_pubsub\//,
-      /\Aphoenix_html\//,
-      /\Aphoenix_live_view\//,
-      /\Aplug\//
-    ]
+    # Filter docs for JS libraries, these use a different HTML layout.
+    # e.g. https://phoenix.hexdocs.pm/js/ and https://phoenix-live-view.hexdocs.pm/1.2.0/js/
+    #
+    # Only match on `js` directories so we still catch normal pages like https://phoenix-live-view.hexdocs.pm/js-interop.html
+    options[:skip_patterns] = [%r{(\A|/)js/}]
 
     options[:attribution] = -> (filter) {
       if filter.slug.start_with?('ecto')
@@ -56,7 +66,7 @@ module Docs
     }
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://hexdocs.pm/phoenix/Phoenix.html', opts)
+      doc = fetch_doc('https://phoenix.hexdocs.pm/api-reference.html', opts)
       doc.at_css('.sidebar-projectVersion').content.strip[1..-1]
     end
   end


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

## Updating an existing documentation to its latest version
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good