### PR TITLE
Fix silent failures of Alt+O / Alt+C shortcuts

### DIFF
--- a/assets/javascripts/templates/notice_tmpl.js
+++ b/assets/javascripts/templates/notice_tmpl.js
@@ -7,3 +7,9 @@ app.templates.singleDocNotice = (doc) =>
 app.templates.disabledDocNotice = () =>
   notice(` <strong>This documentation is disabled.</strong>
 To enable it, go to <a href="/settings" class="_notice-link">Preferences</a>. `);
+
+app.templates.noOriginalLinkNotice = () =>
+  notice(` The original page link is not available for this documentation. `);
+
+app.templates.copyFailedNotice = () =>
+  notice(` Couldn't copy the original page link to the clipboard. `);

--- a/assets/javascripts/views/content/entry_page.js
+++ b/assets/javascripts/views/content/entry_page.js
@@ -221,17 +221,32 @@ app.views.EntryPage = class EntryPage extends app.View {
   onAltC() {
     const link = this.find("._attribution:last-child ._attribution-link");
     if (!link) {
+      this.showTransientNotice("noOriginalLink");
       return;
     }
-    console.log(link.href + location.hash);
-    navigator.clipboard.writeText(link.href + location.hash);
+    navigator.clipboard.writeText(link.href + location.hash).catch(() =>
+      this.showTransientNotice("copyFailed"),
+    );
   }
 
   onAltO() {
     const link = this.find("._attribution:last-child ._attribution-link");
     if (!link) {
+      this.showTransientNotice("noOriginalLink");
       return;
     }
     this.delay(() => $.popup(link.href + location.hash));
+  }
+
+  showTransientNotice(type) {
+    if (this.transientNotice) {
+      clearTimeout(this.transientNoticeTimer);
+      this.transientNotice.deactivate();
+    }
+    this.transientNotice = new app.views.Notice(type);
+    this.transientNoticeTimer = setTimeout(() => {
+      this.transientNotice.deactivate();
+      this.transientNotice = null;
+    }, 3000);
   }
 };


### PR DESCRIPTION
Fixes #2634

## What this PR does

Alt+O (open original page) and Alt+C (copy original link) currently fail completely silently when the rendered entry has no `._attribution ._attribution-link` element, and Alt+C additionally had a leftover `console.log` and ignored clipboard promise rejections. This PR shows a transient notice when the link is unavailable, surfaces clipboard failures instead of swallowing them, and removes the debug logging.

## Investigation notes

While debugging why the shortcuts "do nothing" for some users and work for others:

- The cached entry data on documents.devdocs.io **does** contain the `_attribution` block (verified against e.g. [git-status.html](https://documents.devdocs.io/git/git-status.html)), so the selector input exists at the data level.
- The failure mode is therefore environment- or page-dependent (stale service-worker caches serving pre-attribution HTML, docs whose scrapers render no attribution, or pages where attribution isn't the last child) — exactly the split reported in the issue (works on some macOS setups, dead on Windows/others).
- Because both handlers bailed out with a bare `return`, every one of those cases produced identical "nothing happens" behavior, making the bug impossible to self-diagnose from the UI. Surfacing a notice turns the invisible state into actionable feedback.

## Changes

- `entry_page.js`: both handlers now show a transient notice ("The original page link is not available for this documentation") instead of silently returning; `onAltC` handles the `navigator.clipboard.writeText` rejection with its own notice; removed stray `console.log`
- `notice_tmpl.js`: added `noOriginalLinkNotice` and `copyFailedNotice` templates following the existing pattern
- New notices auto-dismiss after 3 seconds and replace each other rather than stacking

## Testing

DevDocs has no JS unit-test infrastructure yet (#2673), so verification was: syntax check on both modified files plus manual code-path review against the cached-entry structure linked above. The notice path can be exercised by running any entry whose scraped HTML lacks an attribution block.

Happy to iterate if maintainers would prefer different wording/behavior (e.g. also attempting URL reconstruction for docs without attribution).
