### PR TITLE
Add Django 6.1

### DIFF
--- a/lib/docs/scrapers/django.rb
+++ b/lib/docs/scrapers/django.rb
@@ -34,6 +34,11 @@ module Docs
       Licensed under the BSD License.
     HTML
 
+    version '6.1' do
+      self.release = '6.1'
+      self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"
+    end
+
     version '6.0' do
       self.release = '6.0'
       self.base_url = "https://docs.djangoproject.com/en/#{self.version}/"


### PR DESCRIPTION
Currently in alpha: https://www.djangoproject.com/weblog/2026/may/20/django-61-alpha-1-released/

…which means that its docs pages are up: https://docs.djangoproject.com/en/6.1/

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good

(Copying from my previous Django 6.0 PR, #2580, and the previous versions before it.)