### PR TITLE
Fix broken link and typos in docs

### DIFF
--- a/docs/file-scrapers.md
+++ b/docs/file-scrapers.md
@@ -67,7 +67,7 @@ mv man7.org/linux/man-pages/ docs/man/
 
 ## OpenJDK
 Search 'Openjdk' in https://www.debian.org/distrib/packages, find the `openjdk-$VERSION-doc` package,
-download it, extract it with `dpkg -x $PACKAGE ./` and move `./usr/share/doc/openjdk-16-jre-headless/api/`
+download it, extract it with `dpkg -x $PACKAGE ./` and move `./usr/share/doc/openjdk-$VERSION-jre-headless/api/`
 to `path/to/devdocs/docs/openjdk~$VERSION`
 
 ```sh
@@ -82,7 +82,7 @@ If you use or have access to a Debian-based GNU/Linux distribution you can run t
 apt download openjdk-$VERSION-doc
 dpkg -x $PACKAGE ./
 # previous command makes a directory called 'usr' in the current directory
-mv ./usr/share/doc/openjdk-16-jre-headless/api/ docs/openjdk~$VERSION
+mv ./usr/share/doc/openjdk-$VERSION-jre-headless/api/ docs/openjdk~$VERSION
 ```
 
 ## R

--- a/docs/scraper-reference.md
+++ b/docs/scraper-reference.md
@@ -87,7 +87,7 @@ Each scraper has two [filter](https://github.com/freeCodeCamp/devdocs/blob/main/
 
 HTML filters are executed first and manipulate a parsed version of the document (a [Nokogiri](http://nokogiri.org/Nokogiri/XML/Node.html) node object), whereas text filters manipulate the document as a string. This separation avoids parsing the document multiple times.
 
-Filter stacks are like sorted sets. They can modified using the following methods:
+Filter stacks are like sorted sets. They can be modified using the following methods:
 
 ```ruby
 push(*names)                 # append one or more filters at the end
@@ -189,7 +189,7 @@ More information about how filters work is available on the [Filter Reference](.
 
 ### Processing responses before filters
 
-These methods are runned before filter stacks, and can directly process responses.
+These methods are run before filter stacks, and can directly process responses.
 
 * `process_response?(response)`
 
@@ -204,7 +204,7 @@ These methods are runned before filter stacks, and can directly process response
 
   Parse HTTP/File response, and convert to a Nokogiri document by default.
 
-  Overrides this method if you want to modified HTML source code before Nokogiri.
+  Overrides this method if you want to modify HTML source code before Nokogiri.
 It is useful to preserve whitespaces of code segments within non-pre blocks, because Nokogiri may delete them.
 
   Example: [lib/docs/scrapers/go.rb](../lib/docs/scrapers/go.rb)
@@ -284,7 +284,7 @@ To make life easier, there are a few utility methods that you can use in `get_la
 
   Returns the contents of the requested file in the default branch of the given repository.
 
-  Example: [lib/docs/scrapers/minitest.rb](../lib/docs/scrapers/minitest.rb)
+  Example: [lib/docs/scrapers/rdoc/minitest.rb](../lib/docs/scrapers/rdoc/minitest.rb)
 * `get_latest_github_commit_date(owner, repo, opts)`
 
     Returns the date of the most recent commit in the default branch of the given repository.


### PR DESCRIPTION
Small docs cleanup in `docs/`. No behaviour or meaning changes — just a broken link, a stale OpenJDK version ref, and three typos.

## What changed

- `docs/scraper-reference.md`: fix the `get_github_file_contents` example link — `lib/docs/scrapers/minitest.rb` moves to `lib/docs/scrapers/rdoc/minitest.rb` (the file lives under `rdoc/` and is the scraper that actually uses this method).
- `docs/file-scrapers.md`: replace the stale `openjdk-16-jre-headless` path with `openjdk-$VERSION-jre-headless` in the manual-install instructions, matching the `openjdk-$VERSION-doc` package referenced above and the example that now uses OpenJDK 25.
- `docs/scraper-reference.md`: fix three typos — `runned` → `run`, `can modified` → `can be modified`, and `to modified` → `to modify`.

## Why

The link points to a file that no longer exists, the OpenJDK instructions still reference version 16 while the scraper documents version 25, and the typos are plain copy errors. Keeping contributor docs accurate makes them easier to follow.

## How to verify

```sh
git fetch https://github.com/olitreadwell/devdocs.git chore/fix-docs-typos-and-links
git checkout FETCH_HEAD
bundle exec rake
```

`bundle exec rake` runs the Ruby test suite, which is unaffected by these markdown-only doc changes. You can also confirm `lib/docs/scrapers/rdoc/minitest.rb` exists and that the OpenJDK section now consistently uses `openjdk-$VERSION`.
