### PR TITLE
Fix scoped external-search shortcuts

### DIFF
--- a/assets/javascripts/views/search/search.js
+++ b/assets/javascripts/views/search/search.js
@@ -141,7 +141,7 @@ app.views.Search = class Search extends app.View {
   }
 
   externalSearch(url) {
-    const value = this.value;
+    let value = this.value;
     if (value) {
       if (this.scope.name()) {
         value = `${this.scope.name()} ${value}`;

--- a/test/assets/search_hash_test.js
+++ b/test/assets/search_hash_test.js
@@ -48,3 +48,19 @@ test("URL search hash preserves encoded literal plus signs in the query", () => 
 
   assert.equal(search.getHashValue(), "operator+");
 });
+
+test("scoped external search includes the documentation name", () => {
+  let popupUrl;
+  context.$.popup = (url) => {
+    popupUrl = url;
+  };
+
+  const search = Object.create(context.app.views.Search.prototype);
+  search.value = "status";
+  search.scope = { name: () => "Git" };
+  search.reset = () => {};
+
+  search.externalSearch("https://www.google.com/search?q=");
+
+  assert.equal(popupUrl, "https://www.google.com/search?q=Git%20status");
+});


### PR DESCRIPTION
Fixes #2728

Scoped external-search shortcuts threw before opening the provider when a documentation name was included. This makes the local mutable and adds a regression test for the scoped URL.

Tests:
- node --test test/assets/search_hash_test.js
- node --check on all 78 non-vendored JavaScript files

The Ruby suite was not run because Ruby/Bundler are unavailable in the audit environment.