### PR TITLE
Serve app shell directly instead of JS-redirect via cookie

### DIFF
--- a/assets/javascripts/app/router.js
+++ b/assets/javascripts/app/router.js
@@ -179,8 +179,6 @@ app.Router = class Router extends Events {
     if (location.pathname === "/") {
       if ((path = this.getInitialPathFromHash())) {
         page.replace(path + location.search, null, true);
-      } else if ((path = this.getInitialPathFromCookie())) {
-        page.replace(path + location.search + location.hash, null, true);
       }
     }
   }
@@ -189,14 +187,6 @@ app.Router = class Router extends Events {
     try {
       return new RegExp("#/(.+)").exec(decodeURIComponent(location.hash))?.[1];
     } catch (error) {}
-  }
-
-  getInitialPathFromCookie() {
-    const path = Cookies.get("initial_path");
-    if (path) {
-      Cookies.expire("initial_path");
-      return path;
-    }
   }
 
   replaceHash(hash) {

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -232,29 +232,6 @@ class App < Sinatra::Application
       end
     end
 
-    def redirect_via_js(path)
-      response.set_cookie :initial_path, value: path, expires: Time.now + 15, path: '/'
-      redirect '/', 302
-    end
-
-    def supports_js_redirection?
-      modern_browser?(browser) && !memoized_cookies.empty?
-    end
-
-    # https://github.com/fnando/browser#detecting-modern-browsers
-    # https://github.com/fnando/browser/blob/v2.6.1/lib/browser/browser.rb
-    # This restores the old browser gem `#modern?` functionality as it was in 2.6.1
-    # It's possible this isn't even really needed any longer, these versions are quite old now
-    def modern_browser?(browser)
-      [
-        browser.webkit?,
-        browser.firefox? && browser.version.to_i >= 17,
-        browser.ie? && browser.version.to_i >= 9 && !browser.compatibility_view?,
-        browser.edge? && !browser.compatibility_view?,
-        browser.opera? && browser.version.to_i >= 12,
-        browser.firefox? && browser.device.tablet? && browser.platform.android? && b.version.to_i >= 14
-      ].any?
-    end
   end
 
   before do
@@ -285,11 +262,8 @@ class App < Sinatra::Application
 
   %w(settings offline about news help).each do |page|
     get "/#{page}" do
-      if supports_js_redirection?
-        redirect_via_js "/#{page}"
-      else
-        redirect "/#/#{page}", 302
-      end
+      response.headers['Content-Security-Policy'] = settings.csp if settings.csp
+      erb :index
     end
   end
 
@@ -424,8 +398,6 @@ class App < Sinatra::Application
       redirect "/#{doc}#{type}/#{query_string_for_redirection}"
     elsif rest.length > 1 && rest.end_with?('/')
       redirect "/#{doc}#{type}#{rest[0...-1]}#{query_string_for_redirection}"
-    elsif user_has_docs?(doc) && supports_js_redirection?
-      redirect_via_js(request.path)
     else
       response.headers['Content-Security-Policy'] = settings.csp if settings.csp
       erb :other

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -46,21 +46,11 @@ class AppTest < Minitest::Spec
   end
 
   describe "/[static-page]" do
-    it "redirects to /#/[static-page] by default" do
-      %w(offline about news help).each do |page|
+    it "renders the app shell directly" do
+      %w(settings offline about news help).each do |page|
         get "/#{page}", {}, 'HTTP_USER_AGENT' => MODERN_BROWSER
-        assert last_response.redirect?
-        assert_equal "https://example.org/#/#{page}", last_response['Location']
-      end
-    end
-
-    it "redirects via JS cookie when a cookie exists" do
-      %w(offline about news help).each do |page|
-        set_cookie('foo=bar')
-        get "/#{page}", {}, 'HTTP_USER_AGENT' => MODERN_BROWSER
-        assert last_response.redirect?
-        assert_equal 'https://example.org/', last_response['Location']
-        assert last_response['Set-Cookie'].start_with?("initial_path=%2F#{page}; path=/; expires=")
+        assert last_response.ok?
+        assert_nil last_response['Set-Cookie']
       end
     end
   end
@@ -90,12 +80,11 @@ class AppTest < Minitest::Spec
       assert last_response.ok?
     end
 
-    it "redirects via JS cookie when the doc exists and is enabled" do
+    it "renders when the doc exists and is enabled" do
       set_cookie('docs=html~5')
       get '/html~5/', {}, 'HTTP_USER_AGENT' => MODERN_BROWSER
-      assert last_response.redirect?
-      assert_equal 'https://example.org/', last_response['Location']
-      assert last_response['Set-Cookie'].start_with?("initial_path=%2Fhtml%7E5%2F; path=/; expires=")
+      assert last_response.ok?
+      assert_nil last_response['Set-Cookie']
     end
 
     it "renders when the doc exists, has no version in the path, and isn't enabled" do
@@ -103,12 +92,11 @@ class AppTest < Minitest::Spec
       assert last_response.ok?
     end
 
-    it "redirects via JS cookie when the doc exists, has no version in the path, and a version is enabled" do
+    it "renders when the doc exists, has no version in the path, and a version is enabled" do
       set_cookie('docs=html~5')
       get '/html/', {}, 'HTTP_USER_AGENT' => MODERN_BROWSER
-      assert last_response.redirect?
-      assert_equal 'https://example.org/', last_response['Location']
-      assert last_response['Set-Cookie'].start_with?("initial_path=%2Fhtml%2F; path=/; expires=")
+      assert last_response.ok?
+      assert_nil last_response['Set-Cookie']
     end
 
     it "renders when the doc exists and is enabled, and the request is from Googlebot" do


### PR DESCRIPTION
Deep links to docs and the static pages (settings, offline, about, news, help) previously bounced through `/` with a short-lived `initial_path` cookie that the client read back to restore the path. This removes that detour: the server now renders the app shell (erb :index / erb :other) directly at the requested URL, and page.js dispatches location.pathname on start().

This is behaviour that already shipped for docs a user hadn't enabled; enabled docs and the static pages now take the same path. The offline story is unaffected — the service worker already falls back to the cached `/` for non-asset paths when the network fails.

Removes the `initial_path` cookie, the redirect_via_js / supports_js_redirection? / modern_browser? helpers, and the client-side getInitialPathFromCookie. The hash-based initial-path handling (used by /search and legacy /#/ bookmarks) is untouched.
