### PR TITLE
Add PHP to the default documentation set (#2706)

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -30,7 +30,7 @@ class App < Sinatra::Application
     set :docs_origin, File.join('', docs_prefix)
     set :docs_path, File.join(public_folder, docs_prefix)
     set :docs_manifest_path, File.join(docs_path, 'docs.json')
-    set :default_docs, %w(css dom html http javascript)
+    set :default_docs, %w(css dom html http javascript php)
     set :news_path, File.join(root, assets_prefix, 'javascripts', 'news.json')
 
     set :csp, false

--- a/lib/docs.rb
+++ b/lib/docs.rb
@@ -44,7 +44,7 @@ module Docs
   end
 
   def self.defaults
-    %w(css dom html http javascript).map(&method(:find))
+    %w(css dom html http javascript php).map(&method(:find))
   end
 
   def self.installed

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -15,6 +15,11 @@ class AppTest < Minitest::Spec
     current_session.env('HTTPS', 'on')
   end
 
+  it 'includes PHP in the default documentation set' do
+    assert_includes App.settings.default_docs, 'php'
+    assert_includes Docs.defaults.map(&:name), 'PHP'
+  end
+
   it 'redirects to HTTPS' do
     get 'http://example.com/test?q=1', {}, 'HTTPS' => 'off'
     assert last_response.redirect?


### PR DESCRIPTION
## Summary

- Add PHP to the default documentation slugs exposed by the application.
- Add PHP to `Docs.defaults` so the backend default set stays in sync.
- Add regression coverage for both default lists.

Closes #2706

## Testing

- `bundle exec ruby -Itest test/app_test.rb` in the project's Ruby 4.0.5 Docker environment — 36 runs, 86 assertions, 0 failures
- Ruby syntax checks for the three touched files
- `git diff --check`
