### PR TITLE
Add PyTorch 2.10 through 2.13 documentation support

### DIFF
--- a/lib/docs/filters/pytorch/entries.rb
+++ b/lib/docs/filters/pytorch/entries.rb
@@ -2,6 +2,9 @@ module Docs
   class Pytorch
     class EntriesFilter < Docs::EntriesFilter
       def get_breadcrumbs
+        breadcrumbs = schema_breadcrumbs
+        return breadcrumbs unless breadcrumbs.empty?
+
         breadcrumbs = if at_css('.pytorch-breadcrumbs')
           css('.pytorch-breadcrumbs > li').map { |node|
             node.content.delete_suffix(' >').strip
@@ -26,15 +29,19 @@ module Docs
       end
 
       def get_type
-        if at_css('.pytorch-breadcrumbs')
-          get_breadcrumbs[1]
+        breadcrumbs = get_breadcrumbs
+
+        if schema_breadcrumbs.any?
+          breadcrumbs.size > 2 ? breadcrumbs[-2] : breadcrumbs[-1]
+        elsif at_css('.pytorch-breadcrumbs')
+          breadcrumbs[1]
         else
-          get_breadcrumbs.size > 2 ? get_breadcrumbs[2] : get_breadcrumbs[1]
+          breadcrumbs.size > 2 ? breadcrumbs[2] : breadcrumbs[1]
         end
       end
 
       def include_default_entry?
-        !get_breadcrumbs.nil? && get_breadcrumbs.size >= 2
+        schema_breadcrumbs.any? || get_breadcrumbs.size >= 2
       end
 
       def additional_entries
@@ -60,6 +67,22 @@ module Docs
         end
 
         entries
+      end
+
+      private
+
+      def schema_breadcrumbs
+        @schema_breadcrumbs ||= css(
+          '[itemtype="https://schema.org/BreadcrumbList"] [itemprop="itemListElement"]'
+        ).filter_map do |node|
+          name = node.at_css('[itemprop="name"]')
+          next unless name
+
+          text = Nokogiri::HTML.fragment(name['content'] || name.content).text.strip
+          dangling_text = node.text.strip.delete_suffix('">') if name['content']
+          text = "#{text} #{dangling_text}" if dangling_text.present?
+          text
+        end.reject(&:empty?)
       end
     end
   end

--- a/lib/docs/scrapers/pytorch.rb
+++ b/lib/docs/scrapers/pytorch.rb
@@ -15,9 +15,29 @@ module Docs
     options[:max_image_size] = 1_000_000
 
     options[:attribution] = <<-HTML
-    &copy; 2025, PyTorch Contributors<br>
+    &copy; 2026, PyTorch Contributors<br>
     PyTorch has a BSD-style license, as found in the <a href="https://github.com/pytorch/pytorch/blob/main/LICENSE">LICENSE</a> file.
     HTML
+
+    version '2.13' do
+      self.release = '2.13'
+      self.base_url = "https://docs.pytorch.org/docs/#{release}/"
+    end
+
+    version '2.12' do
+      self.release = '2.12'
+      self.base_url = "https://docs.pytorch.org/docs/#{release}/"
+    end
+
+    version '2.11' do
+      self.release = '2.11'
+      self.base_url = "https://docs.pytorch.org/docs/#{release}/"
+    end
+
+    version '2.10' do
+      self.release = '2.10'
+      self.base_url = "https://docs.pytorch.org/docs/#{release}/"
+    end
 
     version '2.9' do
       self.release = '2.9'


### PR DESCRIPTION
This PR adds PyTorch documentation versions 2.10 through 2.13.

PyTorch's structured Schema.org breadcrumbs are now preferred when available, with the existing visible-breadcrumb parsing retained as a fallback for older versions. This restores the complete names of pages whose visible breadcrumbs are incomplete, such as [Use `fullgraph=True` to Identify and Eliminate Graph Breaks](https://docs.pytorch.org/docs/2.13/user_guide/torch_compiler/compile/programming_model.fullgraph_true.html).

Key changes:

- Adds PyTorch 2.10, 2.11, 2.12, and 2.13.
- Uses structured breadcrumbs while preserving compatibility with older documentation themes.
- Updates the PyTorch attribution year.

Validation:

- Generated all four new versions successfully.
- Verified rendering and entry categorization using the local DevDocs server.
- Regenerated PyTorch 2.8 to verify compatibility with an existing schema-enabled version.

If you're updating existing documentation to its latest version, please ensure that you have:

- [x] Updated the versions and releases in the scraper file
- [x] Ensured the license is up-to-date
- [x] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [x] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [x] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
