### PR TITLE
Fix broken version checkers

### DIFF
--- a/lib/docs/scrapers/haskell.rb
+++ b/lib/docs/scrapers/haskell.rb
@@ -78,10 +78,9 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://www.haskell.org/ghc/download.html', opts)
-      links = doc.css('a').to_a
-      versions = links.map {|link| link.content.scan(/\A([0-9.]+)\Z/)}
-      versions.find {|version| !version.empty?}[0][0]
+      tags = get_github_tags('ghc', 'ghc', opts)
+      tag = tags.find {|t| t['name'].ends_with?('-release') }['name']
+      tag[/ghc-(.*)-release/, 1]
     end
 
   end

--- a/lib/docs/scrapers/love.rb
+++ b/lib/docs/scrapers/love.rb
@@ -43,8 +43,7 @@ module Docs
     HTML
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://love2d.org/wiki/Version_History', opts)
-      doc.at_css('#mw-content-text table a').content
+      get_github_tags('love2d', 'love', opts).first['name']
     end
   end
 end

--- a/lib/docs/scrapers/mongoose.rb
+++ b/lib/docs/scrapers/mongoose.rb
@@ -29,9 +29,7 @@ module Docs
     HTML
 
     def get_latest_version(opts)
-      doc = fetch_doc('https://mongoosejs.com/docs/', opts)
-      label = doc.at_css('.pure-menu-link').content.strip
-      label.sub(/Version /, '')
+      get_github_tags('Automattic', 'mongoose', opts).find {|t| t['name'].starts_with?(/\d/)}['name']
     end
   end
 end

--- a/lib/docs/scrapers/tensorflow/tensorflow.rb
+++ b/lib/docs/scrapers/tensorflow/tensorflow.rb
@@ -45,8 +45,8 @@ module Docs
     end
 
     def get_latest_version(opts)
-      doc = fetch_doc(self.base_url, opts)
-      doc.title[/TensorFlow v([.\d]+)/, 1]
+      tag = get_github_tags('tensorflow', 'tensorflow', opts).find { |t| !t['name'].include?('-rc') }
+      tag['name'][1..-1]
     end
 
     private

--- a/lib/docs/scrapers/threejs.rb
+++ b/lib/docs/scrapers/threejs.rb
@@ -44,17 +44,17 @@ module Docs
     self.base_url = "https://threejs.org/docs"
 
     def get_latest_version(opts)
-      get_latest_github_release('mrdoob', 'three.js', opts)[1..]
+      get_github_tags('mrdoob', 'three.js', opts).first['name'][1..]
     end
 
     def initial_paths
       paths = []
-      url = 'https://threejs.org/docs/list.json'
+      url = 'https://threejs.org/docs/search.json'
       response = Request.run(url)
       json_data = JSON.parse(response.body)
 
       # Process both API and manual sections
-      process_documentation(json_data['en'], paths)
+      process_documentation(json_data, paths)
       paths
     end
 


### PR DESCRIPTION
Version checking for six docs have been fixed and should no longer throw errors when running `thor updates:check`:
* Mongoose
* three.js
* Haskell
* TensorFlow
* TensorFlow CPP
* Löve

This does **not** attempt to fix broken documentations (if present) for these projects. three.js still needs a complete rewrite.
This does **not** update latest versions set in devdocs.